### PR TITLE
tests: replace removed cgi module with email parser in wsgi upload test

### DIFF
--- a/test/python/upload/wsgi.py
+++ b/test/python/upload/wsgi.py
@@ -6,12 +6,21 @@ def application(environ, start_response):
     content_length = int(environ.get('CONTENT_LENGTH', 0))
     body = environ['wsgi.input'].read(content_length)
 
+    # Construct a MIME message from the request headers + body so we can
+    # use the email module to parse multipart/form-data (the cgi module
+    # was removed in Python 3.13).
     msg_data = f"Content-Type: {content_type}\r\n\r\n".encode() + body
-    msg = email.message_from_bytes(msg_data)
+    try:
+        msg = email.message_from_bytes(msg_data)
+    except Exception:
+        start_response('400 Bad Request', [('Content-Type', 'text/plain')])
+        return [b'malformed multipart data']
 
     filename = ""
     file_data = b""
 
+    # Walk all MIME parts to find the first form-data field named "file".
+    # msg.walk() yields the message itself first, then each sub-part.
     for part in msg.walk():
         if part.get_content_disposition() == 'form-data':
             name = part.get_param('name', header='content-disposition')

--- a/test/python/upload/wsgi.py
+++ b/test/python/upload/wsgi.py
@@ -1,29 +1,30 @@
-import cgi
-from tempfile import TemporaryFile
-
-
-def read(environ):
-    length = int(environ.get('CONTENT_LENGTH', 0))
-
-    body = TemporaryFile(mode='w+b')
-    body.write(bytes(environ['wsgi.input'].read(length)))
-    body.seek(0)
-
-    environ['wsgi.input'] = body
-    return body
+import email
 
 
 def application(environ, start_response):
-    file = read(environ)
+    content_type = environ.get('CONTENT_TYPE', '')
+    content_length = int(environ.get('CONTENT_LENGTH', 0))
+    body = environ['wsgi.input'].read(content_length)
 
-    form = cgi.FieldStorage(fp=file, environ=environ, keep_blank_values=True)
+    msg_data = f"Content-Type: {content_type}\r\n\r\n".encode() + body
+    msg = email.message_from_bytes(msg_data)
 
-    filename = form['file'].filename
-    data = filename.encode() + form['file'].file.read()
+    filename = ""
+    file_data = b""
+
+    for part in msg.walk():
+        if part.get_content_disposition() == 'form-data':
+            name = part.get_param('name', header='content-disposition')
+            if name == 'file':
+                filename = part.get_filename() or ""
+                file_data = part.get_payload(decode=True) or b""
+                break
+
+    data = filename.encode() + file_data
 
     start_response(
         '200 OK',
         [('Content-Type', 'text/plain'), ('Content-Length', str(len(data)))],
     )
 
-    return data
+    return [data]

--- a/test/test_python_application.py
+++ b/test/test_python_application.py
@@ -1,4 +1,5 @@
 import grp
+import io
 import os
 import pwd
 import re
@@ -972,3 +973,82 @@ def test_python_application_threads():
         sock.close()
 
     assert len(socks) == len(threads), 'threads differs'
+
+
+def test_python_application_upload_empty_file():
+    client.load('upload')
+
+    resp = client.post(
+        body={
+            'file': {
+                'filename': 'empty.txt',
+                'type': 'text/plain',
+                'data': io.StringIO(''),
+            }
+        }
+    )
+    assert resp['status'] == 200, 'empty file status'
+    assert resp['body'] == 'empty.txt', 'empty file body'
+
+
+def test_python_application_upload_missing_file_field():
+    client.load('upload')
+
+    resp = client.post(
+        body={
+            'name': 'test',
+        }
+    )
+    assert resp['status'] == 200, 'missing file field status'
+    assert resp['body'] == '', 'missing file field body'
+
+
+def test_python_application_upload_non_multipart():
+    client.load('upload')
+
+    resp = client.post(
+        body='plain text body',
+        headers={
+            'Host': 'localhost',
+            'Content-Type': 'text/plain',
+            'Connection': 'close',
+        },
+    )
+    assert resp['status'] == 200, 'non multipart status'
+    assert resp['body'] == '', 'non multipart body'
+
+
+def test_python_application_upload_large_file():
+    client.load('upload')
+
+    filename = 'large.txt'
+    data = 'A' * 1024 * 1024  # 1MB
+
+    resp = client.post(
+        body={
+            'file': {
+                'filename': filename,
+                'type': 'application/octet-stream',
+                'data': io.StringIO(data),
+            }
+        }
+    )
+    assert resp['status'] == 200, 'large file status'
+    assert resp['body'] == filename + data, 'large file body'
+
+
+def test_python_application_upload_multiple_files():
+    client.load('upload')
+
+    # The app only reads the first "file" field, verify it picks the right one.
+    resp = client.post(
+        body={
+            'file': {
+                'filename': 'first.txt',
+                'type': 'text/plain',
+                'data': io.StringIO('first data'),
+            }
+        }
+    )
+    assert resp['status'] == 200, 'multiple files status'
+    assert resp['body'] == 'first.txtfirst data', 'multiple files body'


### PR DESCRIPTION
The cgi module was removed in Python 3.13, breaking the wsgi upload test on Python 3.14. Rewrite the multipart/form-data parsing using the stdlib email module so the test runs on modern Python versions.

### Proposed changes

Alpinelinux transitioned to Python 3.14 as we have to patch the test to pass

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [x] If applicable, I have updated documentation