### PR TITLE
feat(docker): add Go 1.26 and Node.js 24 variants; bump version to 1.…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,21 @@ jobs:
           - build: unit
             os: ubuntu-latest
           # Modules
-          - build: go-1.21
+          - build: go-1.24
             os: ubuntu-latest
-          - build: go-1.22
+          - build: go-1.25
+            os: ubuntu-latest
+          - build: go-1.26
             os: ubuntu-latest
           - build: java-17
             os: ubuntu-latest
           - build: java-18
             os: ubuntu-latest
-          - build: java-21
+          - build: java-20
             os: ubuntu-latest
-          - build: node-20
+          - build: node-22
             os: ubuntu-latest
-          - build: node-21
+          - build: node-24
             os: ubuntu-latest
           - build: perl
             os: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,15 +11,17 @@
 # EOL status (as of April 2026):
 #   go1.24      EOL ~Feb 2026  -> supported until Feb 2027
 #   go1.25      EOL ~Aug 2026  -> supported until Aug 2027
+#   go1.26      EOL ~Feb 2027  -> supported until Feb 2028
 #   jsc17       EOL Sep 2029 (OpenJDK 17 LTS, Eclipse Temurin) -> supported until Sep 2030
 #   jsc21       EOL Sep 2031 (OpenJDK 21 LTS, Eclipse Temurin) -> supported until Sep 2032
 #   node20      EOL Apr 2026   -> supported until Apr 2027
 #   node22      EOL Apr 2027   -> supported until Apr 2028
-#   perl5.38    EOL ~Jun 2025  -> supported until Jun 2026
-#   perl5.40    EOL ~Jun 2026  -> supported until Jun 2027
-#   php8.3      EOL Nov 2026   -> supported until Nov 2027
-#   php8.4      EOL Nov 2027   -> supported until Nov 2028
-#   php8.5      EOL Nov 2028   -> supported until Nov 2029
+#   node24      EOL Apr 2028   -> supported until Apr 2029
+#   perl5.38    EOL ~Jul 2026  -> supported until Jul 2027
+#   perl5.40    EOL ~Jul 2028  -> supported until Jul 2029
+#   php8.3      EOL Dec 2027   -> supported until Dec 2028
+#   php8.4      EOL Dec 2028   -> supported until Dec 2029
+#   php8.5      EOL Dec 2029   -> supported until Dec 2030
 #   python3.12  EOL Oct 2028   -> supported until Oct 2029
 #   python3.13  EOL Oct 2029   -> supported until Oct 2030
 #   python3.14  EOL Oct 2030   -> supported until Oct 2031
@@ -68,7 +70,8 @@ jobs:
             dockerfile: pkg/docker/Dockerfile.go1.24
           - variant: go1.25
             dockerfile: pkg/docker/Dockerfile.go1.25
-
+          - variant: go1.26
+            dockerfile: pkg/docker/Dockerfile.go1.26
           # -- JSC (Java Servlet Container / OpenJDK) --------------------------------
           #   Java support for .war/.jsp applications via Eclipse Temurin (OpenJDK)
           #   Base image: eclipse-temurin:17-jdk-noble (Ubuntu 24.04, GPL v2)
@@ -84,6 +87,8 @@ jobs:
             dockerfile: pkg/docker/Dockerfile.node20
           - variant: node22
             dockerfile: pkg/docker/Dockerfile.node22
+          - variant: node24
+            dockerfile: pkg/docker/Dockerfile.node24
 
           # -- Perl ----------------------------------------------------------
           - variant: perl5.38
@@ -188,6 +193,8 @@ jobs:
             dockerfile: pkg/docker/Dockerfile.go1.24
           - variant: go1.25
             dockerfile: pkg/docker/Dockerfile.go1.25
+          - variant: go1.26
+            dockerfile: pkg/docker/Dockerfile.go1.26
 
           # -- JSC (Java / GraalVM) ------------------------------------------
           - variant: jsc17
@@ -200,6 +207,8 @@ jobs:
             dockerfile: pkg/docker/Dockerfile.node20
           - variant: node22
             dockerfile: pkg/docker/Dockerfile.node22
+          - variant: node24
+            dockerfile: pkg/docker/Dockerfile.node24
 
           # -- Perl ----------------------------------------------------------
           - variant: perl5.38
@@ -296,11 +305,13 @@ jobs:
           - variant: wasm
           - variant: go1.24
           - variant: go1.25
+          - variant: go1.26
           # -- JSC (Java / GraalVM) ------------------------------------------
           - variant: jsc17
           - variant: jsc21
           - variant: node20
           - variant: node22
