### PR TITLE
review: tighten SSL_write skip_alerts, harden write-abort test

### DIFF
--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1594,7 +1594,7 @@ nxt_openssl_conn_test_error(nxt_task_t *task, nxt_conn_t *c, int ret,
 
         if (io == NXT_OPENSSL_WRITE) {
             /* Cannot write to a closed connection. */
-            c->socket.error = (sys_err != 0) ? sys_err : NXT_ECONNRESET;
+            c->socket.error = sys_err ? sys_err : NXT_ECONNRESET;
             return NXT_ERROR;
         }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,6 +471,7 @@ def _check_processes():
     router_pid = _fds_info['router']['pid']
     controller_pid = _fds_info['controller']['pid']
     main_pid = unit_instance['pid']
+    main_pid_re = re.compile(r'\b' + re.escape(main_pid) + r'\b')
 
     for _ in range(600):
         out = (
@@ -480,7 +481,7 @@ def _check_processes():
             .decode()
             .splitlines()
         )
-        out = [l for l in out if re.search(r'\b' + main_pid + r'\b', l)]
+        out = [l for l in out if main_pid_re.search(l)]
 
         if len(out) <= 3:
             break

--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -574,11 +574,18 @@ def test_tls_write_abrupt_close():
 
     # SSL_write fails with errno=0 → nxt_socket_error_level(0) → NXT_LOG_ALERT.
     # These alerts are expected; suppress them so teardown does not fail.
-    option.skip_alerts += [r'SSL_write.+failed']
+    # Match only the syscall/zero-return signatures this test provokes,
+    # so unrelated SSL_write regressions are not silently masked.
+    option.skip_alerts += [
+        r'SSL_write\([^)]+\) failed \(0: Success\)',
+        r'SSL_write\([^)]+\) failed \(\d+: Connection reset by peer\)',
+        r'SSL_write\([^)]+\) failed \(\d+: Broken pipe\)',
+    ]
 
-    # 1 MB exceeds kernel socket send buffers so server keeps writing
-    # while we close.
-    body_size = 1024 * 1024
+    # Body must exceed the kernel send buffer so the server is still
+    # writing when the client tears the connection down.  16 MB beats
+    # autotuned SO_SNDBUF on common Linux configurations.
+    body_size = 16 * 1024 * 1024
 
     headers = {
         'Host': 'localhost',


### PR DESCRIPTION
Address review feedback on the issue #28 fix:

* test_tls.py: replace the broad `SSL_write.+failed` skip with the specific syscall/zero-return signatures this test produces, so unrelated SSL_write regressions are not silently masked.
* test_tls.py: bump the response body from 1 MB to 16 MB so the server is reliably mid-write when the client tears the connection down on hosts with large autotuned SO_SNDBUF.
* conftest.py: pre-compile the main-PID match and use re.escape() for safety; minor cleanup of the per-line search.
* nxt_openssl.c: drop the redundant `!= 0` in the ternary to match surrounding style.

No functional change to the TLS fix itself.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses
a GitHub issue, include a link to it.

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [ ] If applicable, I have updated documentation