### PR TITLE
fix(http): handle FIN via generic close path

### DIFF
--- a/src/nxt_conn_read.c
+++ b/src/nxt_conn_read.c
@@ -90,6 +90,16 @@ nxt_conn_io_read(nxt_task_t *task, void *obj, void *data)
             return;
         }
 
+        if (n == 0) {
+            /*
+             * Normalize EOF semantics at the generic layer: some protocol-
+             * specific io_read_handler implementations may return 0 without
+             * touching socket flags.
+             */
+            c->socket.closed = 1;
+            c->socket.read_ready = 0;
+        }
+
         if (n != NXT_AGAIN) {
             /* n == 0 or n == NXT_ERROR. */
             handler = (n == 0) ? state->close_handler : state->error_handler;

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -303,6 +303,13 @@ nxt_http_idle_io_read_handler(nxt_task_t *task, nxt_conn_t *c)
         c->read = b;
 
     } else {
+        /*
+         * n == 0 (peer FIN) and NXT_ERROR are handled by the generic
+         * connection layer in nxt_conn_io_read():
+         * - n == 0 -> state->close_handler (nxt_h1p_conn_close in keepalive)
+         * - NXT_ERROR -> state->error_handler
+         * Keep protocol-specific read handler side effects minimal here.
+         */
         c->read = NULL;
         nxt_event_engine_buf_mem_free(task->thread->engine, b);
     }
@@ -437,23 +444,13 @@ nxt_h1p_idle_io_read_handler(nxt_task_t *task, nxt_conn_t *c)
     if (n > 0) {
         c->read = b;
 
-    } else if (n == 0) {
-        /*
-         * Client sent FIN while in keep-alive.  Schedule immediate close
-         * instead of waiting for idle_timeout to avoid CLOSE-WAIT
-         * accumulation under port scanning load (issue #28).
-         * Use close_work_queue to avoid reentrancy issues during TLS
-         * reconfiguration when c->socket.data may be inconsistent.
-         */
-        nxt_debug(task, "h1p idle: client closed connection");
-
-        c->read = NULL;
-        nxt_event_engine_buf_mem_free(task->thread->engine, b);
-        nxt_work_queue_add(&task->thread->engine->close_work_queue,
-                           nxt_h1p_conn_closing, task, c, NULL);
-        return 0;
-
     } else {
+        /*
+         * n == 0 (peer FIN) and NXT_ERROR are handled by the generic
+         * connection layer in nxt_conn_io_read():
+         * - n == 0 -> state->close_handler (nxt_h1p_conn_close in keepalive)
+         * - NXT_ERROR -> state->error_handler
+         */
         c->read = NULL;
         nxt_event_engine_buf_mem_free(task->thread->engine, b);
     }


### PR DESCRIPTION
  Use the generic connection layer for keepalive EOF handling instead of
  protocol-local close scheduling.

  - remove special n==0 close branch from nxt_h1p_idle_io_read_handler()
  - normalize EOF in nxt_conn_io_read(): set socket.closed=1 and socket.read_ready=0 before dispatching close_handler
  - keep close/error routing centralized through state->close_handler / state->error_handler

  This avoids duplicate close paths and prevents stale keepalive sockets
  under FIN-heavy bot traffic.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses
a GitHub issue, include a link to it.

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [x] If applicable, I have updated documentation