+          - variant: node24
           - variant: perl5.38
           - variant: perl5.40
           - variant: php8.3

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ and are available for `linux/amd64` and `linux/arm64`.
 | PHP 8.5 | `ghcr.io/freeunitorg/freeunit:latest-php8.5` |
 | PHP 8.4 | `ghcr.io/freeunitorg/freeunit:latest-php8.4` |
 | PHP 8.3 | `ghcr.io/freeunitorg/freeunit:latest-php8.3` |
+| Python 3.14 | `ghcr.io/freeunitorg/freeunit:latest-python3.14` |
 | Python 3.13 | `ghcr.io/freeunitorg/freeunit:latest-python3.13` |
 | Python 3.12 | `ghcr.io/freeunitorg/freeunit:latest-python3.12` |
+| Node.js 24 | `ghcr.io/freeunitorg/freeunit:latest-node24` |
 | Node.js 22 | `ghcr.io/freeunitorg/freeunit:latest-node22` |
+| Node.js 20 | `ghcr.io/freeunitorg/freeunit:latest-node20` |
+| Go 1.26 | `ghcr.io/freeunitorg/freeunit:latest-go1.26` |
 | Go 1.25 | `ghcr.io/freeunitorg/freeunit:latest-go1.25` |
 | Ruby 3.4 | `ghcr.io/freeunitorg/freeunit:latest-ruby3.4` |
 | WebAssembly | `ghcr.io/freeunitorg/freeunit:latest-wasm` |

--- a/pkg/docker/Dockerfile.go1.24
+++ b/pkg/docker/Dockerfile.go1.24
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.go1.25
+++ b/pkg/docker/Dockerfile.go1.25
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.go1.26
+++ b/pkg/docker/Dockerfile.go1.26
@@ -1,6 +1,6 @@
-FROM php:8.4-cli-trixie
+FROM golang:1.26-trixie
 
-LABEL org.opencontainers.image.title="FreeUnit (php8.4)"
+LABEL org.opencontainers.image.title="FreeUnit (go1.26)"
 LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
 LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
@@ -71,12 +71,12 @@ RUN set -ex \
     && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && ./configure php \
-    && make -j $NCPU php-install \
+    && ./configure go --go-path=$GOPATH \
+    && make -j $NCPU go-install-src libunit-install \
     && make clean \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
-    && ./configure php \
-    && make -j $NCPU php-install \
+    && ./configure go --go-path=$GOPATH \
+    && make -j $NCPU go-install-src libunit-install \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
@@ -84,7 +84,7 @@ RUN set -ex \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
-    && ldconfig \
+    && /bin/true \
     && mkdir -p /var/lib/unit/ \
     && mkdir -p /docker-entrypoint.d/ \
     && groupadd --gid 999 unit \

--- a/pkg/docker/Dockerfile.jsc17
+++ b/pkg/docker/Dockerfile.jsc17
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.jsc21
+++ b/pkg/docker/Dockerfile.jsc21
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.minimal
+++ b/pkg/docker/Dockerfile.minimal
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.node20
+++ b/pkg/docker/Dockerfile.node20
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.node22
+++ b/pkg/docker/Dockerfile.node22
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.node24
+++ b/pkg/docker/Dockerfile.node24
@@ -1,6 +1,6 @@
-FROM php:8.4-cli-trixie
+FROM node:24-trixie
 
-LABEL org.opencontainers.image.title="FreeUnit (php8.4)"
+LABEL org.opencontainers.image.title="FreeUnit (node24)"
 LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
 LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
@@ -69,14 +69,14 @@ RUN set -ex \
     && make -j $NCPU unitd \
     && install -pm755 build/sbin/unitd /usr/sbin/unitd \
     && make clean \
-    && /bin/true \
+    && npm -g install node-gyp \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && ./configure php \
-    && make -j $NCPU php-install \
+    && ./configure nodejs --node-gyp=/usr/local/bin/node-gyp \
+    && make -j $NCPU node node-install libunit-install \
     && make clean \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
-    && ./configure php \
-    && make -j $NCPU php-install \
+    && ./configure nodejs --node-gyp=/usr/local/bin/node-gyp \
+    && make -j $NCPU node node-install libunit-install \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
@@ -84,7 +84,7 @@ RUN set -ex \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
-    && ldconfig \
+    && rm -rf /root/.cache/ && rm -rf /root/.npm \
     && mkdir -p /var/lib/unit/ \
     && mkdir -p /docker-entrypoint.d/ \
     && groupadd --gid 999 unit \

