### PR TITLE
fix(tls): stop SSL_write busy-loop on peer-initiated close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,16 +126,16 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /opt/openssl-3.6
-          key: openssl-3.6.0-${{ runner.os }}-${{ runner.arch }}
+          key: openssl-3.6.2-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build OpenSSL 3.6
         if: steps.cache-openssl36.outputs.cache-hit != 'true'
         run: |
           sudo apt-get -y install build-essential
           cd /tmp
-          wget -q https://www.openssl.org/source/openssl-3.6.0.tar.gz
-          tar -xzf openssl-3.6.0.tar.gz
-          cd openssl-3.6.0
+          wget -q https://www.openssl.org/source/openssl-3.6.2.tar.gz
+          tar -xzf openssl-3.6.2.tar.gz
+          cd openssl-3.6.2
           ./Configure --prefix=/opt/openssl-3.6 shared no-docs
           make -j$(nproc)
           sudo mkdir -p /opt/openssl-3.6

--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1594,7 +1594,7 @@ nxt_openssl_conn_test_error(nxt_task_t *task, nxt_conn_t *c, int ret,
 
         if (io == NXT_OPENSSL_WRITE) {
             /* Cannot write to a closed connection. */
-            c->socket.error = (sys_err != 0) ? sys_err : NXT_ECONNRESET;
+            c->socket.error = sys_err ? sys_err : NXT_ECONNRESET;
             return NXT_ERROR;
         }
 

--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1592,11 +1592,28 @@ nxt_openssl_conn_test_error(nxt_task_t *task, nxt_conn_t *c, int ret,
             return NXT_ERROR;
         }
 
+        if (io == NXT_OPENSSL_WRITE) {
+            /* Cannot write to a closed connection. */
+            c->socket.error = (sys_err != 0) ? sys_err : NXT_ECONNRESET;
+            return NXT_ERROR;
+        }
+
         /* A connection was just closed. */
         c->socket.closed = 1;
         return 0;
 
     case SSL_ERROR_ZERO_RETURN:
+        /*
+         * SSL_write() may return SSL_ERROR_ZERO_RETURN when the peer has
+         * sent a TLS close_notify.  Writing to a half-closed session is
+         * not possible; treat it as a fatal write error so the connection
+         * is closed rather than spinning the write loop.
+         */
+        if (io == NXT_OPENSSL_WRITE) {
+            c->socket.error = NXT_ECONNRESET;
+            return NXT_ERROR;
+        }
+
         /* A "close notify" alert. */
         return 0;
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,6 +471,7 @@ def _check_processes():
     router_pid = _fds_info['router']['pid']
     controller_pid = _fds_info['controller']['pid']
     main_pid = unit_instance['pid']
+    main_pid_re = re.compile(r'\b' + re.escape(main_pid) + r'\b')
 
     for _ in range(600):
         out = (
@@ -480,7 +481,7 @@ def _check_processes():
             .decode()
             .splitlines()
         )
-        out = [l for l in out if re.search(r'\b' + main_pid + r'\b', l)]
+        out = [l for l in out if main_pid_re.search(l)]
 
         if len(out) <= 3:
             break

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -480,7 +480,7 @@ def _check_processes():
             .decode()
             .splitlines()
         )
-        out = [l for l in out if main_pid in l]
+        out = [l for l in out if re.search(r'\b' + main_pid + r'\b', l)]
 
         if len(out) <= 3:
             break

--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -559,6 +559,58 @@ def test_tls_no_close_notify():
     sock.close()
 
 
+def test_tls_write_abrupt_close():
+    """Regression: SSL_write busy-loop when client closes mid-response.
+
+    If the router spins, the final get_ssl() will time out and fail.
+    Covers both SSL_ERROR_SYSCALL(errno=0) and SSL_ERROR_ZERO_RETURN on
+    the write path (issue #28).
+    """
+    client.load('body_generate')
+
+    client.certificate()
+
+    add_tls(application='body_generate')
+
+    # SSL_write fails with errno=0 → nxt_socket_error_level(0) → NXT_LOG_ALERT.
+    # These alerts are expected; suppress them so teardown does not fail.
+    option.skip_alerts += [r'SSL_write.+failed']
+
+    # 1 MB exceeds kernel socket send buffers so server keeps writing
+    # while we close.
+    body_size = 1024 * 1024
+
+    headers = {
+        'Host': 'localhost',
+        'Connection': 'close',
+        'X-Length': str(body_size),
+    }
+
+    # Case 1: abrupt TCP close without TLS close_notify.
+    # Triggers SSL_ERROR_SYSCALL(errno=0 or ECONNRESET) on server write.
+    sock = client.get_ssl(headers=headers, no_recv=True)
+    sock.recv(256)
+    sock.close()
+
+    time.sleep(0.2)
+
+    # Case 2: TLS close_notify while server is still writing.
+    # Triggers SSL_ERROR_ZERO_RETURN on server write.
+    sock = client.get_ssl(headers=headers, no_recv=True)
+    sock.recv(256)
+    try:
+        plain = sock.unwrap()
+        plain.close()
+    except OSError:
+        sock.close()
+
+    time.sleep(0.2)
+
+    # Router must still be responsive — not stuck in a busy-loop.
+    assert client.get_ssl(read_timeout=5).get('status') == 200, \
+        'router hung after aborted TLS write (issue #28)'
+
+
 @pytest.mark.skip('not yet')
 def test_tls_keepalive_certificate_remove():
     client.load('empty')

--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -574,11 +574,18 @@ def test_tls_write_abrupt_close():
 
     # SSL_write fails with errno=0 → nxt_socket_error_level(0) → NXT_LOG_ALERT.
     # These alerts are expected; suppress them so teardown does not fail.
-    option.skip_alerts += [r'SSL_write.+failed']
+    # Match only the syscall/zero-return signatures this test provokes,
+    # so unrelated SSL_write regressions are not silently masked.
+    option.skip_alerts += [
+        r'SSL_write\([^)]+\) failed \(0: Success\)',
+        r'SSL_write\([^)]+\) failed \(\d+: Connection reset by peer\)',
+        r'SSL_write\([^)]+\) failed \(\d+: Broken pipe\)',
+    ]
 
-    # 1 MB exceeds kernel socket send buffers so server keeps writing
-    # while we close.
-    body_size = 1024 * 1024
+    # Body must exceed the kernel send buffer so the server is still
+    # writing when the client tears the connection down.  16 MB beats
+    # autotuned SO_SNDBUF on common Linux configurations.
+    body_size = 16 * 1024 * 1024
 
     headers = {
         'Host': 'localhost',


### PR DESCRIPTION
### Proposed changes
fix(tls): stop SSL_write busy-loop on peer-initiated close

SSL_ERROR_SYSCALL(errno=0) and SSL_ERROR_ZERO_RETURN both indicate the peer
closed the connection. On the read path this is a clean EOF; on the write path
it means no further data can be sent and the loop must terminate.

Before this fix the write path fell through to the read-side handler, setting
socket.closed=1 and returning success, causing the router to retry SSL_write
indefinitely until the event engine timed out.

- SSL_ERROR_SYSCALL + WRITE: use sys_err if non-zero, else ECONNRESET
- SSL_ERROR_ZERO_RETURN + WRITE: always ECONNRESET

Also bumps OpenSSL in CI from 3.6.0 to 3.6.2.

Closes #28

test: fix process filter for single-digit PIDs in containers

Substring match `main_pid in l` false-positives when unit gets a low PID
(e.g. 9) in Docker: "9" matches "2189" in zombie entries. Word-boundary regex
\b<pid>\b fixes the check

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [ ] If applicable, I have updated documentation