### PR TITLE
Fix: Implement graceful shutdown for TrueAsync mode

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,131 @@
 # TODO
 
+---
+
+## PHP TrueAsync mode (branch: php-graceful-shutdown)
+
+Items below must be resolved before the branch can be merged and before
+`test/test_php_trueasync.py` can run in CI.
+
+### 1. `nxt_php_app_conf_t` is missing `async` and `entrypoint` fields
+
+**Problem.**  `src/nxt_php_sapi.c` (commit 58ffa236) references `c->async`
+and `c->entrypoint` where `c` is a pointer to `nxt_php_app_conf_t`
+(defined in `src/nxt_application.h`).  The struct currently has only
+`targets` and `options`, so the code **will not compile** as-is.
+
+The original upstream commit (EdmondDantes/052afd8) likely also modified
+`nxt_application.h` and the JSON config validator; those changes were not
+included when the commit was cherry-picked into this branch.
+
+**Risk.** Build failure on the first C compile step; CI is entirely broken.
+
+**Fix.**
+- Add the missing fields to `nxt_php_app_conf_t` in `src/nxt_application.h`:
+  ```c
+  typedef struct {
+      nxt_conf_value_t  *targets;
+      nxt_conf_value_t  *options;
+      nxt_bool_t         async;      /* true when TrueAsync mode requested */
+      nxt_str_t          entrypoint; /* path to the PHP entrypoint script   */
+  } nxt_php_app_conf_t;
+  ```
+- Wire them up in the config parser (find where other PHP config fields are
+  read from JSON — probably `nxt_router.c` or a PHP-specific conf handler).
+- Add validation rules in `nxt_conf_validation.c` so the REST API rejects
+  `entrypoint` without `async: true` and vice-versa.
+
+---
+
+### 2. `nxt_php_extension.c` / `nxt_php_extension_init()` are missing
+
+**Problem.**  `PHP_MINIT_FUNCTION(nxt_php_ext)` calls
+`nxt_php_extension_init()` (line 221 of `nxt_php_sapi.c`) and the async
+request handler references `nxt_php_request_callback` (declared `extern`
+at line 2187).  Both symbols are expected to come from `nxt_php_extension.c`,
+which does not exist in the repository.
+
+Without it the linker will fail and there is no PHP-land API for user
+scripts to register a request handler.  The `\Unit\Server::setHandler()`
+calls in `test/php/async_*/entrypoint.php` are placeholders until the
+real extension is in place.
+
+**Risk.** Linker failure; all TrueAsync tests will skip until resolved.
+
+**Fix.**
+- Locate the file in the EdmondDantes fork or write it from scratch.
+  Minimum required:
+  - `zval *nxt_php_request_callback` global (zeroed at startup).
+  - `nxt_php_extension_init()` — registers `\Unit\Server` with a static
+    `setHandler(callable $cb)` that stores `$cb` into the global above.
+  - `\Unit\Request` class with methods `body()`, `query()`, `headers()`,
+    `respond(int $status, array $headers, string $body)`.
+- Add the new `.c` file to the PHP module build rules in `auto/modules/php`.
+- Document the final PHP API surface so entrypoint authors have a stable
+  contract.
+
+---
+
+### 3. No timeout / force-kill fallback in `nxt_php_quit_handler`
+
+**Problem.**  `nxt_php_quit_handler()` calls `ZEND_ASYNC_SHUTDOWN()` and
+returns immediately.  If user coroutines are stuck in a tight loop or
+blocking I/O that the TrueAsync scheduler cannot interrupt, the worker
+hangs forever.
+
+**Risk.** Silent hang in production; container runtime must SIGKILL instead.
+
+**Fix.**
+- After `ZEND_ASYNC_SHUTDOWN()`, arm a timer for a configurable grace
+  period (default 30 s).  On expiry call `exit(1)`.
+- Expose as a PHP application config option:
+  ```json
+  { "type": "php", "async": true, "entrypoint": "server.php",
+    "shutdown_timeout": 30 }
+  ```
+- Add a test that verifies the force-kill fires when a coroutine refuses
+  to stop.
+
+---
+
+### 4. Behavior of in-flight requests on shutdown is undefined
+
+**Problem.**  It is not documented whether `ZEND_ASYNC_SHUTDOWN()` lets
+active request coroutines run to completion or cancels them immediately.
+
+`test_php_trueasync_inflight_request_completes` assumes completion
+semantics.  If cancellation is the designed behavior, the test assertion
+must be changed to `pytest.xfail`.
+
+**Action.**
+- Read the TrueAsync scheduler shutdown semantics.
+- Document the behavior.  Update the test accordingly.
+
+---
+
+### 5. Pending writes in `drain_queue` are silently abandoned on shutdown
+
+**Problem.**  If `ZEND_ASYNC_SHUTDOWN()` fires while `drain_queue` is
+non-empty, buffered response bytes are never sent and the client receives
+a truncated body.
+
+**Fix.**  Drain the queue synchronously in `nxt_php_quit_handler()` before
+calling `ZEND_ASYNC_SHUTDOWN()`.
+
+---
+
+### 6. Test fixtures use a placeholder PHP API
+
+The entrypoint scripts in `test/php/async_*/entrypoint.php` use
+`\Unit\Server::setHandler()` and `\Unit\Request` — these are provisional
+names.  Once item 2 is resolved:
+- Update all three fixture files to match the real class/method names.
+- Replace the `_check_trueasync_available()` runtime probe in
+  `test_php_trueasync.py` with a proper `prerequisites` feature flag
+  (requires updating `unit/check/discover_available.py`).
+
+---
+
 ## PHP 8.5 Compatibility
 
 ### `disable_classes` removed (PHP 8.5)

--- a/auto/modules/php
+++ b/auto/modules/php
@@ -236,6 +236,31 @@ else
 fi
 
 
+nxt_feature="PHP sapi_module_struct pre_request_init field"
+nxt_feature_name=""
+nxt_feature_run=no
+nxt_feature_incs="${NXT_PHP_INCLUDE}"
+nxt_feature_libs="${NXT_PHP_LIB} ${NXT_PHP_LDFLAGS}"
+nxt_feature_test="
+    #include <php.h>
+    #include <main/SAPI.h>
+
+    int main(void) {
+        sapi_module_struct m;
+        m.pre_request_init = NULL;
+        (void) m;
+        return 0;
+    }"
+
+. auto/feature
+
+if [ $nxt_found = yes ]; then
+    NXT_PHP_PRE_REQUEST_INIT=1
+else
+    NXT_PHP_PRE_REQUEST_INIT=0
+fi
+
+
 if grep ^$NXT_PHP_MODULE: $NXT_MAKEFILE 2>&1 > /dev/null; then
     $echo
     $echo $0: error: duplicate \"$NXT_PHP_MODULE\" module configured.
@@ -273,6 +298,7 @@ $NXT_BUILD_DIR/$nxt_obj:	$nxt_src $NXT_VERSION_H
 	\$(v)\$(CC) -c \$(CFLAGS) $NXT_PHP_ADDITIONAL_FLAGS \$(NXT_INCS) \\
 	$NXT_PHP_INCLUDE -DNXT_ZEND_SIGNAL_STARTUP=$NXT_ZEND_SIGNAL_STARTUP \\
 	-DNXT_PHP_TRUEASYNC=$NXT_PHP_TRUEASYNC \\
+	-DNXT_PHP_PRE_REQUEST_INIT=$NXT_PHP_PRE_REQUEST_INIT \\
 	$nxt_dep_flags \\
 	-o $NXT_BUILD_DIR/$nxt_obj $nxt_src
 	$nxt_dep_post

--- a/auto/modules/php
+++ b/auto/modules/php
@@ -211,6 +211,31 @@ else
 fi
 
 
+nxt_feature="PHP TrueAsync API (zend_async_event_t)"
+nxt_feature_name=""
+nxt_feature_run=no
+nxt_feature_incs="${NXT_PHP_INCLUDE}"
+nxt_feature_libs="${NXT_PHP_LIB} ${NXT_PHP_LDFLAGS}"
+nxt_feature_test="
+    #include <php.h>
+
+    int main(void) {
+        zend_async_event_t *e = NULL;
+        (void) e;
+        return 0;
+    }"
+
+. auto/feature
+
+if [ $nxt_found = yes ]; then
+    NXT_PHP_TRUEASYNC=1
+    $echo " + PHP TrueAsync: enabled"
+else
+    NXT_PHP_TRUEASYNC=0
+    $echo " + PHP TrueAsync: not available (standard mode only)"
+fi
+
+
 if grep ^$NXT_PHP_MODULE: $NXT_MAKEFILE 2>&1 > /dev/null; then
     $echo
     $echo $0: error: duplicate \"$NXT_PHP_MODULE\" module configured.
@@ -247,6 +272,7 @@ $NXT_BUILD_DIR/$nxt_obj:	$nxt_src $NXT_VERSION_H
 	\$(PP_CC) \$@
 	\$(v)\$(CC) -c \$(CFLAGS) $NXT_PHP_ADDITIONAL_FLAGS \$(NXT_INCS) \\
 	$NXT_PHP_INCLUDE -DNXT_ZEND_SIGNAL_STARTUP=$NXT_ZEND_SIGNAL_STARTUP \\
+	-DNXT_PHP_TRUEASYNC=$NXT_PHP_TRUEASYNC \\
 	$nxt_dep_flags \\
 	-o $NXT_BUILD_DIR/$nxt_obj $nxt_src
 	$nxt_dep_post

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -368,7 +368,7 @@ static sapi_module_struct  nxt_php_sapi_module =
     NULL,                        /* ini_entries */
     NULL,                        /* additional_functions */
     NULL,                        /* input_filter_init */
-#if NXT_PHP_TRUEASYNC
+#if NXT_PHP_PRE_REQUEST_INIT
     NULL,                        /* pre_request_init */
 #endif
 };

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -83,6 +83,7 @@ static nxt_int_t nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
     nxt_common_app_conf_t *conf);
 static nxt_int_t nxt_php_start(nxt_task_t *task, nxt_process_data_t *data);
 static void nxt_php_cleanup_targets(void);
+#if NXT_PHP_TRUEASYNC
 static nxt_int_t nxt_php_async_load_entrypoint(nxt_task_t *task, nxt_str_t *entrypoint);
 static bool nxt_php_activate_true_async(nxt_task_t *task);
 static void nxt_php_suspend_coroutine(nxt_unit_ctx_t *ctx);
@@ -90,6 +91,7 @@ static int nxt_php_add_port(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port);
 static void nxt_php_remove_port(nxt_unit_t *unit, nxt_unit_ctx_t *ctx, nxt_unit_port_t *port);
 static void nxt_php_quit_handler(nxt_unit_ctx_t *ctx);
 static void nxt_php_shm_ack_handler(nxt_unit_ctx_t *ctx);