--- a/pkg/docker/Dockerfile.perl5.38
+++ b/pkg/docker/Dockerfile.perl5.38
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.perl5.40
+++ b/pkg/docker/Dockerfile.perl5.40
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.php8.3
+++ b/pkg/docker/Dockerfile.php8.3
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.php8.5
+++ b/pkg/docker/Dockerfile.php8.5
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.12
+++ b/pkg/docker/Dockerfile.python3.12
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.12-slim
+++ b/pkg/docker/Dockerfile.python3.12-slim
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.13
+++ b/pkg/docker/Dockerfile.python3.13
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.13-slim
+++ b/pkg/docker/Dockerfile.python3.13-slim
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.14
+++ b/pkg/docker/Dockerfile.python3.14
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.python3.14-slim
+++ b/pkg/docker/Dockerfile.python3.14-slim
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.ruby3.3
+++ b/pkg/docker/Dockerfile.ruby3.3
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.ruby3.4
+++ b/pkg/docker/Dockerfile.ruby3.4
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Dockerfile.wasm
+++ b/pkg/docker/Dockerfile.wasm
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.url="https://freeunit.org"
 LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
 LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
 LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
-LABEL org.opencontainers.image.version="1.35.2"
+LABEL org.opencontainers.image.version="1.35.3"
 
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -35,7 +35,7 @@ RUN set -ex \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && git clone --depth 1 -b 1.35.2 https://github.com/freeunitorg/freeunit unit \
+    && git clone --depth 1 -b 1.35.3 https://github.com/freeunitorg/freeunit unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -20,7 +20,7 @@ INSTALL_minimal ?=	version
 RUN_minimal ?=		/bin/true
 MODULE_PREBUILD_minimal ?= /bin/true
 
-VERSIONS_go ?=		1.24 1.25
+VERSIONS_go ?=		1.24 1.25 1.26
 VARIANT_go ?=		$(VARIANT)
 $(foreach goversion, $(VERSIONS_go), $(eval CONTAINER_go$(goversion) = golang:$(goversion)-$(VARIANT_go)))
 CONFIGURE_go ?=		go --go-path=$$GOPATH
@@ -36,7 +36,7 @@ INSTALL_jsc ?=		java-shared-install java-install
 RUN_jsc ?=	 		rm -rf /root/.m2
 MODULE_PREBUILD_jsc ?= /bin/true
 
-VERSIONS_node ?=	20 22
+VERSIONS_node ?=	20 22 24
 VARIANT_node ?=		$(VARIANT)
 $(foreach nodeversion, $(VERSIONS_node), $(eval CONTAINER_node$(nodeversion) = node:$(nodeversion)-$(VARIANT_node)))
 CONFIGURE_node ?=	nodejs --node-gyp=/usr/local/bin/node-gyp
@@ -162,5 +162,6 @@ all: $(addprefix Dockerfile., $(MODVERSIONS))
 clean:
 	rm -f Dockerfile.*
 	rm -f build-*
+	rm -rf build-logs
 
 .PHONY: default build dockerfiles clean library

--- a/pkg/docker/build-local.sh
+++ b/pkg/docker/build-local.sh
@@ -43,10 +43,12 @@ ALL_VARIANTS=(
     wasm
     go1.24
     go1.25
+    go1.26
     jsc17
     jsc21
     node20
     node22
+    node24
     perl5.38
     perl5.40
     php8.3

--- a/version
+++ b/version
@@ -1,5 +1,5 @@
 
 # Copyright (C) FreeUnit Community
 
-NXT_VERSION=1.35.2
-NXT_VERNUM=13502
+NXT_VERSION=1.35.3
+NXT_VERNUM=13503


### PR DESCRIPTION
feat(docker): add Go 1.26 and Node.js 24 variants; 
- bump version to 1.35.3
- Add Dockerfile.go1.26 and Dockerfile.node24 from template
 - Update docker.yml CI matrix (amd64, arm64, merge) with go1.26 and node24
 - Update EOL dates in docker.yml per endoflife.date (PHP Dec EOL, Perl Jul EOL)
- Add go1.26 and node24 to build-local.sh ALL_VARIANTS
- Update README.md Docker image table with new variants
- Fix pkg/docker/Makefile clean target (rm -rf build-logs)
- Bump version 1.35.2 → 1.35.3

### Proposed changes
Describe the use case and detail of the change. If this PR addresses
a GitHub issue, include a link to it.

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] If applicable, I have added tests
- [x] If applicable, I have updated documentation