### PR TITLE
Version 1.35.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,40 @@
 
+Changes with FreeUnit 1.35.2                                     04 Apr 2026
+
+    *) Bugfix: fix graceful shutdown for PHP workers running in TrueAsync
+       mode; workers now exit cleanly when Unit delivers a quit signal
+       instead of blocking indefinitely in the event loop.
+
+    *) Bugfix: guard pre_request_init SAPI callback registration with
+       NXT_PHP_PRE_REQUEST_INIT to fix builds against PHP versions that
+       do not expose this callback.
+
+    *) CI: fix Ruby language module build in clang-ast workflow on
+       debian:testing — resolve Debian multiarch library path mismatch
+       and suppress -Wdefault-const-init-field-unsafe from clang 21 on
+       Ruby 3.3 headers.
+
+
+Changes with FreeUnit 1.35.1                                     03 Apr 2026
+
+    *) Feature: Docker images for PHP 8.5, PHP 8.4, and Python 3.14
+       published to GitHub Container Registry (GHCR) for linux/amd64
+       and linux/arm64.
+
+    *) Feature: switch all Docker base images from debian:bookworm to
+       debian:trixie.
+
+    *) Feature: add PHP 8.5 pre_request_init SAPI callback support
+       (nxt_php_sapi.c).
+
+    *) Feature: add PHP 8.4 and PHP 8.5 to CI test matrix.
+
+    *) Feature: build CI against OpenSSL 3.6.
+
+    *) Change: fork from nginx/unit as FreeUnit — community LTS
+       continuation of the Unit application server.
+
+
 Changes with Unit 1.35.0                                         03 Sep 2025
 
     *) Security: fix missing websocket payload length validation in the Java

--- a/pkg/docker/Dockerfile.go1.24
+++ b/pkg/docker/Dockerfile.go1.24
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.go1.25
+++ b/pkg/docker/Dockerfile.go1.25
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.jsc11
+++ b/pkg/docker/Dockerfile.jsc11
@@ -6,13 +6,13 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
-         ca-certificates git build-essential libssl-dev openssl libpcre2-dev zlib1g-dev libzstd-dev libbrotli-dev curl wget pkg-config pkgconf libclang-dev cmake \
+         ca-certificates git build-essential libssl-dev openssl libpcre2-dev zlib1g-dev libzstd-dev libbrotli-dev curl wget pkgconf libclang-dev cmake \
     && export RUST_VERSION=1.89.0 \
     && export RUSTUP_HOME=/usr/src/unit/rustup \
     && export CARGO_HOME=/usr/src/unit/cargo \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.minimal
+++ b/pkg/docker/Dockerfile.minimal
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.node20
+++ b/pkg/docker/Dockerfile.node20
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.node22
+++ b/pkg/docker/Dockerfile.node22
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.perl5.38
+++ b/pkg/docker/Dockerfile.perl5.38
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.perl5.40
+++ b/pkg/docker/Dockerfile.perl5.40
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.php8.3
+++ b/pkg/docker/Dockerfile.php8.3
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.php8.4
+++ b/pkg/docker/Dockerfile.php8.4
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.php8.5
+++ b/pkg/docker/Dockerfile.php8.5
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.12
+++ b/pkg/docker/Dockerfile.python3.12
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.12-slim
+++ b/pkg/docker/Dockerfile.python3.12-slim
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.13
+++ b/pkg/docker/Dockerfile.python3.13
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.13-slim
+++ b/pkg/docker/Dockerfile.python3.13-slim
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.14
+++ b/pkg/docker/Dockerfile.python3.14
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.14-slim
+++ b/pkg/docker/Dockerfile.python3.14-slim
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.ruby3.3
+++ b/pkg/docker/Dockerfile.ruby3.3
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.ruby3.4
+++ b/pkg/docker/Dockerfile.ruby3.4
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.wasm
+++ b/pkg/docker/Dockerfile.wasm
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.0"
+LABEL org.opencontainers.image.version="1.35.2"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.0 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/version
+++ b/version
@@ -1,5 +1,5 @@
 
 # Copyright (C) FreeUnit Community
 
-NXT_VERSION=1.35.0
-NXT_VERNUM=13500
+NXT_VERSION=1.35.2
+NXT_VERNUM=13502


### PR DESCRIPTION
docs: add CHANGES entries for FreeUnit 1.35.1 and 1.35.2
  Document the two FreeUnit releases since the nginx/unit 1.35.0 base:

  1.35.1 — initial community fork: PHP 8.5/8.4 Docker images on trixie,
  Python 3.14, pre_request_init SAPI support, OpenSSL 3.6 CI.

  1.35.2 — PHP TrueAsync graceful shutdown fix, NXT_PHP_PRE_REQUEST_INIT
  guard, clang-ast CI fixes for Ruby on debian:testing.

fix(docker): remove conflicting pkg-config from Dockerfile.jsc11

  On Ubuntu 22.04 (jammy), pkgconf replaces pkg-config and the two
  packages cannot be installed simultaneously. jsc11 uses
  eclipse-temurin:11-jdk-jammy as its base image, so installing both
  fails. Remove pkg-config, keep pkgconf (the actual implementation).

  All other Dockerfiles use debian:trixie where this conflict does
  not exist.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses
a GitHub issue, include a link to it.

### Checklist
- [*] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] If applicable, I have added tests
- [*] If applicable, I have updated documentation