+#endif /* NXT_PHP_TRUEASYNC */
 static nxt_int_t nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
     nxt_conf_value_t *conf);
 static nxt_int_t nxt_php_set_ini_path(nxt_task_t *task, nxt_str_t *path,
@@ -115,11 +117,15 @@ static nxt_int_t nxt_php_do_301(nxt_unit_request_info_t *req);
 static nxt_int_t nxt_php_handle_fs_err(nxt_unit_request_info_t *req);
 
 static void nxt_php_request_handler(nxt_unit_request_info_t *req);
+#if NXT_PHP_TRUEASYNC
 static void nxt_php_request_handler_async(nxt_unit_request_info_t *req);
+#endif /* NXT_PHP_TRUEASYNC */
 static void nxt_php_dynamic_request(nxt_php_run_ctx_t *ctx,
     nxt_unit_request_t *r);
+#if NXT_PHP_TRUEASYNC
 static void nxt_php_scope_init_superglobals(zend_async_scope_t *scope);
 static void nxt_php_scope_populate_superglobals(zend_async_scope_t *scope);
+#endif /* NXT_PHP_TRUEASYNC */
 #if (PHP_VERSION_ID < 70400)
 static void nxt_zend_stream_init_fp(zend_file_handle *handle, FILE *fp,
     const char *filename);
@@ -139,8 +145,10 @@ nxt_inline void nxt_php_set_str(nxt_unit_request_info_t *req, const char *name,
 static void nxt_php_set_cstr(nxt_unit_request_info_t *req, const char *name,
     const char *str, uint32_t len, zval *track_vars_array TSRMLS_DC);
 void nxt_php_register_variables(zval *track_vars_array TSRMLS_DC);
+#if NXT_PHP_TRUEASYNC
 static void nxt_php_register_variables_async(nxt_unit_request_info_t *req,
     nxt_php_run_ctx_t *ctx, zval *track_vars_array TSRMLS_DC);
+#endif /* NXT_PHP_TRUEASYNC */
 #if NXT_PHP8
 static void nxt_php_log_message(const char *message, int syslog_type_int);
 #else
@@ -217,10 +225,12 @@ PHP_MINIT_FUNCTION(nxt_php_ext)
     nxt_php_chdir_handler = func->internal_function.handler;
     func->internal_function.handler = nxt_php_chdir;
 
-    /* Register NginxUnit PHP extension classes */
+#if NXT_PHP_TRUEASYNC
+    /* Register NginxUnit PHP extension classes (TrueAsync only) */
     if (nxt_php_extension_init() != NXT_OK) {
         return FAILURE;
     }
+#endif /* NXT_PHP_TRUEASYNC */
 
     return SUCCESS;
 }
@@ -358,7 +368,7 @@ static sapi_module_struct  nxt_php_sapi_module =
     NULL,                        /* ini_entries */
     NULL,                        /* additional_functions */
     NULL,                        /* input_filter_init */
-#if (PHP_VERSION_ID >= 80500)
+#if NXT_PHP_TRUEASYNC
     NULL,                        /* pre_request_init */
 #endif
 };
@@ -476,6 +486,8 @@ nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
     return NXT_OK;
 }
 
+
+#if NXT_PHP_TRUEASYNC
 
 /**
  * Add pending write to drain_queue
@@ -671,6 +683,8 @@ nxt_php_shm_ack_handler(nxt_unit_ctx_t *ctx)
     }
 }
 
+#endif /* NXT_PHP_TRUEASYNC */
+
 
 static nxt_int_t
 nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
@@ -727,6 +741,7 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
     }
 
     /* Choose request handler based on mode */
+#if NXT_PHP_TRUEASYNC
     if (c->async && c->entrypoint.length > 0) {
         nxt_debug(task, "PHP HTTP Server mode enabled with entrypoint: %V", &c->entrypoint);
         php_init.callbacks.add_port = nxt_php_add_port;
@@ -749,9 +764,12 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
             return NXT_ERROR;
         }
     } else {
+#endif /* NXT_PHP_TRUEASYNC */
         nxt_debug(task, "PHP standard mode");
         php_init.callbacks.request_handler = nxt_php_request_handler;
+#if NXT_PHP_TRUEASYNC
     }
+#endif /* NXT_PHP_TRUEASYNC */
 
     unit_ctx = nxt_unit_init(&php_init);
     if (nxt_slow_path(unit_ctx == NULL)) {
@@ -760,6 +778,7 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
 
     nxt_php_unit_ctx = unit_ctx;
 
+#if NXT_PHP_TRUEASYNC
     /* Initialize async context data for drain_queue */
     if (c->async && c->entrypoint.length > 0) {
         nxt_php_async_ctx_data_t *async_data;
@@ -783,6 +802,9 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
     } else {
         nxt_unit_run(nxt_php_unit_ctx);
     }
+#else
+    nxt_unit_run(nxt_php_unit_ctx);
+#endif /* NXT_PHP_TRUEASYNC */
     nxt_unit_done(nxt_php_unit_ctx);
 
     /* Clean up allocated memory before exit */
@@ -1950,6 +1972,8 @@ nxt_php_register_variables(zval *track_vars_array TSRMLS_DC)
 }
 
 
+#if NXT_PHP_TRUEASYNC
+
 static void
 nxt_php_register_variables_async(nxt_unit_request_info_t *req,
     nxt_php_run_ctx_t *ctx, zval *track_vars_array TSRMLS_DC)
@@ -2069,6 +2093,8 @@ nxt_php_register_variables_async(nxt_unit_request_info_t *req,
     }
 }
 
+#endif /* NXT_PHP_TRUEASYNC */
+
 
 static void
 nxt_php_set_sptr(nxt_unit_request_info_t *req, const char *name,
@@ -2180,6 +2206,8 @@ nxt_php_log_message(char *message TSRMLS_DC)
     }
 }
 
+
+#if NXT_PHP_TRUEASYNC
 
 /* TrueAsync Mode Implementation */
 
@@ -2617,3 +2645,5 @@ nxt_php_scope_populate_superglobals(zend_async_scope_t *scope)
         }
     }
 }
+
+#endif /* NXT_PHP_TRUEASYNC */

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -82,6 +82,14 @@ typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 static nxt_int_t nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
     nxt_common_app_conf_t *conf);
 static nxt_int_t nxt_php_start(nxt_task_t *task, nxt_process_data_t *data);
+static void nxt_php_cleanup_targets(void);
+static nxt_int_t nxt_php_async_load_entrypoint(nxt_task_t *task, nxt_str_t *entrypoint);
+static bool nxt_php_activate_true_async(nxt_task_t *task);
+static void nxt_php_suspend_coroutine(nxt_unit_ctx_t *ctx);
+static int nxt_php_add_port(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port);
+static void nxt_php_remove_port(nxt_unit_t *unit, nxt_unit_ctx_t *ctx, nxt_unit_port_t *port);
+static void nxt_php_quit_handler(nxt_unit_ctx_t *ctx);
+static void nxt_php_shm_ack_handler(nxt_unit_ctx_t *ctx);
 static nxt_int_t nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
     nxt_conf_value_t *conf);
 static nxt_int_t nxt_php_set_ini_path(nxt_task_t *task, nxt_str_t *path,
@@ -107,8 +115,11 @@ static nxt_int_t nxt_php_do_301(nxt_unit_request_info_t *req);
 static nxt_int_t nxt_php_handle_fs_err(nxt_unit_request_info_t *req);
 
 static void nxt_php_request_handler(nxt_unit_request_info_t *req);
+static void nxt_php_request_handler_async(nxt_unit_request_info_t *req);
 static void nxt_php_dynamic_request(nxt_php_run_ctx_t *ctx,
     nxt_unit_request_t *r);
+static void nxt_php_scope_init_superglobals(zend_async_scope_t *scope);
+static void nxt_php_scope_populate_superglobals(zend_async_scope_t *scope);
 #if (PHP_VERSION_ID < 70400)
 static void nxt_zend_stream_init_fp(zend_file_handle *handle, FILE *fp,
     const char *filename);
@@ -127,7 +138,9 @@ nxt_inline void nxt_php_set_str(nxt_unit_request_info_t *req, const char *name,
     nxt_str_t *s, zval *track_vars_array TSRMLS_DC);
 static void nxt_php_set_cstr(nxt_unit_request_info_t *req, const char *name,
     const char *str, uint32_t len, zval *track_vars_array TSRMLS_DC);
-static void nxt_php_register_variables(zval *track_vars_array TSRMLS_DC);
+void nxt_php_register_variables(zval *track_vars_array TSRMLS_DC);
+static void nxt_php_register_variables_async(nxt_unit_request_info_t *req,
+    nxt_php_run_ctx_t *ctx, zval *track_vars_array TSRMLS_DC);
 #if NXT_PHP8
 static void nxt_php_log_message(const char *message, int syslog_type_int);
 #else
@@ -166,12 +179,11 @@ ZEND_FUNCTION(fastcgi_finish_request);
 PHP_MINIT_FUNCTION(nxt_php_ext);
 ZEND_NAMED_FUNCTION(nxt_php_chdir);
 
-
+/* PHP extension functions */
 static const zend_function_entry  nxt_php_ext_functions[] = {
     ZEND_FE(fastcgi_finish_request, arginfo_fastcgi_finish_request)
     ZEND_FE_END
 };
-
 
 zif_handler       nxt_php_chdir_handler;
 zend_auto_global  *nxt_php_server_ag;
@@ -193,7 +205,7 @@ static zend_module_entry  nxt_php_unit_module = {
 
 PHP_MINIT_FUNCTION(nxt_php_ext)
 {
-    zend_function  *func;
+    zend_function    *func;
 
     static const nxt_str_t  chdir = nxt_string("chdir");
 
@@ -204,6 +216,11 @@ PHP_MINIT_FUNCTION(nxt_php_ext)
 
     nxt_php_chdir_handler = func->internal_function.handler;
     func->internal_function.handler = nxt_php_chdir;
+
+    /* Register NginxUnit PHP extension classes */
+    if (nxt_php_extension_init() != NXT_OK) {
+        return FAILURE;
+    }
 
     return SUCCESS;
 }
@@ -365,9 +382,12 @@ NXT_EXPORT nxt_app_module_t  nxt_app_module = {
 
 
 static nxt_php_target_t  *nxt_php_targets;
+static nxt_uint_t        nxt_php_targets_count;
 static nxt_int_t         nxt_php_last_target = -1;
 
-static nxt_unit_ctx_t    *nxt_php_unit_ctx;
+/* Global Unit context - needed by nxt_php_extension.c */
+nxt_unit_ctx_t              *nxt_php_unit_ctx;
+
 #if defined(ZTS) && (PHP_VERSION_ID < 70400)
 static void              ***tsrm_ls;
 #endif
@@ -385,6 +405,7 @@ nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
     static const nxt_str_t  file_str = nxt_string("file");
     static const nxt_str_t  user_str = nxt_string("user");
     static const nxt_str_t  admin_str = nxt_string("admin");
+
 
     c = &conf->u.php;
 
@@ -456,6 +477,201 @@ nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
 }
 
 
+/**
+ * Add pending write to drain_queue
+ */
+nxt_php_pending_write_t *
+nxt_php_drain_queue_add(nxt_unit_ctx_t *ctx,
+                        nxt_unit_request_info_t *req,
+                        zend_string *str,
+                        size_t offset)
+{
+    nxt_php_async_ctx_data_t *async_data = ctx->data;
+    nxt_php_pending_write_t  *pw;
+
+    if (async_data == NULL) {
+        return NULL;
+    }
+
+    pw = malloc(sizeof(nxt_php_pending_write_t));
+    if (pw == NULL) {
+        return NULL;
+    }
+
+    pw->req = req;
+    pw->offset = offset;
+
+    /* Increase refcount - string won't be freed */
+    pw->data = zend_string_copy(str);
+
+    nxt_queue_insert_tail(&async_data->drain_queue, &pw->link);
+
+    return pw;
+}
+
+
+/**
+ * Remove and free pending write from drain_queue
+ */
+static void
+nxt_php_drain_queue_remove(nxt_php_pending_write_t *pw)
+{
+    nxt_queue_remove(&pw->link);
+
+    /* Decrease refcount - will be freed when refcount reaches 0 */
+    zend_string_release(pw->data);
+
+    free(pw);
+}
+
+
+/**
+ * Callback function called when port fd becomes readable
+ */
+static void
+nxt_php_port_event_callback(zend_async_event_t *event, zend_async_event_callback_t *callback, void *result, zend_object *exception)
+{
+    nxt_php_port_event_data_t  *event_data;
+
+    /* Get pointer to our extra data using extra_offset */
+    event_data = (nxt_php_port_event_data_t *)((char *)event + event->extra_offset);
+
+    /* Process messages from this port */
+    nxt_unit_process_port_msg(event_data->ctx, event_data->port);
+}
+
+
+/**
+ * Callback to add port - called by Unit for each port
+ */
+static int
+nxt_php_add_port(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port)
+{
+    zend_async_poll_event_t      *poll_event;
+    nxt_php_port_event_data_t    *event_data;
+
+    nxt_php_unit_ctx = ctx;
+
+    /* Skip ports without input fd */
+    if (port->in_fd == -1) {
+        return NXT_UNIT_OK;
+    }
+
+    /* Set port to non-blocking mode */
+    if (fcntl(port->in_fd, F_SETFL, O_NONBLOCK) == -1) {
+        nxt_unit_warn(ctx, "fcntl(%d, O_NONBLOCK) failed: %s (%d)",
+                      port->in_fd, strerror(errno), errno);
+        return NXT_UNIT_ERROR;
+    }
+
+    /* Create TrueAsync poll event with extra space for our data */
+    poll_event = ZEND_ASYNC_NEW_POLL_EVENT_EX(
+        port->in_fd, false, ASYNC_READABLE, sizeof(nxt_php_port_event_data_t)
+    );
+
+    if (poll_event == NULL) {
+        nxt_unit_alert(ctx, "Failed to create TrueAsync poll event for port fd=%d", port->in_fd);
+        return NXT_UNIT_ERROR;
+    }
+
+    /* Get pointer to our extra data */
+    event_data = (nxt_php_port_event_data_t *)((char *)poll_event + poll_event->base.extra_offset);
+    event_data->ctx = ctx;
+    event_data->port = port;
+
+    /* Register callback with poll event */
+    if (!poll_event->base.add_callback(&poll_event->base, ZEND_ASYNC_EVENT_CALLBACK(nxt_php_port_event_callback))) {
+        nxt_unit_alert(ctx, "Failed to add callback for port fd=%d", port->in_fd);
+        poll_event->base.dispose(&poll_event->base);
+        return NXT_UNIT_ERROR;
+    }
+
+    /* Start polling */
+    if (!poll_event->base.start(&poll_event->base)) {
+        nxt_unit_alert(ctx, "Failed to start polling for port fd=%d", port->in_fd);
+        poll_event->base.dispose(&poll_event->base);
+        return NXT_UNIT_ERROR;
+    }
+
+    /* Save poll_event in port->data for cleanup */
+    port->data = poll_event;
+
+    return NXT_UNIT_OK;
+}
+
+
+/**
+ * Callback to remove port
+ */
+static void
+nxt_php_remove_port(nxt_unit_t *unit, nxt_unit_ctx_t *ctx, nxt_unit_port_t *port)
+{
+    zend_async_poll_event_t  *poll_event;
+
+    if (port->data != NULL) {
+        poll_event = (zend_async_poll_event_t *) port->data;
+
+        /* Dispose using TrueAsync cleanup */
+        poll_event->base.dispose(&poll_event->base);
+
+        port->data = NULL;
+    }
+}
+
+
+/**
+ * SHM ACK handler - called when Router releases shared memory
+ */
+static void
+nxt_php_shm_ack_handler(nxt_unit_ctx_t *ctx)
+{
+    nxt_php_async_ctx_data_t *async_data = ctx->data;
+    nxt_queue_link_t         *lnk;
+    nxt_php_pending_write_t  *pw;
+    ssize_t                  res;
+    size_t                   remaining;
+
+    if (async_data == NULL) {
+        return;
+    }
+
+    /* Process all pending writes in drain_queue */
+    lnk = nxt_queue_first(&async_data->drain_queue);
+
+    while (lnk != nxt_queue_tail(&async_data->drain_queue)) {
+        pw = nxt_container_of(lnk, nxt_php_pending_write_t, link);
+        lnk = nxt_queue_next(lnk);  /* Save next element before potential removal */
+
+        remaining = ZSTR_LEN(pw->data) - pw->offset;
+
+        /* Try to send remaining data */
+        res = nxt_unit_response_write_nb(pw->req,
+                                         ZSTR_VAL(pw->data) + pw->offset,
+                                         remaining,
+                                         0);
+
+        if (res < 0) {
+            /* Error - remove from queue */
+            nxt_unit_warn(ctx, "drain_queue: write error, removing pending write");
+            nxt_php_drain_queue_remove(pw);
+            continue;
+        }
+
+        if (res == 0) {
+            /* Still no space - stop processing */
+            return;
+        }
+
+        pw->offset += res;
+
+        if (pw->offset >= ZSTR_LEN(pw->data)) {
+            /* ALL SENT! Remove from queue */
+            nxt_php_drain_queue_remove(pw);
+        }
+    }
+}
+
+
 static nxt_int_t
 nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
 {
@@ -469,6 +685,7 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
     nxt_php_app_conf_t     *c;
     nxt_common_app_conf_t  *conf;
 
+
     conf = data->app;
     c = &conf->u.php;
 
@@ -478,6 +695,8 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
     if (nxt_slow_path(nxt_php_targets == NULL)) {
         return NXT_ERROR;
     }
+
+    nxt_php_targets_count = n;
 
     if (c->targets != NULL) {
         next = 0;
@@ -507,7 +726,32 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
         return ret;
     }
 
-    php_init.callbacks.request_handler = nxt_php_request_handler;
+    /* Choose request handler based on mode */
+    if (c->async && c->entrypoint.length > 0) {
+        nxt_debug(task, "PHP HTTP Server mode enabled with entrypoint: %V", &c->entrypoint);
+        php_init.callbacks.add_port = nxt_php_add_port;
+        php_init.callbacks.remove_port = nxt_php_remove_port;
+        php_init.callbacks.request_handler = nxt_php_request_handler_async;
+        php_init.callbacks.quit = nxt_php_quit_handler;
+        php_init.callbacks.shm_ack_handler = nxt_php_shm_ack_handler;
+
+        if (nxt_slow_path(nxt_php_async_load_entrypoint(task, &c->entrypoint) != NXT_OK)) {
+            nxt_alert(task, "failed to load entrypoint script");
+            return NXT_ERROR;
+        }
+
+        if (nxt_php_request_callback == NULL) {
+            nxt_alert(task, "TrueAsync: Request callback not registered in the entrypoint script!");
+            return NXT_ERROR;
+        }
+
+        if(nxt_slow_path(!nxt_php_activate_true_async(task))) {
+            return NXT_ERROR;
+        }
+    } else {
+        nxt_debug(task, "PHP standard mode");
+        php_init.callbacks.request_handler = nxt_php_request_handler;
+    }
 
     unit_ctx = nxt_unit_init(&php_init);
     if (nxt_slow_path(unit_ctx == NULL)) {
@@ -516,8 +760,33 @@ nxt_php_start(nxt_task_t *task, nxt_process_data_t *data)
 
     nxt_php_unit_ctx = unit_ctx;
 
-    nxt_unit_run(nxt_php_unit_ctx);
+    /* Initialize async context data for drain_queue */
+    if (c->async && c->entrypoint.length > 0) {
+        nxt_php_async_ctx_data_t *async_data;
+
+        async_data = malloc(sizeof(nxt_php_async_ctx_data_t));
+        if (async_data == NULL) {
+            nxt_alert(task, "Failed to allocate async context data");
+            nxt_unit_done(unit_ctx);
+            return NXT_ERROR;
+        }
+
+        nxt_queue_init(&async_data->drain_queue);
+        async_data->ctx = unit_ctx;
+
+        unit_ctx->data = async_data;
+    }
+
+    if (c->async && c->entrypoint.length > 0) {
+        /* Suspend main coroutine until the server continues to operate successfully */
+        nxt_php_suspend_coroutine(nxt_php_unit_ctx);
+    } else {
+        nxt_unit_run(nxt_php_unit_ctx);
+    }
     nxt_unit_done(nxt_php_unit_ctx);
+
+    /* Clean up allocated memory before exit */
+    nxt_php_cleanup_targets();
 
     exit(0);
 
@@ -537,6 +806,7 @@ nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
     static const nxt_str_t  root_str = nxt_string("root");
     static const nxt_str_t  script_str = nxt_string("script");
     static const nxt_str_t  index_str = nxt_string("index");
+    static const nxt_str_t  entrypoint_str = nxt_string("entrypoint");
 
     value = nxt_conf_get_object_member(conf, &root_str, NULL);
 
@@ -600,12 +870,14 @@ nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
                            target->root.start, target->root.length))
         {
             nxt_alert(task, "script is not under php root");
+            nxt_free(p);
             return NXT_ERROR;
         }
 
         ret = nxt_php_dirname(&target->script_filename,
                               &target->script_dirname);
         if (nxt_slow_path(ret != NXT_OK)) {
+            nxt_free(target->script_filename.start);
             return NXT_ERROR;
         }
 
@@ -615,17 +887,86 @@ nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
                                     + target->root.length;
 
     } else {
+        /* Check for entrypoint (async mode) */
+        value = nxt_conf_get_object_member(conf, &entrypoint_str, NULL);
+
+        if (value != NULL) {
+            nxt_conf_get_string(value, &str);
+
+            /* Check if entrypoint is an absolute path */
+            if (str.length > 0 && str.start[0] == '/') {
+                /* Absolute path - use it directly */
+                tmp = nxt_malloc(str.length + 1);
+                if (nxt_slow_path(tmp == NULL)) {
+                    return NXT_ERROR;
+                }
+
+                nxt_memcpy(tmp, str.start, str.length);
+                tmp[str.length] = '\0';
+
+            } else {
+                /* Relative path - prepend root */
+                nxt_php_str_trim_lead(&str, '/');
+
+                tmp = nxt_malloc(target->root.length + 1 + str.length + 1);
+                if (nxt_slow_path(tmp == NULL)) {
+                    return NXT_ERROR;
+                }
+
+                p = tmp;
+
+                p = nxt_cpymem(p, target->root.start, target->root.length);
+                *p++ = '/';
+
+                p = nxt_cpymem(p, str.start, str.length);
+                *p = '\0';
+            }
+
+            p = nxt_realpath(tmp);
+            if (nxt_slow_path(p == NULL)) {
+                nxt_alert(task, "entrypoint realpath(%s) failed %E", tmp, nxt_errno);
+                nxt_free(tmp);
+                return NXT_ERROR;
+            }
+
+            nxt_free(tmp);
+
+            target->script_filename.length = nxt_strlen(p);
+            target->script_filename.start = p;
+
+            if (!nxt_str_start(&target->script_filename,
+                               target->root.start, target->root.length))
+            {
+                nxt_alert(task, "entrypoint is not under php root");
+                nxt_free(p);
+                return NXT_ERROR;
+            }
+
+            ret = nxt_php_dirname(&target->script_filename,
+                                  &target->script_dirname);
+            if (nxt_slow_path(ret != NXT_OK)) {
+                nxt_free(p);
+                return NXT_ERROR;
+            }
+
+            target->script_name.length = target->script_filename.length
+                                         - target->root.length;
+            target->script_name.start = target->script_filename.start
+                                        + target->root.length;
+        }
+
         value = nxt_conf_get_object_member(conf, &index_str, NULL);
 
         if (value != NULL) {
             nxt_conf_get_string(value, &str);
 
-            tmp = nxt_malloc(str.length);
+            tmp = nxt_malloc(str.length + 1);
             if (nxt_slow_path(tmp == NULL)) {
                 return NXT_ERROR;
             }
 
             nxt_memcpy(tmp, str.start, str.length);
+            tmp[str.length] = '\0';
 
             target->index.length = str.length;
             target->index.start = tmp;
@@ -636,6 +977,46 @@ nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
     }
 
     return NXT_OK;
+}
+
+
+static void
+nxt_php_cleanup_targets(void)
+{
+    nxt_uint_t  i;
+
+    if (nxt_php_targets == NULL) {
+        return;
+    }
+
+    for (i = 0; i < nxt_php_targets_count; i++) {
+        nxt_php_target_t *target = &nxt_php_targets[i];
+
+        /* Free root (allocated by nxt_realpath) */
+        if (target->root.start != NULL) {
+            nxt_free(target->root.start);
+        }
+
+        /* Free script_filename (allocated by nxt_realpath) */
+        if (target->script_filename.start != NULL) {
+            nxt_free(target->script_filename.start);
+        }
+
+        /* Free script_dirname (allocated by nxt_php_dirname) */
+        if (target->script_dirname.start != NULL) {
+            nxt_free(target->script_dirname.start);
+        }
+
+        /* Free index if it's not the default "index.php" constant */
+        if (target->index.start != NULL &&
+            target->index.start != (u_char *)"index.php") {
+            nxt_free(target->index.start);
+        }
+    }
+
+    nxt_free(nxt_php_targets);
+    nxt_php_targets = NULL;
+    nxt_php_targets_count = 0;
 }
 
 
@@ -1306,6 +1687,14 @@ nxt_php_unbuffered_write(const char *str, uint str_length TSRMLS_DC)
 
     ctx = SG(server_context);
 
+    /* During entrypoint execution there's no request context */
+    if (ctx == NULL || ctx->req == NULL) {
+        /* Log output from entrypoint to unit log */
+        nxt_unit_log(nxt_php_unit_ctx, NXT_UNIT_LOG_INFO,
+                     "PHP output: %.*s", (int)str_length, str);
+        return str_length;
+    }
+
     rc = nxt_unit_response_write(ctx->req, str, str_length);
     if (nxt_fast_path(rc == NXT_UNIT_OK)) {
         return str_length;
@@ -1329,6 +1718,12 @@ nxt_php_send_headers(sapi_headers_struct *sapi_headers TSRMLS_DC)
     nxt_unit_request_info_t  *req;
 
     ctx = SG(server_context);
+
+    /* During entrypoint execution there's no request context */
+    if (ctx == NULL || ctx->req == NULL) {
+        return SAPI_HEADER_SENT_SUCCESSFULLY;
+    }
+
     req = ctx->req;
 
     nxt_unit_req_debug(req, "nxt_php_send_headers");
@@ -1403,6 +1798,11 @@ nxt_php_read_post(char *buffer, uint count_bytes TSRMLS_DC)
 
     ctx = SG(server_context);
 
+    /* During entrypoint execution there's no request context */
+    if (ctx == NULL || ctx->req == NULL) {
+        return 0;
+    }
+
     nxt_unit_req_debug(ctx->req, "nxt_php_read_post %d", (int) count_bytes);
 
     return nxt_unit_request_read(ctx->req, buffer, count_bytes);
@@ -1416,13 +1816,18 @@ nxt_php_read_cookies(TSRMLS_D)
 
     ctx = SG(server_context);
 
+    /* During entrypoint execution there's no request context */
+    if (ctx == NULL) {
+        return NULL;
+    }
+
     nxt_unit_req_debug(ctx->req, "nxt_php_read_cookies");
 
     return ctx->cookie;
 }
 
 
-static void
+void
 nxt_php_register_variables(zval *track_vars_array TSRMLS_DC)
 {
     const char               *name;
@@ -1432,6 +1837,11 @@ nxt_php_register_variables(zval *track_vars_array TSRMLS_DC)
     nxt_unit_request_info_t  *req;
 
     ctx = SG(server_context);
+
+    /* During entrypoint execution there's no request context */
+    if (ctx == NULL || ctx->req == NULL) {
+        return;
+    }
 
     req = ctx->req;
     r = req->request;
@@ -1541,6 +1951,126 @@ nxt_php_register_variables(zval *track_vars_array TSRMLS_DC)
 
 
 static void
+nxt_php_register_variables_async(nxt_unit_request_info_t *req,
+    nxt_php_run_ctx_t *ctx, zval *track_vars_array TSRMLS_DC)
+{
+    const char               *name;
+    char                     *str;
+    nxt_unit_field_t         *f, *f_end;
+    nxt_unit_request_t       *r;
+
+    r = req->request;
+
+    nxt_unit_req_debug(req, "nxt_php_register_variables_async");
+
+    /* Register SERVER_SOFTWARE */
+    php_register_variable_safe((char *) "SERVER_SOFTWARE",
+                               (char *) nxt_server.start,
+                               nxt_server.length, track_vars_array TSRMLS_CC);
+
+    /* Register SERVER_PROTOCOL */
+    str = nxt_unit_sptr_get(&r->version);
+    php_register_variable_safe((char *) "SERVER_PROTOCOL", str,
+                               r->version_length, track_vars_array TSRMLS_CC);
+
+    /* Register PHP_SELF and PATH_INFO */
+    if (ctx->path_info.length != 0) {
+        str = nxt_unit_sptr_get(&r->path);
+        php_register_variable_safe((char *) "PHP_SELF", str,
+                                   r->path_length, track_vars_array TSRMLS_CC);
+        php_register_variable_safe((char *) "PATH_INFO",
+                                   (char *) ctx->path_info.start,
+                                   ctx->path_info.length, track_vars_array TSRMLS_CC);
+    } else {
+        php_register_variable_safe((char *) "PHP_SELF",
+                                   (char *) ctx->script_name.start,
+                                   ctx->script_name.length, track_vars_array TSRMLS_CC);
+    }
+
+    /* Register SCRIPT_NAME */
+    php_register_variable_safe((char *) "SCRIPT_NAME",
+                               (char *) ctx->script_name.start,
+                               ctx->script_name.length, track_vars_array TSRMLS_CC);
+
+    /* Register SCRIPT_FILENAME */
+    php_register_variable_safe((char *) "SCRIPT_FILENAME",
+                               (char *) ctx->script_filename.start,
+                               ctx->script_filename.length, track_vars_array TSRMLS_CC);
+
+    /* Register DOCUMENT_ROOT */
+    php_register_variable_safe((char *) "DOCUMENT_ROOT",
+                               (char *) ctx->root->start,
+                               ctx->root->length, track_vars_array TSRMLS_CC);
+
+    /* Register REQUEST_METHOD */
+    str = nxt_unit_sptr_get(&r->method);
+    php_register_variable_safe((char *) "REQUEST_METHOD", str,
+                               r->method_length, track_vars_array TSRMLS_CC);
+
+    /* Register REQUEST_URI */
+    str = nxt_unit_sptr_get(&r->target);
+    php_register_variable_safe((char *) "REQUEST_URI", str,
+                               r->target_length, track_vars_array TSRMLS_CC);
+
+    /* Register QUERY_STRING */
+    str = nxt_unit_sptr_get(&r->query);
+    php_register_variable_safe((char *) "QUERY_STRING", str,
+                               r->query_length, track_vars_array TSRMLS_CC);
+
+    /* Register REMOTE_ADDR */
+    str = nxt_unit_sptr_get(&r->remote);
+    php_register_variable_safe((char *) "REMOTE_ADDR", str,
+                               r->remote_length, track_vars_array TSRMLS_CC);
+
+    /* Register SERVER_ADDR */
+    str = nxt_unit_sptr_get(&r->local_addr);
+    php_register_variable_safe((char *) "SERVER_ADDR", str,
+                               r->local_addr_length, track_vars_array TSRMLS_CC);
+
+    /* Register SERVER_NAME */
+    str = nxt_unit_sptr_get(&r->server_name);
+    php_register_variable_safe((char *) "SERVER_NAME", str,
+                               r->server_name_length, track_vars_array TSRMLS_CC);
+
+    /* Register SERVER_PORT */
+    str = nxt_unit_sptr_get(&r->local_port);
+    php_register_variable_safe((char *) "SERVER_PORT", str,
+                               r->local_port_length, track_vars_array TSRMLS_CC);
+
+    /* Register HTTPS if TLS is enabled */
+    if (r->tls) {
+        php_register_variable_safe((char *) "HTTPS", (char *) "on",
+                                   2, track_vars_array TSRMLS_CC);
+    }
+
+    /* Register HTTP headers */
+    f_end = r->fields + r->fields_count;
+    for (f = r->fields; f < f_end; f++) {
+        name = nxt_unit_sptr_get(&f->name);
+        str = nxt_unit_sptr_get(&f->value);
+        php_register_variable_safe((char *) name, str,
+                                   f->value_length, track_vars_array TSRMLS_CC);
+    }
+
+    /* Register CONTENT_LENGTH */
+    if (r->content_length_field != NXT_UNIT_NONE_FIELD) {
+        f = r->fields + r->content_length_field;
+        str = nxt_unit_sptr_get(&f->value);
+        php_register_variable_safe((char *) "CONTENT_LENGTH", str,
+                                   f->value_length, track_vars_array TSRMLS_CC);
+    }
+
+    /* Register CONTENT_TYPE */
+    if (r->content_type_field != NXT_UNIT_NONE_FIELD) {
+        f = r->fields + r->content_type_field;
+        str = nxt_unit_sptr_get(&f->value);
+        php_register_variable_safe((char *) "CONTENT_TYPE", str,
+                                   f->value_length, track_vars_array TSRMLS_CC);
+    }
+}
+
+
+static void
 nxt_php_set_sptr(nxt_unit_request_info_t *req, const char *name,
     nxt_unit_sptr_t *v, uint32_t len, zval *track_vars_array TSRMLS_DC)
 {
@@ -1640,12 +2170,450 @@ nxt_php_log_message(char *message TSRMLS_DC)
 
     ctx = SG(server_context);
 
-    if (ctx != NULL) {
+    if (ctx != NULL && ctx->req != NULL) {
         nxt_unit_req_log(ctx->req, NXT_UNIT_LOG_NOTICE,
                          "php message: %s", message);
 
     } else {
         nxt_unit_log(nxt_php_unit_ctx, NXT_UNIT_LOG_NOTICE,
                      "php message: %s", message);
+    }
+}
+
+
+/* TrueAsync Mode Implementation */
+
+/* External globals */
+extern zval  *nxt_php_request_callback;
+
+/**
+ * The request handler invoked from NGINX UNIT.
+ * The handler uses a PHP callback function (nxt_php_request_callback) to process the request.
+ *
+ **/
+static void
+nxt_php_request_handler_async(nxt_unit_request_info_t *req)
+{
+    zend_async_scope_t    *request_scope;
+    zend_coroutine_t      *coroutine;
+    nxt_php_run_ctx_t     run_ctx;
+    nxt_php_target_t      *target;
+    nxt_unit_request_t    *r;
+    nxt_unit_field_t      *f;
+    void                  *saved_server_context;
+
+    r = req->request;
+    target = &nxt_php_targets[r->app_target];
+
+    /* 1. Create new Scope for this request with its own superglobals */
+    request_scope = ZEND_ASYNC_NEW_SCOPE(ZEND_ASYNC_CURRENT_SCOPE);
+
+    if (request_scope == NULL) {
+        nxt_unit_req_alert(req, "Failed to create request scope");
+        nxt_unit_request_done(req, NXT_UNIT_ERROR);
+        return;
+    }
+
+    /* 2. DISABLE inheriting global superglobals - each request has its own */
+    ZEND_ASYNC_SCOPE_CLR_INHERIT_SUPERGLOBALS(request_scope);
+
+    /* 3. Setup SG(server_context) and SG(request_info) for superglobals population */
+    saved_server_context = SG(server_context);
+
+    /* Prepare run context */
+    nxt_memzero(&run_ctx, sizeof(run_ctx));
+    run_ctx.req = req;
+    run_ctx.root = &target->root;
+    run_ctx.index = &target->index;
+    run_ctx.script_filename = target->script_filename;
+    run_ctx.script_dirname = target->script_dirname;
+    run_ctx.script_name = target->script_name;
+
+    /* Extract cookie if present */
+    if (r->cookie_field != NXT_UNIT_NONE_FIELD) {
+        f = r->fields + r->cookie_field;
+        run_ctx.cookie = nxt_unit_sptr_get(&f->value);
+    }
+
+    /* Setup SG(server_context) */
+    SG(server_context) = &run_ctx;
+
+    /* Setup SG(request_info) for php_default_treat_data */
+    SG(request_info).request_method = nxt_unit_sptr_get(&r->method);
+    SG(request_info).query_string = r->query.offset ? nxt_unit_sptr_get(&r->query) : NULL;
+    SG(request_info).content_length = r->content_length;
+
+    if (r->content_type_field != NXT_UNIT_NONE_FIELD) {
+        f = r->fields + r->content_type_field;
+        SG(request_info).content_type = nxt_unit_sptr_get(&f->value);
+    } else {
+        SG(request_info).content_type = NULL;
+    }
+
+    /* 4. Populate superglobals with data from HTTP request */
+    nxt_php_scope_populate_superglobals(request_scope);
+
+    /* 5. Restore original SG(server_context) */
+    SG(server_context) = saved_server_context;
+
+    /* 6. Create coroutine within this Scope */
+    coroutine = ZEND_ASYNC_NEW_COROUTINE(request_scope);
+    if (coroutine == NULL) {
+        nxt_unit_req_alert(req, "Failed to create coroutine");
+        /* Scope will be automatically cleaned up */
+        nxt_unit_request_done(req, NXT_UNIT_ERROR);
+        return;
+    }
+
+    /* 5. Setup coroutine entry point and data */
+    coroutine->internal_entry = nxt_php_request_coroutine_entry;
+    coroutine->extended_data = req;
+
+    /* 6. Enqueue coroutine for execution */
+    if (!ZEND_ASYNC_ENQUEUE_COROUTINE(coroutine)) {
+        nxt_unit_req_alert(req, "Failed to enqueue coroutine");
+        nxt_unit_request_done(req, NXT_UNIT_ERROR);
+        return;
+    }
+}
+
+/* Load and execute entrypoint script in async mode */
+static nxt_int_t
+nxt_php_async_load_entrypoint(nxt_task_t *task, nxt_str_t *entrypoint)
+{
+    FILE              *fp;
+    const char        *filename;
+    zend_file_handle  file_handle;
+
+    nxt_log(task, NXT_LOG_INFO, "TrueAsync: nxt_php_async_load_entrypoint called, PID=%d", getpid());
+
+
+    /* Create null-terminated filename */
+    char *filename_buf = nxt_malloc(entrypoint->length + 1);
+    if (filename_buf == NULL) {
+        nxt_alert(task, "TrueAsync: Failed to allocate filename buffer");
+        return NXT_ERROR;
+    }
+
+    nxt_memcpy(filename_buf, entrypoint->start, entrypoint->length);
+    filename_buf[entrypoint->length] = '\0';
+    filename = filename_buf;
+
+
+    fp = fopen(filename, "re");
+    if (fp == NULL) {
+        nxt_alert(task, "TrueAsync: Failed to open entrypoint %s", filename);
+        nxt_free(filename_buf);
+        return NXT_ERROR;
+    }
+
+    /* Initialize minimal SG() fields like CLI does */
+    SG(request_info).argc = 0;
+    SG(request_info).argv = NULL;
+    SG(request_info).path_translated = (char*)filename;
+    SG(server_context) = NULL;
+
+    /* Call php_request_startup() like CLI does */
+#ifdef NXT_PHP7
+    if (nxt_slow_path(php_request_startup() == FAILURE)) {
+#else
+    if (nxt_slow_path(php_request_startup(TSRMLS_C) == FAILURE)) {
+#endif
+        nxt_alert(task, "TrueAsync: php_request_startup() failed");
+        fclose(fp);
+        nxt_free(filename_buf);
+        return NXT_ERROR;
+    }
+
+    nxt_zend_stream_init_fp(&file_handle, fp, filename);
+
+    /* Execute entrypoint script */
+    int result = php_execute_script(&file_handle TSRMLS_CC);
+
+    if (result == FAILURE) {
+        nxt_alert(task, "TrueAsync: php_execute_script() FAILED!");
+        fclose(fp);
+        nxt_free(filename_buf);
+        return NXT_ERROR;
+    }
+
+#if (PHP_VERSION_ID >= 80100)
+    zend_destroy_file_handle(&file_handle);
+#endif
+
+    nxt_free(filename_buf);
+
+    /* Check if callback was registered */
+    if (nxt_php_request_callback == NULL) {
+        nxt_alert(task, "TrueAsync: No request handler registered! Call HttpServer->onRequest() in your entrypoint.");
+        return NXT_ERROR;
+    }
+
+    /* Check callback is callable */
+    if (nxt_php_request_callback != NULL && Z_TYPE_P(nxt_php_request_callback) == IS_OBJECT) {
+        nxt_log(task, NXT_LOG_INFO, "TrueAsync: Callback is object, type OK");
+    } else {
+        nxt_alert(task, "TrueAsync: Callback has wrong type: %d",
+                  nxt_php_request_callback ? Z_TYPE_P(nxt_php_request_callback) : -1);
+    }
+
+    /* DON'T call php_request_shutdown() - we want the callback to persist after fork */
+
+    return NXT_OK;
+}
+
+
+/* Quit handler for graceful shutdown */
+static void
+nxt_php_quit_handler(nxt_unit_ctx_t *ctx)
+{
+    nxt_unit_debug(ctx, "TrueAsync: quit handler called, triggering graceful shutdown");
+
+    /* Call ZEND_ASYNC_SHUTDOWN to trigger graceful shutdown of all coroutines */
+    ZEND_ASYNC_SHUTDOWN();
+}
+
+
+/* Server wait event methods */
+static bool
+nxt_php_server_wait_event_start(zend_async_event_t *event)
+{
+    /* No action needed - event waits indefinitely */
+    return true;
+}
+
+static bool
+nxt_php_server_wait_event_stop(zend_async_event_t *event)
+{
+    /* No action needed */
+    return true;
+}
+
+static bool
+nxt_php_server_wait_event_add_callback(zend_async_event_t *event, zend_async_event_callback_t *callback)
+{
+    return zend_async_callbacks_push(event, callback);
+}
+
+static bool
+nxt_php_server_wait_event_del_callback(zend_async_event_t *event, zend_async_event_callback_t *callback)
+{
+    return zend_async_callbacks_remove(event, callback);
+}
+
+static bool
+nxt_php_server_wait_event_replay(zend_async_event_t *event, zend_async_event_callback_t *callback, zval *result, zend_object **exception)
+{
+    /* Event never resolves - cannot replay */
+    return false;
+}
+
+static zend_string *
+nxt_php_server_wait_event_info(zend_async_event_t *event)
+{
+    return zend_string_init("NGINX Unit server waiting", sizeof("NGINX Unit server waiting") - 1, 0);
+}
+
+static bool
+nxt_php_server_wait_event_dispose(zend_async_event_t *event)
+{
+    if (ZEND_ASYNC_EVENT_REFCOUNT(event) > 1) {
+        ZEND_ASYNC_EVENT_DEL_REF(event);
+        return true;
+    }
+
+    if (ZEND_ASYNC_EVENT_REFCOUNT(event) == 1) {
+        ZEND_ASYNC_EVENT_DEL_REF(event);
+    }
+
+    /* Notify all callbacks that event is disposed */
+    ZEND_ASYNC_CALLBACKS_NOTIFY(event, NULL, NULL);
+
+    /* Free the event */
+    efree(event);
+
+    return true;
+}
+
+static bool
+nxt_php_activate_true_async(nxt_task_t *task)
+{
+    if (ZEND_ASYNC_IS_OFF) {
+        nxt_alert(task, "TrueAsync: async mode is off");
+        return false;
+    }
+
+    if (ZEND_ASYNC_IS_READY) {
+        if (!ZEND_ASYNC_SCHEDULER_LAUNCH()) {
+            nxt_alert(task, "TrueAsync: Failed to launch scheduler");
+            return false;
+        }
+    }
+
+    return ZEND_ASYNC_IS_ACTIVE;
+}
+
+/**
+ * Suspend coroutine until application should finish
+ * Event handlers registered via add_port/remove_port will be triggered by scheduler
+ */
+static void
+nxt_php_suspend_coroutine(nxt_unit_ctx_t *ctx)
+{
+    zend_coroutine_t *coroutine = ZEND_ASYNC_CURRENT_COROUTINE;
+    if (coroutine == NULL) {
+        nxt_unit_alert(ctx, "TrueAsync: Failed to get current coroutine");
+        return;
+    }
+
+    /* Create server wait event (it's custom nginx unit trigger for TrueAsync) */
+    zend_async_event_t *event = emalloc(sizeof(zend_async_event_t));
+    if (event == NULL) {
+        nxt_unit_alert(ctx, "TrueAsync: Failed to allocate server wait event");
+        return;
+    }
+
+    /* Initialize event structure */
+    memset(event, 0, sizeof(zend_async_event_t));
+
+    /* Set event methods */
+    event->start = nxt_php_server_wait_event_start;
+    event->stop = nxt_php_server_wait_event_stop;
+    event->add_callback = nxt_php_server_wait_event_add_callback;
+    event->del_callback = nxt_php_server_wait_event_del_callback;
+    event->replay = nxt_php_server_wait_event_replay;
+    event->info = nxt_php_server_wait_event_info;
+    event->dispose = nxt_php_server_wait_event_dispose;
+
+    /* Create waker for coroutine */
+    if (UNEXPECTED(zend_async_waker_new(coroutine) == NULL)) {
+        nxt_unit_alert(ctx, "TrueAsync: Failed to create waker");
+        event->dispose(event);
+        return;
+    }
+
+    /* Attach coroutine to wait event - it will suspend until GRACEFUL_SHUTDOWN */
+    zend_async_resume_when(coroutine, event, true, zend_async_waker_callback_resolve, NULL);
+
+    if (UNEXPECTED(EG(exception) != NULL)) {
+        nxt_unit_alert(ctx, "TrueAsync: Failed to attach coroutine to wait event");
+        zend_async_waker_clean(coroutine);
+        event->dispose(event);
+        return;
+    }
+
+    ZEND_ASYNC_SUSPEND();
+    zend_async_waker_clean(coroutine);
+}
+
+
+static void
+nxt_php_scope_init_superglobals(zend_async_scope_t *scope)
+{
+    zval tmp;
+
+    if (scope->superglobals != NULL) {
+        return;
+    }
+
+    ALLOC_HASHTABLE(scope->superglobals);
+    zend_hash_init(scope->superglobals, 8, NULL, ZVAL_PTR_DTOR, 0);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_GET", sizeof("_GET") - 1, &tmp);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_POST", sizeof("_POST") - 1, &tmp);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_COOKIE", sizeof("_COOKIE") - 1, &tmp);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_SERVER", sizeof("_SERVER") - 1, &tmp);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_ENV", sizeof("_ENV") - 1, &tmp);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_FILES", sizeof("_FILES") - 1, &tmp);
+
+    array_init(&tmp);
+    zend_hash_str_add_new(scope->superglobals, "_REQUEST", sizeof("_REQUEST") - 1, &tmp);
+}
+
+
+static void
+nxt_php_scope_populate_superglobals(zend_async_scope_t *scope)
+{
+    zval               *server_array, *get_array, *post_array, *cookie_array;
+    nxt_php_run_ctx_t  *ctx;
+    nxt_unit_request_t *r;
+    nxt_unit_field_t   *f;
+
+    if (scope->superglobals == NULL) {
+        nxt_php_scope_init_superglobals(scope);
+    }
+
+    ctx = SG(server_context);
+    if (ctx == NULL || ctx->req == NULL) {
+        return;
+    }
+
+    r = ctx->req->request;
+
+    server_array = zend_hash_str_find(scope->superglobals, "_SERVER", sizeof("_SERVER") - 1);
+    get_array    = zend_hash_str_find(scope->superglobals, "_GET", sizeof("_GET") - 1);
+    post_array   = zend_hash_str_find(scope->superglobals, "_POST", sizeof("_POST") - 1);
+    cookie_array = zend_hash_str_find(scope->superglobals, "_COOKIE", sizeof("_COOKIE") - 1);
+
+    /* Populate $_SERVER */
+    if (server_array != NULL) {
+        nxt_php_register_variables_async(ctx->req, ctx, server_array);
+    }
+
+    /* Populate $_GET - use PARSE_STRING to write into our array */
+    if (get_array != NULL && r->query_length > 0) {
+        char *query = estrndup((char *)nxt_unit_sptr_get(&r->query), r->query_length);
+        php_default_treat_data(PARSE_STRING, query, get_array);
+    }
+
+    /* Populate $_COOKIE - use PARSE_STRING to write into our array */
+    if (cookie_array != NULL && ctx->cookie != NULL) {
+        char *cookie = estrdup(ctx->cookie);
+        php_default_treat_data(PARSE_STRING, cookie, cookie_array);
+    }
+
+    /* Populate $_POST - use PARSE_STRING for application/x-www-form-urlencoded */
+    if (post_array != NULL &&
+        SG(request_info).request_method &&
+        !strcasecmp(SG(request_info).request_method, "POST"))
+    {
+        /* Check if content type is application/x-www-form-urlencoded */
+        if (r->content_type_field != NXT_UNIT_NONE_FIELD) {
+            f = r->fields + r->content_type_field;
+            const char *content_type = nxt_unit_sptr_get(&f->value);
+
+            /* Only parse if it's form-urlencoded (simple POST data) */
+            if (content_type && 
+                strncasecmp(content_type, "application/x-www-form-urlencoded", 33) == 0)
+            {
+                /* Read POST body into memory */
+                size_t post_len = r->content_length;
+                if (post_len > 0) {
+                    char *post_data = nxt_malloc(post_len + 1);
+                    if (post_data != NULL) {
+                        size_t read_bytes = nxt_unit_request_read(ctx->req, post_data, post_len);
+                        if (read_bytes > 0) {
+                            post_data[read_bytes] = '\0';
+                            /* php_default_treat_data will modify and free the string, so use estrndup */
+                            char *post_copy = estrndup(post_data, read_bytes);
+                            php_default_treat_data(PARSE_STRING, post_copy, post_array);
+                        }
+                        nxt_free(post_data);
+                    }
+                }
+            }
+            /* For multipart/form-data and others - not supported yet in async mode */
+        }
     }
 }

--- a/test/php/async_mirror/entrypoint.php
+++ b/test/php/async_mirror/entrypoint.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * TrueAsync entrypoint for echo/mirror tests.
+ *
+ * Reads the request body and echoes it back, similar to the standard
+ * test/php/mirror fixture but using the async request API.
+ *
+ * Requires: PHP 8.5+ with TrueAsync + Unit PHP extension.
+ *
+ * TODO: Adjust \Unit\Request API surface once nxt_php_extension.c
+ *       is implemented and the PHP-side class names are finalised.
+ */
+
+\Unit\Server::setHandler(function (\Unit\Request $request): void {
+    $body = $request->body();
+    $request->respond(200, [
+        'Content-Type'   => 'text/plain',
+        'Content-Length' => (string) strlen($body),
+    ], $body);
+});

--- a/test/php/async_shutdown/entrypoint.php
+++ b/test/php/async_shutdown/entrypoint.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * TrueAsync entrypoint for graceful shutdown tests.
+ *
+ * This file is loaded once when the PHP worker starts (not per-request).
+ * It registers a request handler callback with the Unit PHP extension,
+ * which is then called by nxt_php_request_handler_async() for each
+ * incoming HTTP request.
+ *
+ * Requires: PHP 8.5+ with TrueAsync extension and Unit PHP extension
+ *           (nxt_php_extension.c / nxt_php_extension_init()).
+ *
+ * TODO: Replace \Unit\Server::setHandler() with the actual API once
+ *       nxt_php_extension.c is implemented. The C side expects
+ *       nxt_php_request_callback to be set to a callable/object.
+ */
+
+\Unit\Server::setHandler(function (\Unit\Request $request): void {
+    // Minimal handler: return 200 OK with a known body so tests can
+    // verify the worker is alive and serving requests.
+    $request->respond(200, ['Content-Type' => 'text/plain'], "OK\n");
+});

--- a/test/php/async_slow/entrypoint.php
+++ b/test/php/async_slow/entrypoint.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * TrueAsync entrypoint that simulates a slow (in-flight) request.
+ *
+ * Sleeps for a configurable number of seconds before responding,
+ * controlled by the ?sleep=N query parameter (default 3 s, max 30 s).
+ * Used by tests that need to verify graceful shutdown waits for
+ * in-flight coroutines to finish before exiting.
+ *
+ * Requires: PHP 8.5+ with TrueAsync + Unit PHP extension.
+ *
+ * NOTE: The sleep here must be a coroutine-friendly async sleep so
+ * that the scheduler remains responsive to shutdown signals while
+ * the handler is suspended. Using the synchronous sleep() would block
+ * the event loop and defeat the purpose of TrueAsync mode.
+ *
+ * TODO: Replace \Async\sleep() with the correct TrueAsync API once
+ *       the extension API surface is stable.
+ */
+
+\Unit\Server::setHandler(function (\Unit\Request $request): void {
+    $params = [];
+    parse_str($request->query(), $params);
+
+    $delay = min((int) ($params['sleep'] ?? 3), 30);
+
+    // Write a sentinel file before sleeping so the test process can
+    // detect that this handler is genuinely in-flight (not just queued
+    // in the kernel TCP buffer).  The path is passed as ?signal=<path>.
+    // Writing the worker PID lets the test double-check which process is
+    // handling the request.
+    if (!empty($params['signal'])) {
+        file_put_contents($params['signal'], (string) getmypid());
+    }
+
+    // Async sleep: suspends this coroutine without blocking the event
+    // loop, allowing other coroutines (and the quit handler) to run.
+    \Async\sleep($delay);
+
+    $request->respond(200, ['Content-Type' => 'text/plain'], "done\n");
+});

--- a/test/test_php_trueasync.py
+++ b/test/test_php_trueasync.py
@@ -81,12 +81,17 @@ def require_trueasync():
     Skip every test in this module if the TrueAsync infrastructure is absent.
 
     Runs before each test body (after the conftest 'run' fixture starts Unit).
-    Configures a minimal async application, makes one probe request, and calls
-    pytest.skip() if the response is not 200.  Two distinct failure modes are
-    distinguished so the skip message is actionable:
+    Three distinct failure modes are distinguished so the skip message is
+    actionable and unambiguous:
 
-    • Config rejected with "error" → "async"/"entrypoint" fields missing from
-      nxt_php_app_conf_t (TODO.md #1).  The fix is in nxt_application.h.
+    • PHP version < 8.5 → TrueAsync C code was compiled out via
+      #if NXT_PHP_TRUEASYNC (which configure sets to 0 when zend_async_event_t
+      is absent from the PHP headers).  The skip message points to the version
+      guard, not to a missing extension.  This catches any edge case where an
+      older PHP version slips past the prerequisites filter.
+
+    • Config rejected with "error" → "async"/"entrypoint" fields are missing
+      from nxt_php_app_conf_t (TODO.md #1).  The fix is in nxt_application.h.
 
     • Config accepted but status != 200 → nxt_php_extension.c is not built,
       so the PHP worker starts but \\Unit\\Server is undefined and the entrypoint
@@ -97,6 +102,20 @@ def require_trueasync():
     loading whatever config it actually needs — client.conf() in the test body
     will replace the probe config before any real assertions run.
     """
+    # ── Guard 1: PHP version ────────────────────────────────────────────────
+    # TrueAsync C code is compiled only when configure detects
+    # zend_async_event_t in the PHP headers (NXT_PHP_TRUEASYNC=1), which
+    # requires PHP 8.5+.  A misleading "extension not available" message
+    # would appear on older PHP if we went straight to the HTTP probe.
+    php_type = client.get_application_type()  # e.g. "php 8.5.0"
+    match = re.search(r'(\d+)\.(\d+)', php_type)
+    if not match or [match.group(1), match.group(2)] < ['8', '5']:
+        pytest.skip(
+            f'TrueAsync requires PHP 8.5+ with zend_async_event_t in headers '
+            f'(got {php_type!r}); C code excluded by #if NXT_PHP_TRUEASYNC'
+        )
+
+    # ── Guard 2 & 3: runtime probe ──────────────────────────────────────────
     probe_conf = {
         'listeners': {'*:8080': {'pass': 'applications/_trueasync_probe'}},
         'applications': {

--- a/test/test_php_trueasync.py
+++ b/test/test_php_trueasync.py
@@ -1,0 +1,545 @@
+"""
+Tests for PHP TrueAsync mode with graceful shutdown.
+
+Background
+----------
+Commit 58ffa236 (cherry-picked from EdmondDantes/052afd8) adds
+nxt_php_quit_handler() to src/nxt_php_sapi.c.  When Unit sends a quit
+signal to a PHP worker started in TrueAsync mode, the handler calls
+ZEND_ASYNC_SHUTDOWN() so the coroutine scheduler terminates gracefully
+instead of leaving the process hanging indefinitely.
+
+Status: TDD — tests are written for code that is not yet complete.
+See TODO.md items #1 and #2.  All tests in this file are automatically
+skipped (via the require_trueasync autouse fixture) when:
+  - The "async"/"entrypoint" config fields are not parsed by Unit, OR
+  - nxt_php_extension.c is not built (no \\Unit\\Server PHP class).
+
+Prerequisites
+-------------
+- PHP 8.5+ (TrueAsync is a PHP 8.5+ feature).
+- Unit PHP extension built from nxt_php_extension.c.
+- The application config must set "async": true + "entrypoint" to
+  activate nxt_php_quit_handler registration in nxt_php_start().
+
+Fixture layout
+--------------
+  test/php/async_shutdown/entrypoint.php  – minimal OK responder
+  test/php/async_mirror/entrypoint.php    – echo request body
+  test/php/async_slow/entrypoint.php      – sleeps N seconds; writes
+                                            sentinel file when handler starts
+
+Running
+-------
+  sudo pytest-3 --print-log test/test_php_trueasync.py
+"""
+
+import os
+import re
+import signal
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+from unit.applications.lang.php import ApplicationPHP
+from unit.option import option
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Module-level prerequisites
+# ──────────────────────────────────────────────────────────────────────────────
+
+# pytest_generate_tests() reads this and parametrises against each PHP
+# version satisfying the filter — only 8.5+ gets TrueAsync support.
+prerequisites = {
+    'modules': {
+        'php': lambda version: version.split('.')[:2] >= ['8', '5'],
+    }
+}
+
+client = ApplicationPHP()
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Seconds a worker is given to exit cleanly after the quit signal.
+# Keep it generous on slow CI runners, but short enough to surface hangs.
+SHUTDOWN_TIMEOUT = 15
+
+# Seconds to poll before declaring a worker "failed to start".
+WORKER_START_TIMEOUT = 10
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Module-level autouse fixture — replaces per-test runtime probes
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def require_trueasync():
+    """
+    Skip every test in this module if the TrueAsync infrastructure is absent.
+
+    Runs before each test body (after the conftest 'run' fixture starts Unit).
+    Configures a minimal async application, makes one probe request, and calls
+    pytest.skip() if the response is not 200.  Two distinct failure modes are
+    distinguished so the skip message is actionable:
+
+    • Config rejected with "error" → "async"/"entrypoint" fields missing from
+      nxt_php_app_conf_t (TODO.md #1).  The fix is in nxt_application.h.
+
+    • Config accepted but status != 200 → nxt_php_extension.c is not built,
+      so the PHP worker starts but \\Unit\\Server is undefined and the entrypoint
+      fails to register a request callback (TODO.md #2).
+
+    The probe config is intentionally minimal (async_shutdown fixture, one
+    process) to minimise side-effects.  The test body is responsible for
+    loading whatever config it actually needs — client.conf() in the test body
+    will replace the probe config before any real assertions run.
+    """
+    probe_conf = {
+        'listeners': {'*:8080': {'pass': 'applications/_trueasync_probe'}},
+        'applications': {
+            '_trueasync_probe': {
+                'type': client.get_application_type(),
+                'processes': {'spare': 0},
+                'root': f'{option.test_dir}/php/async_shutdown',
+                'async': True,
+                'entrypoint': 'entrypoint.php',
+            }
+        },
+    }
+
+    r = client.conf(probe_conf)
+    if 'error' in r:
+        pytest.skip(
+            'PHP async config rejected — "async"/"entrypoint" fields are '
+            'missing from nxt_php_app_conf_t (see TODO.md #1)'
+        )
+
+    if client.get()['status'] != 200:
+        pytest.skip(
+            'PHP TrueAsync extension not available — '
+            'build nxt_php_extension.c and relink the PHP module '
+            '(see TODO.md #2)'
+        )
+
+    yield  # test body runs here; probe config is replaced by the test itself
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _async_app_conf(script: str) -> dict:
+    """
+    Return a Unit application config dict for TrueAsync mode.
+
+    "async": true + "entrypoint" is the combination that activates
+    nxt_php_quit_handler registration inside nxt_php_start().
+    """
+    return {
+        'type': client.get_application_type(),
+        'processes': {'spare': 0},
+        'root': f'{option.test_dir}/php/{script}',
+        'async': True,
+        'entrypoint': 'entrypoint.php',
+    }
+
+
+def _worker_pids(app_name: str, unit_pid: int) -> list:
+    """
+    Return PIDs of live worker processes for *app_name*.
+
+    Unit names application workers after the application name, so we
+    match the Unit master PID as ppid and the app name in the command.
+    """
+    output = subprocess.check_output(['ps', 'ax', '-O', 'ppid']).decode()
+    return re.findall(
+        fr'\s*(\d+)\s+{unit_pid}\s+.*{re.escape(app_name)}',
+        output,
+    )
+
+
+def _wait_for_worker(app_name: str, unit_pid: int,
+                     timeout: float = WORKER_START_TIMEOUT) -> list:
+    """
+    Poll until at least one worker for *app_name* appears in /proc.
+    Raises AssertionError if no worker appears within *timeout* seconds.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        pids = _worker_pids(app_name, unit_pid)
+        if pids:
+            return pids
+        time.sleep(0.1)
+    raise AssertionError(
+        f'Worker for {app_name!r} did not start within {timeout}s'
+    )
+
+
+def _workers_gone(pids: list, timeout: float = SHUTDOWN_TIMEOUT) -> bool:
+    """
+    Return True once every PID in *pids* has vanished from /proc.
+    Return False if any remain alive after *timeout* seconds.
+
+    Checking /proc/{pid} is more reliable than parsing 'ps' output:
+    the entry disappears exactly when the kernel reaps the process,
+    with no race between the read and the process exiting.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if all(not os.path.exists(f'/proc/{p}') for p in pids):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _wait_for_file(path: str, timeout: float = WORKER_START_TIMEOUT) -> bool:
+    """
+    Poll until *path* exists on disk (written by the PHP handler as a
+    start sentinel) or *timeout* elapses.  Return True if found in time.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.05)
+    return False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_php_trueasync_worker_starts(unit_pid):
+    """
+    Smoke test: a PHP worker in TrueAsync mode starts and serves requests.
+
+    This is the minimal sanity check for every other test.  If it fails
+    after the require_trueasync fixture passed, the most likely cause is
+    a config field being silently ignored rather than raising an error
+    (e.g. "async" accepted but not wired to c->async in nxt_php_start).
+    """
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_shutdown'}},
+            'applications': {'async_shutdown': _async_app_conf('async_shutdown')},
+        }
+    ), 'configuration accepted'
+
+    pids = _wait_for_worker('async_shutdown', unit_pid)
+    assert pids, 'at least one worker process is running'
+
+    resp = client.get()
+    assert resp['status'] == 200, 'worker responds with 200'
+    assert 'OK' in resp['body'], 'response body from async handler'
+
+
+def test_php_trueasync_graceful_shutdown_on_reconfigure(unit_pid, wait_for_record):
+    """
+    Core regression test for commit 58ffa236.
+
+    Scenario
+    --------
+    1. Start a PHP worker in TrueAsync mode.
+    2. Confirm it is alive and serving.
+    3. Remove the application — Unit's router sends the quit signal to
+       the worker, exercising nxt_php_quit_handler() → ZEND_ASYNC_SHUTDOWN().
+    4. Assert the worker exits within SHUTDOWN_TIMEOUT seconds.
+
+    Before the fix the worker blocked in nxt_unit_run() indefinitely
+    because the scheduler never received a shutdown trigger.
+    """
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_app'}},
+            'applications': {'async_app': _async_app_conf('async_shutdown')},
+        }
+    ), 'load async_shutdown configuration'
+
+    # Capture PIDs before reconfiguration so we can track these specific
+    # processes — not just any worker that might appear later.
+    pids = _wait_for_worker('async_app', unit_pid)
+
+    assert client.get()['status'] == 200, 'worker alive before reconfigure'
+
+    # Remove the application; Unit will deliver the quit signal.
+    assert 'success' in client.conf(
+        {'listeners': {}, 'applications': {}}
+    ), 'empty configuration accepted'
+
+    assert _workers_gone(pids), (
+        f'TrueAsync worker(s) {pids} did not exit within {SHUTDOWN_TIMEOUT}s '
+        f'— nxt_php_quit_handler may not have fired, or '
+        f'ZEND_ASYNC_SHUTDOWN() did not stop the scheduler'
+    )
+
+    # Informational: verify Unit logged the quit handler invocation.
+    # Only present when Unit is built with debug logging; not a hard failure.
+    wait_for_record(r'TrueAsync: quit handler called', wait=5)
+
+
+def test_php_trueasync_graceful_shutdown_on_sigquit(unit_pid, skip_alert):
+    """
+    Graceful shutdown when SIGQUIT is delivered to the Unit master.
+
+    This is the normal production shutdown path: systemd ExecStop,
+    container runtime "stop", or NGINX-style graceful reload all use SIGQUIT.
+    The signal path is: SIGQUIT → master → router → quit callback → ZEND_ASYNC_SHUTDOWN.
+
+    skip_alert suppresses the "exited on signal" log alert that would
+    otherwise cause the test-teardown checker to flag a failure.
+    """
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_app'}},
+            'applications': {'async_app': _async_app_conf('async_shutdown')},
+        }
+    ), 'load configuration'
+
+    pids = _wait_for_worker('async_app', unit_pid)
+
+    assert client.get()['status'] == 200, 'worker alive'
+
+    for pid in pids:
+        skip_alert(fr'process {pid} exited on signal')
+
+    os.kill(unit_pid, signal.SIGQUIT)
+
+    assert _workers_gone(pids), (
+        f'TrueAsync worker(s) did not exit within {SHUTDOWN_TIMEOUT}s '
+        f'after SIGQUIT → Unit master (pid={unit_pid})'
+    )
+
+
+def test_php_trueasync_no_zombie_after_shutdown(unit_pid, skip_alert):
+    """
+    Exited TrueAsync workers must be reaped — no zombies.
+
+    A zombie means the master is not calling waitpid() after the quit
+    handler returns.  This is a process-management regression independent
+    of TrueAsync, but worth asserting here alongside the shutdown tests.
+    """
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_app'}},
+            'applications': {'async_app': _async_app_conf('async_shutdown')},
+        }
+    ), 'load configuration'
+
+    pids = _wait_for_worker('async_app', unit_pid)
+    for pid in pids:
+        skip_alert(fr'process {pid} exited on signal')
+
+    assert 'success' in client.conf(
+        {'listeners': {}, 'applications': {}}
+    ), 'empty configuration to trigger quit'
+
+    assert _workers_gone(pids), 'workers exited before zombie check'
+
+    out = subprocess.check_output(
+        ['ps', 'ax', '-o', 'state', '-o', 'ppid']
+    ).decode()
+    zombie_ppids = re.findall(r'Z\s+(\d+)', out)
+    assert str(unit_pid) not in zombie_ppids, (
+        'No zombie processes parented to Unit master after async worker shutdown'
+    )
+
+
+def test_php_trueasync_standard_mode_unaffected():
+    """
+    Regression guard: nxt_php_sapi.c changes must not break standard PHP.
+
+    Standard mode uses nxt_php_request_handler (not the async variant).
+    nxt_php_quit_handler is NOT registered (php_init.callbacks.quit = NULL)
+    and the pre-existing shutdown path is used unchanged.
+    """
+    # Load the plain mirror fixture — no async config involved.
+    client.load('mirror')
+
+    resp = client.post(body='hello', headers={'Content-Length': '5'})
+    assert resp['status'] == 200, 'standard mode: POST succeeds'
+    assert resp['body'] == 'hello', 'standard mode: body echoed'
+
+    assert client.get()['status'] == 200, 'standard mode: GET succeeds'
+
+
+def test_php_trueasync_mirror_request_body(unit_pid):
+    """
+    Functional test: async handler reads and echoes the request body.
+
+    Exercises nxt_php_request_handler_async(),
+    nxt_php_scope_populate_superglobals(), and the response-write path
+    including nxt_php_drain_queue under backpressure.
+    """
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_mirror'}},
+            'applications': {'async_mirror': _async_app_conf('async_mirror')},
+        }
+    ), 'load async_mirror configuration'
+
+    _wait_for_worker('async_mirror', unit_pid)
+
+    payload = 'TrueAsync echo test payload'
+    resp = client.post(
+        body=payload,
+        headers={'Content-Length': str(len(payload))},
+    )
+    assert resp['status'] == 200, 'async mirror: status 200'
+    assert resp['body'] == payload, 'async mirror: body echoed correctly'
+
+
+def test_php_trueasync_multiple_workers_all_exit(unit_pid, skip_alert):
+    """
+    All worker processes must exit gracefully on shutdown, not just one.
+
+    Each worker runs nxt_php_start() independently, so nxt_php_quit_handler
+    must be registered per-worker (not once globally).  ZEND_ASYNC_SHUTDOWN()
+    must stop each worker's own scheduler instance.
+    """
+    conf = _async_app_conf('async_shutdown')
+    conf['processes'] = 2   # request two workers explicitly
+
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_multi'}},
+            'applications': {'async_multi': conf},
+        }
+    ), 'load multi-worker configuration'
+
+    # Wait until both workers are visible in the process table.
+    deadline = time.monotonic() + WORKER_START_TIMEOUT
+    pids = []
+    while time.monotonic() < deadline:
+        pids = _worker_pids('async_multi', unit_pid)
+        if len(pids) >= 2:
+            break
+        time.sleep(0.1)
+
+    assert len(pids) >= 2, (
+        f'Expected ≥2 TrueAsync workers, got {len(pids)}: {pids}'
+    )
+
+    for pid in pids:
+        skip_alert(fr'process {pid} exited on signal')
+
+    assert 'success' in client.conf(
+        {'listeners': {}, 'applications': {}}
+    ), 'empty config to stop all workers'
+
+    still_alive = [p for p in pids if os.path.exists(f'/proc/{p}')]
+    assert _workers_gone(pids), (
+        f'Not all TrueAsync workers exited within {SHUTDOWN_TIMEOUT}s. '
+        f'Still alive: {still_alive}'
+    )
+
+
+def test_php_trueasync_inflight_request_completes(unit_pid, skip_alert, tmp_path):
+    """
+    In-flight requests must complete before the worker exits on shutdown.
+
+    Approach
+    --------
+    1. Start the slow entrypoint (?sleep=2).  The handler writes a sentinel
+       file to *signal_file* the moment it begins executing — before sleeping.
+    2. Poll *signal_file* instead of using time.sleep(): once the file exists
+       the handler is definitively in-flight inside the PHP coroutine.
+    3. Issue the reconfigure (removes the app, triggers the quit signal).
+    4. Wait for curl to finish and assert the response is 200 "done".
+
+    The slow request is made via curl in a subprocess rather than a thread:
+    subprocess.Popen avoids GIL contention and gives an independent TCP
+    connection not shared with the client used for conf() calls.
+
+    NOTE: This test asserts cooperative-shutdown semantics — that
+    ZEND_ASYNC_SHUTDOWN() lets active coroutines run to completion.
+    If the TrueAsync scheduler cancels coroutines on shutdown instead,
+    this test will fail with a connection error or non-200 status; see
+    TODO.md #4 for the discussion and resolution path.
+    """
+    assert 'success' in client.conf(
+        {
+            'listeners': {'*:8080': {'pass': 'applications/async_slow'}},
+            'applications': {'async_slow': _async_app_conf('async_slow')},
+        }
+    ), 'load async_slow configuration'
+
+    pids = _wait_for_worker('async_slow', unit_pid)
+    for pid in pids:
+        skip_alert(fr'process {pid} exited on signal')
+
+    # Build the sentinel file path in /tmp rather than in pytest's tmp_path.
+    #
+    # tmp_path is owned by the user running pytest (typically root in CI),
+    # but the Unit PHP worker runs under its own user (e.g. "unit").  The
+    # worker process would get EACCES writing to a 0o700 directory it does
+    # not own.  /tmp is world-writable (mode 1777) on every POSIX system,
+    # so no chmod dance is needed.
+    #
+    # We include the pytest tmp_path basename (unique per-test) to avoid
+    # collisions when multiple test runs overlap, and clean up explicitly
+    # at the end of the test.
+    signal_file = os.path.join(
+        tempfile.gettempdir(),
+        f'unit_async_{os.path.basename(str(tmp_path))}',
+    )
+
+    # Launch curl in a subprocess: one independent TCP connection,
+    # no GIL contention, clean resource lifetime via context manager.
+    url = f'http://localhost:8080/?sleep=2&signal={signal_file}'
+    with subprocess.Popen(
+        ['curl', '-s', '--max-time', '25', url],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ) as proc:
+
+        # Wait for the PHP handler to create the sentinel file.
+        # This is the authoritative signal that the coroutine is sleeping
+        # inside the handler — not just enqueued in the kernel or router.
+        if not _wait_for_file(signal_file):
+            proc.terminate()
+            pytest.fail(
+                f'Slow request did not reach the PHP handler within '
+                f'{WORKER_START_TIMEOUT}s (sentinel file not created). '
+                f'Check that async_slow/entrypoint.php writes ?signal= path.'
+            )
+
+        # The request is now definitively in-flight.  Trigger shutdown.
+        assert 'success' in client.conf(
+            {'listeners': {}, 'applications': {}}
+        ), 'reconfigure while request is in flight'
+
+        # Wait for curl to finish; generous timeout covers sleep=2 plus
+        # scheduler shutdown overhead.
+        try:
+            stdout, _ = proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            pytest.fail('curl did not finish within 30s after shutdown trigger')
+
+    body = stdout.decode()
+
+    assert proc.returncode == 0, (
+        f'curl exited with code {proc.returncode} — connection was dropped '
+        f'before the response arrived. ZEND_ASYNC_SHUTDOWN() may cancel '
+        f'in-flight coroutines rather than letting them complete (TODO.md #4).'
+    )
+    assert 'done' in body, (
+        f'Unexpected response body: {body!r}. '
+        f'Expected "done" from async_slow handler.'
+    )
+
+    assert _workers_gone(pids), (
+        f'Worker(s) did not exit within {SHUTDOWN_TIMEOUT}s after the '
+        f'in-flight request completed.'
+    )
+
+    # Remove the sentinel file written by the PHP worker.  It lives in /tmp
+    # (not in pytest's tmp_path) so pytest cannot clean it up automatically.
+    try:
+        os.unlink(signal_file)
+    except FileNotFoundError:
+        pass  # handler may not have written it if the test failed early


### PR DESCRIPTION
- Add nxt_php_quit_handler to handle Unit shutdown signal
- Register quit callback in async mode initialization
- Call ZEND_ASYNC_SHUTDOWN() to trigger graceful coroutine shutdown
- Fixes worker processes hanging on server termination

Original author: EdmondDantes
Original commit: 052afd88d337a6bb30857115e883b74d28e8dd26