### PR TITLE
Docker: add builder mode, parallel default, reference build stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ __pycache__/
 /.claude/
 /pkg/docker/build-logs/
 /QWEN.md
-/.qwen/settings.json
-/.qwen/settings.json.orig
+/.qwen/
+/qwen/
 /njs/
 /pkg/contrib/njs/
 /pkg/contrib/.sum-*
@@ -17,11 +17,5 @@ __pycache__/
 /pkg/contrib/local/
 /FIX.md
 /CLAUDE.original.md
-/.qwen/skills/clang-ast/SKILL.md
-/.qwen/.qwen/settings.json
-/.qwen/.qwen/settings.json.orig
-/.qwen/.qwen/skills/clang-ast/SKILL.md
 test/fake_upstream/target/
 /pkg/eol/build.log
-/qwen/.qwen/settings.json
-/qwen/.qwen/skills/clang-ast/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ __pycache__/
 /.qwen/.qwen/skills/clang-ast/SKILL.md
 test/fake_upstream/target/
 /pkg/eol/build.log
+/qwen/.qwen/settings.json
+/qwen/.qwen/skills/clang-ast/SKILL.md

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,140 @@
 
 ---
 
+## Release 1.35.6 — Rust developer experience
+
+**Goal:** attract Rust developers — the fastest-growing language community with no
+dedicated app server since Unit was archived. FreeUnit becomes the first app server
+with a native Rust workflow.
+
+### Background & analysis (2026-05-26)
+
+- `rust:1-slim-trixie` confirmed on Docker Hub — ships Rust 1.95.0, `RUSTUP_HOME` /
+  `CARGO_HOME` already set, same layout as our `freeunit-builder:trixie-rust1.94.1`.
+  Image pulled and verified locally.
+- All 21 trixie-based Dockerfiles already download Rust at build time (for wasmtime /
+  wasm-wasi-component) and then discard it. The rust variant just keeps it in the final
+  image — same pattern as `go1.x` variants.
+- `libunit-go` is 676 lines of Go + 127 lines of C glue over `nxt_unit.c` (6800 lines).
+  Path A for `libunit-rust` (bindgen) is estimated at ~500–1000 lines of Rust — a
+  reasonable scope for a single contributor.
+- Path B (pure Rust protocol reimplementation) rejected: too risky, too large, no benefit
+  until `libunit-rust` has proven adoption.
+- No existing Rust SDK for Unit found on GitHub (searched `unit-rs`, `libunit-rust`,
+  `nginx-unit-rust`). First-mover advantage available.
+- axum: 26k ⭐, actix-web: 24k ⭐ — Rust web ecosystem is mature and large.
+- ngx-rust (https://github.com/nginx/ngx-rust) reviewed as reference. Longevity risk:
+  F5-controlled, WIP, 60% commits from one engineer — use as pattern reference only.
+
+### Step 1 — `rust1.x` Docker variant (WASM path, no C changes needed)
+
+Base image `rust:1-slim-trixie` already ships Rust 1.95.0 with `RUSTUP_HOME` /
+`CARGO_HOME` configured (same layout as our builder images). Only additions needed:
+- `rustup target add wasm32-wasip1` inside the Dockerfile
+- Build FreeUnit with wasm + wasm-wasi-component modules (same as `Dockerfile.wasm`)
+- Keep Rust toolchain in the final image — identical pattern to `go1.x` variants
+
+Result: `ghcr.io/freeunitorg/freeunit:latest-rust1.x` — write, compile, and serve
+Rust WASM apps from a single container. No external toolchain, no separate build step.
+
+- [ ] Create `pkg/docker/Dockerfile.rust1.x` based on `rust:1-slim-trixie`
+- [ ] Add `rust1.x` to `docker.yml` CI matrix
+- [ ] Add `rust1.x` to `ALL_VARIANTS` in `build-local.sh`
+- [ ] Add `rust1.x` to variants table in `pkg/docker/README.md`
+- [ ] Test: compile a minimal axum→WASM app and serve via FreeUnit wasm runtime
+
+### Step 2 — `libunit-rust` SDK (native path, Path A: bindgen + FFI)
+
+Mirrors `go/` library. Rust apps import `libunit-rust`, link `libnxt_unit.a`, and
+speak the Unit app-worker protocol directly — no WASM compilation needed.
+
+Architecture (same as Go):
+```
+nxt_unit.c (6800 lines)  ←  C protocol core, already battle-tested
+     ↓  bindgen on nxt_unit.h
+libunit-rust/src/ffi.rs  ←  generated FFI types (~auto)
+libunit-rust/src/lib.rs  ←  safe wrappers (~500-1000 lines)
+libunit-rust/src/axum.rs ←  axum/hyper adapter (drop-in replace for std listener)
+```
+
+Reference files: `go/unit.go`, `go/port.go`, `go/request.go`, `go/response.go`,
+`go/nxt_cgo_lib.h`.
+
+- [ ] Run `bindgen` on `src/nxt_unit.h` → `libunit-rust/src/ffi.rs`
+- [ ] Implement safe wrappers: port management, request/response, handler registry
+- [ ] Add `axum` adapter: `ListenAndServe(handler)` equivalent
+- [ ] Publish to crates.io as `libunit-rust`
+- [ ] Add example app to `tools/` or a separate `examples/rust/` directory
+
+### Why this matters for growth
+
+| | Today | After 1.35.6 |
+|---|---|---|
+| Rust WASM apps | manual setup | `docker pull freeunit:latest-rust1.x` |
+| Rust native apps | not supported | `libunit-rust` on crates.io |
+| Developer story | "compile to wasm32-wasi manually" | one-liner |
+
+Rust is the #1 most admired language (Stack Overflow 2024). No app server currently
+serves Rust developers. FreeUnit can own this space.
+
+---
+
+## OpenTelemetry crate upgrade 0.24 → 0.32 (issue #65)
+
+**Prerequisite:** audit current OTEL JSON config schema against `docs/unit-openapi.yaml`
+before touching any Rust code (see issue #65 comment for rationale).
+
+### Known pitfalls (from code audit)
+
+- `opentelemetry_otlp::new_pipeline()` removed in 0.27 — `nxt_otel_rs_runtime()` must be
+  rewritten from scratch, not patched
+- `BoxedSpan` is passed as a raw pointer across the C FFI boundary (`r->otel->trace`);
+  verify its memory layout did not change between 0.24 and 0.32 before writing new code
+- `opentelemetry_sdk::trace::Config`, `BatchConfigBuilder`, `runtime::Tokio` — all moved
+  or removed; check new API in `opentelemetry_sdk` 0.32 docs
+- `Protocol::HttpJson` arm in the runtime match is unreachable dead code — fix in same PR
+- Service name `"NGINX Unit"` hardcoded in `lib.rs` lines 154 and 274 — rename to `"FreeUnit"`
+- `eprintln!` used for errors in `nxt_otel_rs_runtime()` instead of the `log_callback` —
+  fix while rewriting the function
+
+### Tasks
+
+- [ ] Audit OTEL JSON config schema vs `docs/unit-openapi.yaml`; document supported fields
+- [ ] Check `BoxedSpan` definition in opentelemetry 0.24 vs 0.32 — confirm ABI compatibility
+- [ ] Bump all `opentelemetry*` crates to 0.32.x in `src/otel/Cargo.toml`
+- [ ] Rewrite `nxt_otel_rs_runtime()` for new 0.32 API (TracerProviderBuilder pattern)
+- [ ] Fix `Protocol::HttpJson` dead code; fix `eprintln!` → log_callback
+- [ ] Rename `"NGINX Unit"` → `"FreeUnit"` in `lib.rs`
+- [ ] Update `src/nxt_otel.c` / `nxt_otel.h` if Rust ABI changed
+- [ ] Build with `./configure --otel --openssl && make`; run clang-ast check
+- [ ] Build `test/fake_otlp/` (std-only Rust binary, mirrors `test/fake_upstream/` pattern)
+      and write `test/test_otel.py` — no real collector needed, tests run self-contained in CI
+
+### test/fake_otlp design
+
+Mirrors `test/fake_upstream/` exactly — single Rust binary, no external deps, installed to
+`/usr/local/bin/fake_otlp` in CI (same step as `fake_upstream`).
+
+```
+fake_otlp --port 19878 --requests 1
+```
+
+- Accepts `POST /v1/traces`, validates `Content-Type: application/x-protobuf` + non-empty body
+- Responds `200 OK` with empty body (valid `ExportTraceServiceResponse`)
+- Prints `span_received content_length=NNN` to stdout per request
+- Exits after `--requests N`
+- **HTTP only** — gRPC (HTTP/2) not supported; document as "use a real collector for gRPC"
+
+`test/test_otel.py` test cases (all gated on `FAKE_OTLP_BIN` + `--otel` build flag):
+
+| Test | What it checks |
+|------|----------------|
+| `test_otel_span_exported` | span arrives at fake_otlp after one FreeUnit request |
+| `test_otel_traceparent_propagated` | FreeUnit injects `traceparent` header into forwarded request |
+| `test_otel_sampling_zero` | `sample_fraction=0.0` → fake_otlp receives nothing (stays alive) |
+
+---
+
 ## PHP TrueAsync mode (branch: php-graceful-shutdown)
 
 Items below must be resolved before the branch can be merged and before
@@ -188,6 +322,31 @@ inside a chroot/rootfs-isolated Unit application.
 
 ## Test Infrastructure
 
+### Download statistics for packages.freeunit.org
+
+`packages.freeunit.org` serves tarballs (njs, wasmtime, wasi-sysroot, libunit-wasm)
+but there is no download counter — no visibility into which packages are downloaded
+and how often.
+
+Server runs **Angie** (nginx-compatible fork, COMBINED log format).
+
+**Options (ascending complexity):**
+- [ ] **GoAccess** — install on server, parse Angie access log, publish HTML report to
+      `packages.freeunit.org/stats/`
+- [ ] **JSON counter via cron** — hourly `awk` over access.log → `stats.json`, enables
+      badge endpoints or API consumers
+- [ ] **Angie NJS counter** — shared-memory counter incremented per `.tar.gz` request,
+      exposed as `/metrics` endpoint (no log parsing needed, real-time)
+
+**Quick start (GoAccess):**
+```bash
+sudo apt-get install -y goaccess
+goaccess /var/log/angie/packages.freeunit.org.access.log \
+  --log-format=COMBINED -o /var/www/packages.freeunit.org/stats/index.html
+```
+
+---
+
 ### Prebuild `fake_upstream` binary via packages.freeunit.org
 
 `test/fake_upstream/` — Rust HTTP mock used by `test_proxy_chunked.py`.
@@ -217,6 +376,71 @@ Fixed: use `clang llvm-dev libclang-dev` (not `clang-21 llvm-21-dev libclang-21-
 - [ ] Prebuild `freeunit-test-full:local` image and publish to GHCR
 - [ ] Or add packages.freeunit.org binary for clang-ast plugin
 - [ ] Cache Docker layers for apt install + clang-ast build
+
+---
+
+## ngx-rust — study Rust bindings and evaluate Rust runtime for FreeUnit
+
+https://github.com/nginx/ngx-rust — Rust bindings for nginx dynamic modules by F5/NGINX.
+
+**Longevity risk:** project is F5-controlled, WIP, and 60% of commits come from a single
+engineer (`bavshin-f5`). F5 archived nginx/unit in Oct 2025 — same pattern applies here.
+Use as a reference only; do not take a hard dependency.
+
+**ngx-rust ≠ Rust runtime support.** ngx-rust is about writing nginx *modules* in Rust.
+For FreeUnit there are two separate ideas worth separating:
+
+### Idea 1 — Write FreeUnit C-layer extensions in Rust (like ngx-rust does for nginx)
+Study `nginx-sys` FFI layer and `build.rs`/bindgen approach; apply safe/unsafe separation
+patterns to `src/otel/`.
+
+- [ ] Clone ngx-rust, study `nginx-sys` (FFI) and `build.rs` (bindgen)
+- [ ] Apply safe wrapper patterns to `src/otel/`
+
+### Idea 2 — Rust as a language runtime
+
+**Current state:** no native Rust runtime exists.
+- Go has `go/` library (`libunit-go`, 676 lines) — apps import it, it links `libnxt_unit.a`
+  and speaks the Unit app-worker protocol via Unix sockets.
+- Rust apps today: only path is compile to `wasm32-wasi` → run via FreeUnit wasm runtime.
+
+**Path A — bindgen + FFI (recommended, ~2–4 weeks)**
+- Run `bindgen` on `nxt_unit.h` → generate Rust FFI types
+- Write safe wrappers (~500–1000 lines), mirroring `go/unit.go`, `go/port.go`,
+  `go/request.go`, `go/response.go`
+- Add `axum`/`hyper` adapter so users drop in `libunit-rust` like they do `libunit-go`
+- Pro: reuses existing 6800-line `nxt_unit.c`, protocol already battle-tested
+- Con: C linkage required (`libnxt_unit.a`), same as Go
+
+**Path B — pure Rust protocol reimplementation (~2–3 months, high risk)**
+- Reverse-engineer Unix socket framing from `nxt_unit.c` (6800 lines)
+- Pro: no C dependency, fully async-native (tokio)
+- Con: high risk of protocol bugs, large effort
+
+**Recommendation:** Path A first. Path B only if `libunit-rust` gains traction and
+users demand a zero-C dependency.
+
+- [ ] Prototype `libunit-rust` via Path A (reference: `go/*.go`, `src/nxt_unit.h`)
+- [ ] Decide: native `libunit-rust` vs WASM-first (WASM works today, lower barrier)
+
+### Idea 3 — `rust` Docker variant (WASM path, no libunit-rust needed)
+
+All trixie-based Dockerfiles already install Rust at build time (for wasmtime /
+wasm-wasi-component) and then discard it. Go variants keep Go in the final image
+(`FROM golang:1.24-trixie`). Same pattern applies for Rust:
+
+Proposed `Dockerfile.rust1.x`:
+- Base: `FROM rust:1-slim-trixie` (official Rust image, trixie variant)
+- Add `wasm32-wasip1` target: `rustup target add wasm32-wasip1`
+- Build FreeUnit with wasm + wasm-wasi-component modules (same as `Dockerfile.wasm`)
+- Keep Rust toolchain in final image — users compile and serve Rust WASM in one container
+
+Value: "compile and run Rust WASM apps with a single FreeUnit container" — no separate
+build step, no external toolchain. Works today via existing wasm runtime.
+
+- [ ] Check `rust:1-slim-trixie` exists on Docker Hub and is suitable as base
+- [ ] Add `Dockerfile.rust1.x` to `pkg/docker/` and `docker.yml` matrix
+- [ ] Add `rust1.x` to `build-local.sh` ALL_VARIANTS
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,54 @@
 
 ---
 
+## Release roadmap
+
+| Milestone | Due | Focus |
+|-----------|-----|-------|
+| **1.35.5** | current branch | Docker builder mode, parallel builds, Go 1.26, Node 24 |
+| **1.35.6** | 2026-06-25 | OTEL 0.24→0.32 (#65), Rust DX (`rust1.x` variant, `libunit-rust`) |
+| **1.35.7** | 2026-07-31 | Short-cycle release |
+| **1.35.8** | 2026-08-28 | Short-cycle release + Docker Hub Official Images (`make library`) |
+
+### Action plan — work streams & start dates
+
+**Now (June):**
+
+| Task | Milestone |
+|------|-----------|
+| Finish PR #66 (builder mode, parallel builds, README) | 1.35.5 |
+| OTEL Phase 0: config audit, new fields, `fake_otlp`, `test_otel.py` | 1.35.6 |
+| OTEL Phase 2: rewrite `nxt_otel_rs_runtime()` for 0.32 API (after Phase 0) | 1.35.6 |
+| `rust1.x` Docker variant (WASM path, `Dockerfile.rust1.x`) | 1.35.6 |
+
+**July (after 1.35.6):**
+
+| Task | Milestone |
+|------|-----------|
+| `libunit-rust` SDK — bindgen + FFI + axum adapter (prototype) | 1.35.7 |
+| Evaluate `libunit-rust` prototype → decide: WASM-first or native-first | 1.35.7 |
+| `packages.freeunit.org` — GoAccess / JSON stats for download counter | 1.35.7 |
+| `fake_upstream` prebuilt binary on `packages.freeunit.org` | 1.35.7 |
+
+**August 1 — start 1.35.8 work:**
+
+| Task | Milestone |
+|------|-----------|
+| Prepare `docker-library/official-images` PR: uncomment `make library` in Makefile, update `GitFetch`, test metadata generation | 1.35.8 |
+| Docker Hub Official Images: go through review process (docker-library/official-images PR template, CI validation) | 1.35.8 |
+| clang-ast plugin prebuilt binary on `packages.freeunit.org` | 1.35.8 |
+| `libunit-rust` — crates.io publish (if 1.35.7 prototype passes review) | 1.35.8 |
+| OTEL Phase 3: housekeeping (`"NGINX Unit"` → `"FreeUnit"`, `eprintln!` → log_callback) | 1.35.8 |
+
+**Open questions (decide before August):**
+
+- [ ] PHP TrueAsync — determine source of `nxt_php_extension.c` (fork EdmondDantes or write from scratch)
+- [ ] PHP 8.5 `rootfs` SIGSEGV — needs diagnostics on real hardware
+- [ ] OpenSSL 3.6 migration — verify clang-ast compatibility
+- [ ] Proxy request buffering (#58) — define scope (per-action vs global)
+
+---
+
 ## Release 1.35.6 — Rust developer experience
 
 **Goal:** attract Rust developers — the fastest-growing language community with no

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,7 @@
 | OTEL Phase 0: config audit, new fields, `fake_otlp`, `test_otel.py` | 1.35.6 |
 | OTEL Phase 2: rewrite `nxt_otel_rs_runtime()` for 0.32 API (after Phase 0) | 1.35.6 |
 | `rust1.x` Docker variant (WASM path, `Dockerfile.rust1.x`) | 1.35.6 |
+| Docker: make debug build optional (`--debug` flag in `build-local.sh`, off by default; saves ~30-40 MB per image) | 1.35.6 |
 
 **July (after 1.35.6):**
 

--- a/TODO.md
+++ b/TODO.md
@@ -80,10 +80,18 @@ serves Rust developers. FreeUnit can own this space.
 
 ---
 
-## OpenTelemetry crate upgrade 0.24 → 0.32 (issue #65)
+## OpenTelemetry crate upgrade 0.24 → 0.32 (issue #65, milestone 1.35.6)
 
-**Prerequisite:** audit current OTEL JSON config schema against `docs/unit-openapi.yaml`
-before touching any Rust code (see issue #65 comment for rationale).
+| Crate | Current | Latest | Gap |
+|-------|---------|--------|-----|
+| `opentelemetry` | 0.24.0 | 0.32.0 | 8 minor |
+| `opentelemetry-otlp` | 0.17.0 | 0.32.0 | 15 minor |
+| `opentelemetry_sdk` | 0.24.1 | 0.32.0 | 8 minor |
+| `opentelemetry-semantic-conventions` | 0.16.0 | 0.32.0 | 16 minor |
+
+Original implementation by Ava Hahn — co-author of FreeUnit's OTel layer.
+New account: [@ava-affine](https://github.com/ava-affine), `ava@sunnypup.io` (left F5, personal domain `sunnypup.io`).
+The upstream `nginx/nginx-otel` is a separate C++ module, unrelated to our Rust crate.
 
 ### Known pitfalls (from code audit)
 
@@ -98,23 +106,81 @@ before touching any Rust code (see issue #65 comment for rationale).
 - `eprintln!` used for errors in `nxt_otel_rs_runtime()` instead of the `log_callback` —
   fix while rewriting the function
 
-### Tasks
+### Phase 0: Documentation audit + new config fields + test infrastructure (prerequisite)
 
-- [ ] Audit OTEL JSON config schema vs `docs/unit-openapi.yaml`; document supported fields
-- [ ] Check `BoxedSpan` definition in opentelemetry 0.24 vs 0.32 — confirm ABI compatibility
-- [ ] Bump all `opentelemetry*` crates to 0.32.x in `src/otel/Cargo.toml`
-- [ ] Rewrite `nxt_otel_rs_runtime()` for new 0.32 API (TracerProviderBuilder pattern)
-- [ ] Fix `Protocol::HttpJson` dead code; fix `eprintln!` → log_callback
-- [ ] Rename `"NGINX Unit"` → `"FreeUnit"` in `lib.rs`
-- [ ] Update `src/nxt_otel.c` / `nxt_otel.h` if Rust ABI changed
-- [ ] Build with `./configure --otel --openssl && make`; run clang-ast check
-- [ ] Build `test/fake_otlp/` (std-only Rust binary, mirrors `test/fake_upstream/` pattern)
-      and write `test/test_otel.py` — no real collector needed, tests run self-contained in CI
+**Current config (4 fields):**
+```json
+{ "endpoint": "...", "protocol": "http", "batch_size": 128, "sampling_ratio": 1.0 }
+```
 
-### test/fake_otlp design
+**0a — Audit existing config:**
+- [ ] Audit current OTEL JSON config schema against `docs/unit-openapi.yaml`
+- [ ] Document all supported OTEL config fields and their defaults
+- [ ] Check for gaps between OpenAPI spec and actual C/Rust implementation
 
-Mirrors `test/fake_upstream/` exactly — single Rust binary, no external deps, installed to
-`/usr/local/bin/fake_otlp` in CI (same step as `fake_upstream`).
+**0b — New configuration fields (backward-compatible, current crate versions):**
+
+Hardcoded values that must become configurable:
+
+| Value | Current | Where | Proposed field |
+|-------|---------|-------|----------------|
+| Service name | `"NGINX Unit"` | `lib.rs:98,274` | `service_name` |
+| Max queue size | `4096` | `lib.rs:103` | `max_queue_size` |
+| Export timeout | `10s` | `lib.rs:27` | `export_timeout` |
+
+Missing fields needed for production OTEL:
+
+| Field | Type | Default | Why |
+|-------|------|---------|-----|
+| `service_name` | string | `"FreeUnit"` | Replaces hardcoded `"NGINX Unit"`; every service needs its own name |
+| `headers` | object | `{}` | Auth to collector (`Authorization: Bearer ...`, `X-Api-Key`) |
+| `root_certificate` | string | — | Custom CA for TLS collector connection |
+| `resource_attributes` | object | `{}` | `service.version`, `deployment.environment`, custom labels |
+| `max_queue_size` | integer | `4096` | Replaces hardcoded queue depth |
+| `export_timeout` | integer (sec) | `10` | Replaces hardcoded timeout |
+
+Bug fixes in existing fields:
+- [ ] Fix `protocol`: add `enum: ["http", "grpc"]` to OpenAPI; sync required/optional between C validator and OpenAPI
+- [ ] Fix `batch_size`: add upper bound validation (e.g. `<= 65536`)
+- [ ] Fix span attributes to use OTel semconv: `"method"` → `http.request.method`, `"path"` → `url.path`, `"status"` → `http.response.status_code`
+- [ ] Wrap sampler in `ParentBased(TraceIdRatioBased(...))` — respect upstream sampling decisions
+- [ ] Pass `tracestate` through to Rust OTEL SDK (currently parsed in C, echoed, but dropped)
+
+New fields implementation:
+- [ ] Add all new fields to `docs/unit-openapi.yaml` (`configSettingsTelemetry` schema)
+- [ ] Add validators in `src/nxt_conf_validation.c`
+- [ ] Parse new fields in `src/nxt_router.c`
+- [ ] Accept and use new parameters in `src/otel/src/lib.rs`
+
+**Proposed full config after Phase 0:**
+```json
+{
+  "settings": {
+    "telemetry": {
+      "endpoint": "http://collector:4318",
+      "protocol": "http",
+      "service_name": "my-app",
+      "sampling_ratio": 1.0,
+      "batch_size": 128,
+      "max_queue_size": 4096,
+      "export_timeout": 10,
+      "headers": { "Authorization": "Bearer token" },
+      "root_certificate": "/path/to/ca.pem",
+      "resource_attributes": {
+        "service.version": "1.0.0",
+        "deployment.environment": "production"
+      }
+    }
+  }
+}
+```
+
+**0c — Test infrastructure:**
+- [ ] Build `test/fake_otlp/` — std-only Rust mock OTLP collector
+
+**fake_otlp design** — mirrors `test/fake_upstream/` exactly: single Rust binary,
+no external deps, installed to `/usr/local/bin/fake_otlp` in CI (same step as
+`fake_upstream`).
 
 ```
 fake_otlp --port 19878 --requests 1
@@ -126,13 +192,48 @@ fake_otlp --port 19878 --requests 1
 - Exits after `--requests N`
 - **HTTP only** — gRPC (HTTP/2) not supported; document as "use a real collector for gRPC"
 
-`test/test_otel.py` test cases (all gated on `FAKE_OTLP_BIN` + `--otel` build flag):
+- [ ] Write `test/test_otel.py` — gated on `FAKE_OTLP_BIN` + `--otel` build flag:
 
 | Test | What it checks |
 |------|----------------|
 | `test_otel_span_exported` | span arrives at fake_otlp after one FreeUnit request |
 | `test_otel_traceparent_propagated` | FreeUnit injects `traceparent` header into forwarded request |
-| `test_otel_sampling_zero` | `sample_fraction=0.0` → fake_otlp receives nothing (stays alive) |
+| `test_otel_sampling_zero` | `sampling_ratio=0.0` → fake_otlp receives nothing (stays alive) |
+| `test_otel_service_name` | exported span contains configured `service_name` |
+| `test_otel_auth_header` | fake_otlp receives configured `headers` (Authorization) |
+| `test_otel_resource_attributes` | span resource contains custom attributes |
+
+- [ ] Verify all Phase 0 tests pass against the **current** 0.24 crates (establishes baseline)
+
+### Phase 1: Pre-upgrade safety checks
+
+- [ ] Verify `BoxedSpan` layout compatibility between 0.24 and 0.32 — `Arc<BoxedSpan>`
+      crosses C FFI as raw pointer; layout change = UB. If trait bounds changed (e.g. added
+      `Send + Sync`), introduce an intermediate opaque wrapper type
+- [ ] Confirm `Protocol::HttpJson` is dead code — remove unreachable match arm
+
+### Phase 2: Crate upgrade — full rewrite of `nxt_otel_rs_runtime()`
+
+- [ ] Bump all `opentelemetry*` crates to 0.32.x in `src/otel/Cargo.toml`
+- [ ] Rewrite `nxt_otel_rs_runtime()` — `new_pipeline()`, `new_exporter()`, `.tracing()`,
+      `.with_trace_config()`, `.with_batch_config()`, `.install_batch()` all gone in 0.27+.
+      Use `TracerProvider::builder()` + new `OtlpTracePipeline` API
+- [ ] Replace `opentelemetry_sdk::trace::Config` → `TracerProviderBuilder`
+- [ ] Replace `BatchConfigBuilder` → new location/API
+- [ ] Replace `opentelemetry_sdk::runtime::Tokio` → new runtime model
+- [ ] Adapt `src/otel/src/lib.rs` to all remaining API changes
+- [ ] Update `src/nxt_otel.c` / `nxt_otel.h` if Rust ABI changed
+- [ ] Run `test/test_otel.py` against upgraded code — must pass same baseline tests
+
+### Phase 3: Housekeeping fixes (same PR)
+
+- [ ] Rename `"NGINX Unit"` → `"FreeUnit"` in `lib.rs` (lines 154, 274)
+- [ ] Replace `eprintln!` (lib.rs lines 188–189, 204) with `nxt_otel_log_callback`
+
+### Phase 4: Final verification
+
+- [ ] Build with `./configure --otel --openssl && make`; run clang-ast check
+- [ ] Full `test/test_otel.py` pass
 
 ---
 
@@ -376,6 +477,33 @@ Fixed: use `clang llvm-dev libclang-dev` (not `clang-21 llvm-21-dev libclang-21-
 - [ ] Prebuild `freeunit-test-full:local` image and publish to GHCR
 - [ ] Or add packages.freeunit.org binary for clang-ast plugin
 - [ ] Cache Docker layers for apt install + clang-ast build
+
+---
+
+## avahahn/ngx-testing-fmk — evaluate as cross-platform test orchestration reference
+
+https://github.com/avahahn/ngx-testing-fmk — personal shell-based framework by Ava Hahn
+(ex-F5, co-author of FreeUnit OTel layer; new account: [@ava-affine](https://github.com/ava-affine), `ava@sunnypup.io`) for running nginx/nginx-otel tests across multiple
+libvirt VMs in parallel.
+
+**What it does:** boots libvirt VMs, rsyncs source + test dirs, builds and runs tests
+on each VM in parallel, collects logs, shuts VMs down. `common.sh` provides a reusable
+`parallel_invoke_and_wait` bash helper (fan-out with aggregated exit codes).
+
+**Why it is not a direct fit for FreeUnit:**
+- Hardwired to nginx + nginx-tests + nginx-otel — no Unit/FreeUnit hooks
+- Requires a pre-configured libvirt infrastructure with shared credentials (`SECRET.sh`)
+- FreeUnit already has pytest (`test/`) + GitHub Actions CI covering the same ground
+- 0 stars, last commit Jan 2025, no active maintenance
+
+**What is worth studying:**
+- `parallel_invoke_and_wait` pattern in `common.sh` — clean bash fan-out with per-input
+  log files and aggregated failure reporting; could inform a future `test/run-matrix.sh`
+  if we ever need to test across distros locally without Docker
+- Overall VM lifecycle approach (on → sync → build → test → off) as a template if we add
+  libvirt/QEMU-based cross-distro testing outside of GitHub Actions
+
+**Decision:** no code to borrow now. Revisit if we add a local multi-distro test matrix.
 
 ---
 

--- a/pkg/community/CENTOS.ALMALINUX.md
+++ b/pkg/community/CENTOS.ALMALINUX.md
@@ -1,0 +1,316 @@
+# CentOS Stream 9 / AlmaLinux 9 — Build from Source
+
+> Verified on:
+> - CentOS Stream 9 (kernel `5.14.0-706.el9.x86_64`), OpenSSL 3.5.6
+> - AlmaLinux 9.7 (kernel `5.14.0-706.el9.x86_64`), OpenSSL 3.5.1
+>
+> FreeUnit 1.35.5, PHP 8.5.6 from Remi modular, `unit-php` 1.35.0.
+> Last verified: May 2026.
+
+## Prerequisites
+
+```bash
+# brotli-devel is in EPEL, not in base EL9 repos
+dnf install -y epel-release
+
+dnf install -y gcc make git openssl-devel pcre2-devel \
+    zlib-devel libzstd-devel brotli-devel
+# For OTEL support: Rust >= 1.94.1 (rustup.rs)
+```
+
+### PHP version options
+
+| Source | PHP versions | Notes |
+|--------|-------------|-------|
+| EL9 AppStream (native) | 8.1, 8.2, 8.3 | No Remi needed |
+| Remi modular | 7.4 — 8.5 | PHP 8.4/8.5 require Remi |
+
+### Option A: native AppStream PHP (8.1–8.3)
+
+```bash
+# Enable desired PHP stream
+dnf module reset php -y
+dnf module enable php:8.3 -y
+
+dnf install -y php php-cli php-devel php-embedded php-mbstring \
+    php-mysqlnd php-pdo php-xml php-sodium
+
+# Build PHP module from source (no unit-php package in AppStream)
+./configure php
+make -j$(nproc)
+sudo make php-install
+```
+
+### Option B: Remi PHP 8.4/8.5 + `unit-php` package
+
+```bash
+dnf install -y epel-release
+dnf install -y https://rpms.remirepo.net/enterprise/remi-release-9.rpm
+dnf module reset php -y
+dnf module enable php:remi-8.5 -y
+
+# unit-php lives in the non-modular remi repo, which dnf module enable does not
+# activate automatically — enable it explicitly so dnf can resolve unit-php
+dnf config-manager --enable remi
+
+dnf install -y php php-cli php-devel php-embedded php-mbstring \
+    php-mysqlnd php-pdo php-xml php-sodium unit-php
+```
+
+Remi's `unit-php` 1.35.0 is built from the archived `nginx/unit` source
+(ABI-compatible with FreeUnit — the module loads and works correctly).
+
+See [REMI.md](REMI.md) for details.
+
+### Option C: Remi PHP 8.4/8.5 + build from source
+
+```bash
+# EPEL may be needed for some PHP dependencies
+dnf install -y epel-release
+
+dnf install -y https://rpms.remirepo.net/enterprise/remi-release-9.rpm
+dnf module reset php -y
+dnf module enable php:remi-8.5 -y
+
+dnf install -y php php-cli php-devel php-embedded php-mbstring \
+    php-mysqlnd php-pdo php-xml php-sodium
+
+./configure php
+make -j$(nproc)
+sudo make php-install
+```
+
+The resulting `php.unit.so` links against Remi's `libphp-8.5.so` but is
+compiled from FreeUnit source — exact version match.
+
+### Comparison
+
+| | A: AppStream PHP | B: Remi `unit-php` | C: Remi + build |
+|---|---|---|---|
+| PHP version | 8.1–8.3 | 8.4 or 8.5 | 8.4 or 8.5 |
+| External repo | None | Remi | Remi |
+| PHP module | Build from source | `dnf install` | Build from source |
+| FreeUnit version match | Exact | ABI-compatible | Exact |
+| `dnf update` risk | PHP ABI change | None | PHP ABI change |
+
+## Build
+
+```bash
+git clone https://github.com/freeunitorg/freeunit.git
+cd freeunit
+
+git checkout v1.35.5   # or master / latest tag
+
+./configure --prefix=/usr \
+    --libdir=/usr/lib64 \
+    --statedir=/var/lib/unit \
+    --logdir=/var/log/unit \
+    --runstatedir=/run/unit \
+    --control=unix:/run/unit/control.sock \
+    --openssl --otel --zlib --brotli --zstd \
+    --modulesdir=/usr/lib64/unit/modules
+
+make -j$(nproc)
+```
+
+> **Note:** `--otel` requires Rust ≥ 1.94.1 (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+> Remove `--otel` if you don't need OpenTelemetry support.
+>
+> `--user` / `--group` are omitted because the systemd service runs unitd directly.
+> To restrict the runtime user, add `User=unit` and `Group=unit` to the `[Service]`
+> section, and create the user: `useradd -r -s /sbin/nologin unit`.
+
+### Language modules (non-PHP)
+
+PHP module setup varies by option above. For other languages:
+
+```bash
+# Python
+./configure python --config=python3-config
+make -j$(nproc) python3-install
+
+# Go, Node.js, Ruby, Perl, Java, WASM — see ./configure --help
+```
+
+## Install
+
+```bash
+sudo make install
+```
+
+Binaries land at:
+- `/usr/sbin/unitd` — release daemon
+- `/usr/sbin/unitd-debug` — debug daemon (if `--debug` was used)
+- `/usr/lib64/unit/modules/*.unit.so` — language modules
+
+## systemd Service
+
+```bash
+sudo tee /etc/systemd/system/unit.service << 'EOF'
+[Unit]
+Description=FreeUnit Application Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/unitd --no-daemon \
+    --log /var/log/unit/unit.log \
+    --statedir /var/lib/unit \
+    --control unix:/run/unit/control.sock
+ExecReload=/bin/kill -HUP $MAINPID
+RuntimeDirectory=unit
+RuntimeDirectoryMode=0755
+TimeoutStartSec=30s
+LimitNOFILE=65535
+LimitCORE=infinity
+Restart=on-failure
+RestartSec=3s
+CPUQuota=70%
+TasksMax=512
+Nice=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now unit
+```
+
+### Why `Type=simple` + `--no-daemon`
+
+The original NGINX Unit packages used `Type=forking` with `PIDFile=`, which creates a
+race between systemd and unitd writing the PID file. `--no-daemon` keeps the process
+attached to systemd as a direct child process — no PID file, no race, clean lifecycle management.
+
+`RuntimeDirectory=unit` ensures `/run/unit` is created on start and removed on stop.
+
+### Why resource limits
+
+`CPUQuota`, `TasksMax`, and `Nice` are set as a safety net after past incidents where
+runaway worker processes consumed excessive resources. Kept enabled for observability
+until the root causes are confirmed fixed across all workloads.
+
+## Verify
+
+```bash
+systemctl status unit
+
+# Check loaded modules
+curl --unix-socket /run/unit/control.sock http://localhost/config
+
+# Expected output includes "modules" with loaded language modules:
+#   "modules": { "php": { "version": "8.x.y", "lib": "/usr/lib64/unit/modules/php.unit.so" } }
+```
+
+## Basic Application Setup
+
+```bash
+# Create a PHP application
+sudo mkdir -p /var/www/app
+echo '<?php echo "Hello from FreeUnit\n";' | sudo tee /var/www/app/index.php
+
+# Configure via REST API
+curl -X PUT --unix-socket /run/unit/control.sock http://localhost/config/applications/hello << 'EOF'
+{
+    "type": "php",
+    "root": "/var/www/app",
+    "index": "index.php"
+}
+EOF
+
+curl -X PUT --unix-socket /run/unit/control.sock http://localhost/config/listeners/'*:8080' << 'EOF'
+{
+    "pass": "applications/hello"
+}
+EOF
+
+# Test
+curl http://localhost:8080/
+```
+
+## Logs
+
+```bash
+tail -f /var/log/unit/unit.log
+```
+
+### Access log
+
+Unit supports per-config access logs via the `access_log` directive:
+
+```bash
+# Add access log to config
+curl -X PUT --unix-socket /run/unit/control.sock \
+    http://localhost/config/access_log << 'EOF'
+{
+    "path": "/var/log/unit/access.log",
+    "format": "$remote_addr - - [$time_local] \"$request_line\" $status $body_bytes_sent \"$header_referer\" \"$header_user_agent\""
+}
+EOF
+```
+
+```bash
+tail -f /var/log/unit/access.log
+```
+
+## Paths Summary
+
+| Item | Path |
+|------|------|
+| Daemon | `/usr/sbin/unitd` |
+| Control socket | `/run/unit/control.sock` |
+| State | `/var/lib/unit/` |
+| Log | `/var/log/unit/unit.log` |
+| Modules | `/usr/lib64/unit/modules/*.unit.so` |
+
+## Migration from NGINX Unit
+
+If upgrading from the archived NGINX Unit RPM packages:
+
+```bash
+# Stop old service
+sudo systemctl stop unit
+
+# Remove old repo
+sudo rm /etc/yum.repos.d/unit.repo
+
+# Build and install FreeUnit (steps above)
+```
+
+The control socket path changed from the old RPM default
+(`/var/run/unit/control.unit.sock`) to `/run/unit/control.sock`.
+Update any scripts that hardcode the old path:
+
+```bash
+# Find references to old socket path
+grep -r 'control.unit.sock' /etc/ /srv/ /root/ --include='*.sh' --include='*.conf' --include='*.php' -l 2>/dev/null
+```
+
+### Remi `unit-php` compatibility
+
+FreeUnit is API/ABI compatible with NGINX Unit 1.35.0+. Existing `unit-php` packages
+from Remi's repository continue to work without reinstalling.
+When using prebuilt RPM packages from `packages.freeunit.org` (not source builds),
+FreeUnit provides `Provides: unit = %{version}` for RPM dependency resolution.
+
+## Troubleshooting
+
+**`unitd` won't start, "address already in use":**
+```bash
+sudo ss -tlnp | grep 8080
+# Kill stale process or change listener port
+```
+
+**PHP module not found:**
+```bash
+ls /usr/lib64/unit/modules/
+# If empty, rebuild: ./configure php && make php-install && sudo make install
+```
+
+**Permission denied on control socket:**
+```bash
+ls -la /run/unit/control.sock
+# Run curl with sudo, or add user to the appropriate group
+```

--- a/pkg/community/REMI.md
+++ b/pkg/community/REMI.md
@@ -33,8 +33,9 @@ As of the last verified check (April 2026):
 PHP versions with confirmed `unit-php` packages: **7.4, 8.0, 8.3, 8.4, 8.5**
 
 > Remi stopped updating `unit-php` at version 1.35.0 (the last NGINX Unit release before
-> the project was archived in October 2025). FreeUnit is API/ABI compatible starting from
-> that version.
+> the project was archived in October 2025). The packages track the last NGINX Unit
+> source release. FreeUnit is API/ABI compatible starting from that version — the module
+> loads and works correctly with FreeUnit 1.35.5.
 
 ## Migration from NGINX Unit + Remi
 
@@ -99,6 +100,5 @@ That page is archived. Current FreeUnit installation docs:
 ## Notes
 
 Last verified: April 2026. Remi's `unit-php` packages were last published at version 1.35.0
-and have not been updated since NGINX Unit was archived. If Remi does not resume updates,
-native `freeunit-php` modules via `packages.freeunit.org` are the planned fallback.
-Track progress at [github.com/freeunitorg/freeunit/issues](https://github.com/freeunitorg/freeunit/issues).
+and have not been updated since NGINX Unit was archived. Contact with Remi about
+FreeUnit integration is planned after the 1.35.5 stable release.

--- a/pkg/docker/Dockerfile.builder-php8.5
+++ b/pkg/docker/Dockerfile.builder-php8.5
@@ -1,0 +1,31 @@
+FROM php:8.5-cli-trixie
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+         ca-certificates git build-essential libssl-dev openssl libpcre2-dev \
+         zlib1g-dev libzstd-dev libbrotli-dev curl wget pkg-config pkgconf \
+         libclang-dev cmake \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
+         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
+         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+       esac \
+    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
+    && curl -L -O "$url" \
+    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
+    && chmod +x rustup-init \
+    && export RUSTUP_HOME=/usr/local/rustup \
+    && export CARGO_HOME=/usr/local/cargo \
+    && export PATH=/usr/local/cargo/bin:$PATH \
+    && ./rustup-init -y --no-modify-path --profile minimal \
+           --default-toolchain 1.94.1 --default-host "${rustArch}" \
+    && rm rustup-init \
+    && rustc --version \
+    && cargo --version
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH

--- a/pkg/docker/Dockerfile.builder-trixie
+++ b/pkg/docker/Dockerfile.builder-trixie
@@ -1,0 +1,31 @@
+FROM debian:trixie-slim
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+         ca-certificates git build-essential libssl-dev openssl libpcre2-dev \
+         zlib1g-dev libzstd-dev libbrotli-dev curl wget pkg-config pkgconf \
+         libclang-dev cmake \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
+         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
+         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+       esac \
+    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
+    && curl -L -O "$url" \
+    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
+    && chmod +x rustup-init \
+    && export RUSTUP_HOME=/usr/local/rustup \
+    && export CARGO_HOME=/usr/local/cargo \
+    && export PATH=/usr/local/cargo/bin:$PATH \
+    && ./rustup-init -y --no-modify-path --profile minimal \
+           --default-toolchain 1.94.1 --default-host "${rustArch}" \
+    && rm rustup-init \
+    && rustc --version \
+    && cargo --version
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH

--- a/pkg/docker/Dockerfile.go1.24
+++ b/pkg/docker/Dockerfile.go1.24
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.go1.25
+++ b/pkg/docker/Dockerfile.go1.25
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.go1.26
+++ b/pkg/docker/Dockerfile.go1.26
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.jsc17
+++ b/pkg/docker/Dockerfile.jsc17
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.jsc21
+++ b/pkg/docker/Dockerfile.jsc21
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.minimal
+++ b/pkg/docker/Dockerfile.minimal
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.node20
+++ b/pkg/docker/Dockerfile.node20
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.node22
+++ b/pkg/docker/Dockerfile.node22
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.node24
+++ b/pkg/docker/Dockerfile.node24
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.perl5.38
+++ b/pkg/docker/Dockerfile.perl5.38
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.perl5.40
+++ b/pkg/docker/Dockerfile.perl5.40
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.php8.3
+++ b/pkg/docker/Dockerfile.php8.3
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.php8.4
+++ b/pkg/docker/Dockerfile.php8.4
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.php8.5
+++ b/pkg/docker/Dockerfile.php8.5
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.python3.12
+++ b/pkg/docker/Dockerfile.python3.12
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.python3.12-slim
+++ b/pkg/docker/Dockerfile.python3.12-slim
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.python3.13
+++ b/pkg/docker/Dockerfile.python3.13
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.python3.13-slim
+++ b/pkg/docker/Dockerfile.python3.13-slim
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.python3.14
+++ b/pkg/docker/Dockerfile.python3.14
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.python3.14-slim
+++ b/pkg/docker/Dockerfile.python3.14-slim
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.ruby3.3
+++ b/pkg/docker/Dockerfile.ruby3.3
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.ruby3.4
+++ b/pkg/docker/Dockerfile.ruby3.4
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Dockerfile.wasm
+++ b/pkg/docker/Dockerfile.wasm
@@ -81,7 +81,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -161,7 +161,7 @@ all: $(addprefix Dockerfile., $(MODVERSIONS))
 
 clean:
 	rm -f Dockerfile.*
-	rm -f build-*
+	rm -f $(addprefix build-, $(MODVERSIONS))
 	rm -rf build-logs
 
 .PHONY: default build dockerfiles clean library

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -160,7 +160,7 @@ diff-%:
 all: $(addprefix Dockerfile., $(MODVERSIONS))
 
 clean:
-	rm -f Dockerfile.*
+	rm -f $(filter-out $(wildcard Dockerfile.builder-*), $(wildcard Dockerfile.*))
 	rm -f $(addprefix build-, $(MODVERSIONS))
 	rm -rf build-logs
 

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -118,39 +118,39 @@ build-%: Dockerfile.%
 	docker build --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
 	touch $@
 
-library:
-	@echo "# this file is generated via https://github.com/nginx/unit/blob/$(shell git describe --always --abbrev=0 HEAD)/pkg/docker/Makefile"
-	@echo ""
-	@echo "Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx),"
-	@echo "             Konstantin Pavlov (@thresheek),"
-	@echo "             Igor Ippolitov (@oxpa)"
-	@echo "GitRepo: https://github.com/nginx/unit.git"
-	@previous=""; \
-	 for mod in $(MODVERSIONS); do \
-		echo ""; \
-		modname="$$( echo $$mod | tr -d '.0123456789')"; \
-		modmajor="$${mod%%.*}"; \
-		if test "$${mod#*slim}" != "$$mod"; then \
-			modmajor="$${modmajor}-slim"; \
-		fi; \
-		TAGS="$$mod $$modmajor $$modname"; \
-		TAGS="$$(echo $$TAGS | tr " " "\n" | sort -u -r | tr "\n" "," | sed "s/,/, /g")"; \
-		if test "$${previous#*"$$modname"}" != "$$previous"; then \
-			echo "Tags: $(VERSION)-$$mod, $$mod"; \
-		else \
-			if [ "$$mod" = "minimal" ]; then \
-				echo "Tags: $(VERSION)-$$mod, $${TAGS%, }, latest"; \
-			else \
-				echo "Tags: $(VERSION)-$$mod, $${TAGS%, }"; \
-			fi; \
-		fi; \
-		echo "Architectures: amd64, arm64v8"; \
-		echo "GitFetch: refs/heads/packaging"; \
-		echo "GitCommit: $(shell git describe --always --abbrev=0 HEAD)"; \
-		echo "Directory: pkg/docker"; \
-		echo "File: Dockerfile.$$mod"; \
-		previous="$$previous $$modname"; \
-	done
+# TODO(#milestone-1.35.8): uncomment and update GitFetch when publishing to
+# Docker Hub Official Images.  Target date: 2026-08-28 (1.35.8 release).
+#library:
+#	@echo "# this file is generated via https://github.com/freeunitorg/freeunit/blob/$(shell git describe --always --abbrev=0 HEAD)/pkg/docker/Makefile"
+#	@echo ""
+#	@echo "Maintainers: FreeUnit Community <team@freeunit.org> (@freeunitorg)"
+#	@echo "GitRepo: https://github.com/freeunitorg/freeunit.git"
+#	@previous=""; \
+#	 for mod in $(MODVERSIONS); do \
+#		echo ""; \
+#		modname="$$( echo $$mod | tr -d '.0123456789')"; \
+#		modmajor="$${mod%%.*}"; \
+#		if test "$${mod#*slim}" != "$$mod"; then \
+#			modmajor="$${modmajor}-slim"; \
+#		fi; \
+#		TAGS="$$mod $$modmajor $$modname"; \
+#		TAGS="$$(echo $$TAGS | tr " " "\n" | sort -u -r | tr "\n" "," | sed "s/,/, /g")"; \
+#		if test "$${previous#*"$$modname"}" != "$$previous"; then \
+#			echo "Tags: $(VERSION)-$$mod, $$mod"; \
+#		else \
+#			if [ "$$mod" = "minimal" ]; then \
+#				echo "Tags: $(VERSION)-$$mod, $${TAGS%, }, latest"; \
+#			else \
+#				echo "Tags: $(VERSION)-$$mod, $${TAGS%, }"; \
+#			fi; \
+#		fi; \
+#		echo "Architectures: amd64, arm64v8"; \
+#		echo "GitFetch: refs/heads/master"; \
+#		echo "GitCommit: $(shell git describe --always --abbrev=0 HEAD)"; \
+#		echo "Directory: pkg/docker"; \
+#		echo "File: Dockerfile.$$mod"; \
+#		previous="$$previous $$modname"; \
+#	done
 
 diff: $(addprefix diff-, $(MODVERSIONS))
 
@@ -164,4 +164,4 @@ clean:
 	rm -f $(addprefix build-, $(MODVERSIONS))
 	rm -rf build-logs
 
-.PHONY: default build dockerfiles clean library
+.PHONY: default build dockerfiles clean

--- a/pkg/docker/README.md
+++ b/pkg/docker/README.md
@@ -131,9 +131,11 @@ cd pkg/docker
 
 | Command | Description |
 |---------|-------------|
-| `./build-local.sh` | Build **all** variants sequentially |
+| `./build-local.sh` | Build **all** variants, `nproc/2` in parallel |
 | `./build-local.sh minimal php8.5` | Build only the listed variants |
 | `./build-local.sh -j4` | Build 4 variants in parallel (requires `parallel`) |
+| `./build-local.sh -b minimal php8.5` | Fast build via pre-built builder images (no apt/Rust download) |
+| `./build-local.sh -b` | Fast build all builder-supported variants |
 | `./build-local.sh -v 1.35.2` | Pin a specific FreeUnit version |
 | `./build-local.sh -p linux/arm64` | Build for a specific platform |
 | `./build-local.sh -p linux/amd64,linux/arm64 -j2` | Multi-arch build (requires buildx) |
@@ -147,10 +149,30 @@ as an APT proxy — no flags needed.
 ```
 -v VERSION   FreeUnit version string to pin (default: current git branch name)
 -p PLATFORM  Target platform (default: host arch, e.g. linux/amd64)
--j N         Number of parallel builds (default: 1)
+-j N         Number of parallel builds (default: nproc/2)
+-b           Builder mode — fast local builds via pre-built builder images
+             Skips apt install and Rust download; supported: minimal, wasm, php8.5
 -n           Dry-run — print commands, do not execute
 -h           Show help
 ```
+
+### Builder mode (-b): fast local iteration
+
+For `minimal`, `wasm`, and `php8.5` variants, `-b` uses pre-built builder images
+that already contain all build tools and Rust. This eliminates ~100 MB apt download
+and ~70 MB Rust download per build — useful for iterating locally.
+
+Builder images (`Dockerfile.builder-*`) are pulled from GHCR automatically, or
+built locally on first use if unavailable:
+
+```
+Dockerfile.builder-trixie   →  ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1
+Dockerfile.builder-php8.5   →  ghcr.io/freeunitorg/freeunit-builder:php8.5-rust1.94.1
+```
+
+The `local/` subdirectory contains the corresponding multi-stage Dockerfiles used
+with `-b`. These files are **not** used by CI — the GitHub Actions workflow always
+uses single-stage `Dockerfile.*` files without builder images.
 
 ### Logs
 
@@ -165,10 +187,12 @@ A summary (OK / FAILED) is printed at the end.
 | `wasm` | debian:trixie-slim |
 | `go1.24` | golang:1.24 |
 | `go1.25` | golang:1.25 |
+| `go1.26` | golang:1.26 |
 | `jsc17` | eclipse-temurin:17-jdk-noble |
 | `jsc21` | eclipse-temurin:21-jdk-noble |
 | `node20` | node:20 |
 | `node22` | node:22 |
+| `node24` | node:24 |
 | `perl5.38` | perl:5.38 |
 | `perl5.40` | perl:5.40 |
 | `php8.3` | php:8.3-cli |
@@ -182,6 +206,24 @@ A summary (OK / FAILED) is printed at the end.
 | `python3.14-slim` | python:3.14-slim |
 | `ruby3.3` | ruby:3.3 |
 | `ruby3.4` | ruby:3.4 |
+
+## Reference build environment
+
+Measured full build (all 23 variants, `./build-local.sh`) on the maintainer's local machine:
+
+| Parameter | Value |
+|-----------|-------|
+| CPU | AMD Ryzen 7 5700X — 8 cores / 16 threads |
+| RAM | 32 GiB |
+| Storage | NVMe SSD |
+| Docker | 29.5.0, `overlay2` |
+| Parallelism | 8 builds in parallel (`-j 8`, default `nproc/2`) |
+| APT cache | apt-cacher-ng on port 3142 (auto-detected) |
+| **Total time** | **~58 min** (23 variants, cold Docker layer cache) |
+
+With apt-cacher-ng, repeated builds that share base layers are significantly faster.
+Builder mode (`-b`) for `minimal`, `wasm`, and `php8.5` cuts those three variants to
+~2–3 min each by skipping apt and Rust downloads entirely.
 
 ## CI workflow
 

--- a/pkg/docker/README.md
+++ b/pkg/docker/README.md
@@ -101,6 +101,21 @@ sudo usermod -aG docker "$USER"
 sudo apt-get install -y parallel
 ```
 
+### apt-cacher-ng (optional, speeds up repeated builds)
+
+Caches downloaded `.deb` packages locally — subsequent builds skip re-downloading
+~100 MB of build tools per variant. Start once, works automatically:
+
+```bash
+docker run -d --name apt-cacher-ng --restart=always \
+  -p 3142:3142 \
+  -v apt-cacher-ng:/var/cache/apt-cacher-ng \
+  sameersbn/apt-cacher-ng
+```
+
+`build-local.sh` detects apt-cacher-ng automatically (checks port 3142) and
+passes it as an APT proxy via `--build-arg`. No configuration needed.
+
 ### Verify installation
 
 ```bash
@@ -123,6 +138,9 @@ cd pkg/docker
 | `./build-local.sh -p linux/arm64` | Build for a specific platform |
 | `./build-local.sh -p linux/amd64,linux/arm64 -j2` | Multi-arch build (requires buildx) |
 | `./build-local.sh -n` | Dry-run — print commands without executing |
+
+If apt-cacher-ng is running on port 3142, it is detected automatically and used
+as an APT proxy — no flags needed.
 
 ### Options
 

--- a/pkg/docker/build-local.sh
+++ b/pkg/docker/build-local.sh
@@ -7,11 +7,19 @@
 #
 # Options:
 #   -v VERSION   FreeUnit version string to pin (default: git branch name)
-#   -p PLATFORM  Target platform (default: current host arch)
+#   -p PLATFORM  Target platform (default: current arch)
 #                Examples: linux/amd64  linux/arm64  linux/amd64,linux/arm64
 #   -j N         Parallel builds (default: 1)
 #   -n           Dry-run — print commands, do not execute
 #   -h           Show this help
+#
+# apt-cacher-ng (optional):
+#   If apt-cacher-ng is running on port 3142, it is detected automatically and
+#   used as an APT proxy — subsequent builds skip re-downloading .deb packages.
+#   Start it once with:
+#     docker run -d --name apt-cacher-ng --restart=always \
+#       -p 3142:3142 -v apt-cacher-ng:/var/cache/apt-cacher-ng \
+#       sameersbn/apt-cacher-ng
 #
 # Examples:
 #   ./build-local.sh                        # build all variants sequentially
@@ -30,6 +38,12 @@ LOG_DIR="${SCRIPT_DIR}/build-logs"
 PARALLEL=1
 DRY_RUN=false
 PLATFORM=""
+APT_PROXY=""
+
+# Auto-detect apt-cacher-ng on port 3142
+if nc -z 127.0.0.1 3142 2>/dev/null; then
+    APT_PROXY="http://host-gateway:3142"
+fi
 
 # Derive default version from git branch
 VERSION="$(git -C "${SCRIPT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "local")"
@@ -145,6 +159,7 @@ info "  Parallel : ${PARALLEL}"
 info "  Variants : ${VARIANTS[*]}"
 info "  Log dir  : ${LOG_DIR}"
 info "  Dry-run  : ${DRY_RUN}"
+info "  APT proxy: ${APT_PROXY:-none (start apt-cacher-ng on :3142 to enable)}"
 info "============================================================"
 
 # ---------------------------------------------------------------------------
@@ -191,6 +206,13 @@ build_variant() {
             )
         fi
 
+        if [[ -n "$APT_PROXY" ]]; then
+            CMD+=(--add-host=host-gateway:host-gateway
+                  --build-arg "http_proxy=${APT_PROXY}"
+                  --build-arg "HTTP_PROXY=${APT_PROXY}"
+            )
+        fi
+
         echo "[$(date '+%H:%M:%S')] CMD    ${CMD[*]}"
 
         if $DRY_RUN; then
@@ -215,7 +237,7 @@ build_variant() {
 }
 
 export -f build_variant
-export VERSION SCRIPT_DIR LOG_DIR USE_BUILDX PLATFORM DRY_RUN
+export VERSION SCRIPT_DIR LOG_DIR USE_BUILDX PLATFORM DRY_RUN APT_PROXY
 
 # ---------------------------------------------------------------------------
 # Run builds

--- a/pkg/docker/build-local.sh
+++ b/pkg/docker/build-local.sh
@@ -9,7 +9,11 @@
 #   -v VERSION   FreeUnit version string to pin (default: git branch name)
 #   -p PLATFORM  Target platform (default: current arch)
 #                Examples: linux/amd64  linux/arm64  linux/amd64,linux/arm64
-#   -j N         Parallel builds (default: 1)
+#   -j N         Parallel builds (default: nproc/2)
+#   -b           Builder mode — use pre-built builder images (local/Dockerfile.*)
+#                Skips apt install and Rust download; builder image is built
+#                automatically if not found locally or on GHCR.
+#                Supported variants: minimal, wasm, php8.5
 #   -n           Dry-run — print commands, do not execute
 #   -h           Show this help
 #
@@ -27,6 +31,7 @@
 #   ./build-local.sh -j4                    # build 4 at a time
 #   ./build-local.sh -v 1.35.2 go1.25      # pin specific version
 #   ./build-local.sh -p linux/amd64,linux/arm64 -j2   # multi-arch (needs buildx)
+#   ./build-local.sh -b minimal php8.5     # fast local build via builder images
 
 set -euo pipefail
 
@@ -35,10 +40,14 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_DIR="${SCRIPT_DIR}/build-logs"
-PARALLEL=1
+# Each parallel Docker build runs make -j$(nproc) internally, so halving avoids
+# CPU saturation when multiple builds compile simultaneously.
+_NCPU=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)
+PARALLEL=$(( _NCPU / 2 < 1 ? 1 : _NCPU / 2 ))
 DRY_RUN=false
 PLATFORM=""
 APT_PROXY=""
+USE_BUILDER=false
 
 # Auto-detect apt-cacher-ng on port 3142
 if nc -z 127.0.0.1 3142 2>/dev/null; then
@@ -94,11 +103,12 @@ usage() {
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
-while getopts ":v:p:j:nh" opt; do
+while getopts ":v:p:j:bnh" opt; do
     case $opt in
         v) VERSION="$OPTARG" ;;
         p) PLATFORM="$OPTARG" ;;
         j) PARALLEL="$OPTARG" ;;
+        b) USE_BUILDER=true ;;
         n) DRY_RUN=true ;;
         h) usage ;;
         :) err "Option -$OPTARG requires an argument."; exit 1 ;;
@@ -160,7 +170,45 @@ info "  Variants : ${VARIANTS[*]}"
 info "  Log dir  : ${LOG_DIR}"
 info "  Dry-run  : ${DRY_RUN}"
 info "  APT proxy: ${APT_PROXY:-none (start apt-cacher-ng on :3142 to enable)}"
+info "  Builder  : ${USE_BUILDER} (-b uses local/Dockerfile.* with pre-built Rust)"
 info "============================================================"
+
+# ---------------------------------------------------------------------------
+# Builder image management
+# ---------------------------------------------------------------------------
+ensure_builder() {
+    local VARIANT="$1"
+    # Maps variant → builder image tag and source Dockerfile
+    local IMG BDF
+    case "$VARIANT" in
+        minimal|wasm) IMG="ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1"
+                      BDF="${SCRIPT_DIR}/Dockerfile.builder-trixie" ;;
+        php8.5)       IMG="ghcr.io/freeunitorg/freeunit-builder:php8.5-rust1.94.1"
+                      BDF="${SCRIPT_DIR}/Dockerfile.builder-php8.5" ;;
+        *)            return 0 ;;  # no builder for this variant
+    esac
+
+    if docker image inspect "$IMG" &>/dev/null; then
+        info "Builder image found locally: ${IMG}"
+        return 0
+    fi
+
+    if $DRY_RUN; then
+        info "DRY-RUN: would pull/build builder image: ${IMG}"
+        return 0
+    fi
+
+    info "Builder image not found locally: ${IMG}"
+    info "Trying to pull from GHCR..."
+    if docker pull "$IMG" 2>/dev/null; then
+        info "Pulled: ${IMG}"
+        return 0
+    fi
+
+    info "Pull failed — building from ${BDF}"
+    docker build -t "$IMG" -f "$BDF" "${SCRIPT_DIR}" \
+        || { err "Failed to build builder image: ${IMG}"; return 1; }
+}
 
 # ---------------------------------------------------------------------------
 # Build function (runs in subshell for parallelism)
@@ -168,6 +216,12 @@ info "============================================================"
 build_variant() {
     local VARIANT="$1"
     local DOCKERFILE="${SCRIPT_DIR}/Dockerfile.${VARIANT}"
+
+    # Builder mode: use local/Dockerfile.* if available for this variant
+    if $USE_BUILDER && [[ -f "${SCRIPT_DIR}/local/Dockerfile.${VARIANT}" ]]; then
+        ensure_builder "$VARIANT"
+        DOCKERFILE="${SCRIPT_DIR}/local/Dockerfile.${VARIANT}"
+    fi
     local IMAGE_TAG="freeunit:${VERSION}-${VARIANT}"
     local LOG_FILE="${LOG_DIR}/${VARIANT}.log"
     local TMP_DOCKERFILE
@@ -236,8 +290,8 @@ build_variant() {
     } 2>&1 | tee "${LOG_FILE}"
 }
 
-export -f build_variant
-export VERSION SCRIPT_DIR LOG_DIR USE_BUILDX PLATFORM DRY_RUN APT_PROXY
+export -f build_variant ensure_builder
+export VERSION SCRIPT_DIR LOG_DIR USE_BUILDX PLATFORM DRY_RUN APT_PROXY USE_BUILDER
 
 # ---------------------------------------------------------------------------
 # Run builds

--- a/pkg/docker/build-local.sh
+++ b/pkg/docker/build-local.sh
@@ -49,11 +49,6 @@ PLATFORM=""
 APT_PROXY=""
 USE_BUILDER=false
 
-# Auto-detect apt-cacher-ng on port 3142
-if nc -z 127.0.0.1 3142 2>/dev/null; then
-    APT_PROXY="http://host-gateway:3142"
-fi
-
 # Derive default version from git branch
 VERSION="$(git -C "${SCRIPT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "local")"
 VERSION="${VERSION//\//-}"   # replace / with - (e.g. feat/foo → feat-foo)
@@ -146,6 +141,12 @@ if [[ -z "$PLATFORM" ]]; then
     esac
 fi
 
+# Auto-detect apt-cacher-ng on port 3142 (bash-native, no nc dependency)
+# Placed after arg parsing so dry-run mode skips the network probe
+if ! $DRY_RUN && (echo > /dev/tcp/127.0.0.1/3142) >/dev/null 2>&1; then
+    APT_PROXY="http://host-gateway:3142"
+fi
+
 # ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
@@ -219,7 +220,7 @@ build_variant() {
 
     # Builder mode: use local/Dockerfile.* if available for this variant
     if $USE_BUILDER && [[ -f "${SCRIPT_DIR}/local/Dockerfile.${VARIANT}" ]]; then
-        ensure_builder "$VARIANT"
+        ensure_builder "$VARIANT" || return 1
         DOCKERFILE="${SCRIPT_DIR}/local/Dockerfile.${VARIANT}"
     fi
     local IMAGE_TAG="freeunit:${VERSION}-${VARIANT}"
@@ -292,6 +293,28 @@ build_variant() {
 
 export -f build_variant ensure_builder
 export VERSION SCRIPT_DIR LOG_DIR USE_BUILDX PLATFORM DRY_RUN APT_PROXY USE_BUILDER
+
+# ---------------------------------------------------------------------------
+# Pre-build builder images (sequential, before parallel loop)
+# Ensures minimal/wasm (share one builder) and php8.5 are pulled/built once,
+# so parallel build_variant calls hit only the fast docker-inspect path.
+# ---------------------------------------------------------------------------
+if $USE_BUILDER; then
+    declare -A _BUILDER_SEEN
+    for _V in "${VARIANTS[@]}"; do
+        [[ -f "${SCRIPT_DIR}/local/Dockerfile.${_V}" ]] || continue
+        case "$_V" in
+            minimal|wasm) _BKEY="trixie" ;;
+            php8.5)       _BKEY="php8.5" ;;
+            *)            continue ;;
+        esac
+        if [[ -z "${_BUILDER_SEEN[$_BKEY]:-}" ]]; then
+            _BUILDER_SEEN[$_BKEY]=1
+            ensure_builder "$_V" || exit 1
+        fi
+    done
+    unset _BUILDER_SEEN _BKEY _V
+fi
 
 # ---------------------------------------------------------------------------
 # Run builds

--- a/pkg/docker/local/Dockerfile.minimal
+++ b/pkg/docker/local/Dockerfile.minimal
@@ -92,6 +92,7 @@ RUN set -ex \
          --comment "unit user" \
          --shell /bin/false \
          unit \
+    && ldconfig \
     && ln -sf /dev/stderr /var/log/unit.log
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/pkg/docker/local/Dockerfile.minimal
+++ b/pkg/docker/local/Dockerfile.minimal
@@ -53,7 +53,8 @@ RUN set -ex \
     && ./configure \
     && make -j $NCPU version \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' \
           | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done \
           | grep -v '^diversion' \
           | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \

--- a/pkg/docker/local/Dockerfile.minimal
+++ b/pkg/docker/local/Dockerfile.minimal
@@ -1,0 +1,104 @@
+# Fast local build — uses pre-built builder image (no apt/Rust download).
+# Build builder first:
+#   docker build -t ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1 \
+#     -f ../Dockerfile.builder-trixie ..
+# Then build this variant:
+#   ../build-local.sh -b minimal
+
+FROM ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1 AS build
+
+RUN set -ex \
+    && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
+    && mkdir -p /usr/src/unit \
+    && cd /usr/src/unit \
+    && git clone --depth 1 -b 1.35.5 https://github.com/freeunitorg/freeunit unit \
+    && cd unit \
+    && NCPU="$(getconf _NPROCESSORS_ONLN)" \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \
+    && CC_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_CFLAGS_MAINT_APPEND="-fPIC" dpkg-buildflags --get CFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && LD_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed -pie" dpkg-buildflags --get LDFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && CONFIGURE_ARGS_MODULES="--prefix=/usr \
+                --statedir=/var/lib/unit \
+                --control=unix:/var/run/control.unit.sock \
+                --runstatedir=/var/run \
+                --pid=/var/run/unit.pid \
+                --logdir=/var/log \
+                --log=/var/log/unit.log \
+                --tmpdir=/var/tmp \
+                --user=unit \
+                --group=unit \
+                --openssl \
+                --libdir=/usr/lib/$DEB_HOST_MULTIARCH" \
+    && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
+                --njs \
+                --otel \
+                --zlib \
+                --zstd \
+                --brotli" \
+    && make -j $NCPU -C pkg/contrib .njs \
+    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && ./configure \
+    && make -j $NCPU version \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
+    && ./configure \
+    && make -j $NCPU version \
+    && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
+        ldd $f | awk '/=>/{print $(NF-1)}' \
+          | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done \
+          | grep -v '^diversion' \
+          | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+       done
+
+FROM debian:trixie-slim
+
+LABEL org.opencontainers.image.title="FreeUnit (minimal)"
+LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
+LABEL org.opencontainers.image.url="https://freeunit.org"
+LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
+LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
+LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
+LABEL org.opencontainers.image.version="1.35.5"
+
+COPY --from=build /usr/sbin/unitd         /usr/sbin/unitd
+COPY --from=build /usr/sbin/unitd-debug   /usr/sbin/unitd-debug
+COPY --from=build /usr/lib/unit/          /usr/lib/unit/
+COPY --from=build /requirements.apt       /requirements.apt
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y install \
+         curl $(cat /requirements.apt) \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /requirements.apt \
+    && mkdir -p /var/lib/unit/ \
+    && mkdir -p /docker-entrypoint.d/ \
+    && groupadd --gid 999 unit \
+    && useradd \
+         --uid 999 \
+         --gid unit \
+         --no-create-home \
+         --home /nonexistent \
+         --comment "unit user" \
+         --shell /bin/false \
+         unit \
+    && ln -sf /dev/stderr /var/log/unit.log
+
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY welcome.* /usr/share/unit/welcome/
+COPY seccomp-no-af-alg.json /usr/share/unit/
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+EXPOSE 80
+CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/local/Dockerfile.php8.5
+++ b/pkg/docker/local/Dockerfile.php8.5
@@ -53,7 +53,8 @@ RUN set -ex \
     && ./configure php \
     && make -j $NCPU php-install \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' \
           | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done \
           | grep -v '^diversion' \
           | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \

--- a/pkg/docker/local/Dockerfile.php8.5
+++ b/pkg/docker/local/Dockerfile.php8.5
@@ -1,0 +1,105 @@
+# Fast local build — uses pre-built builder image (no apt/Rust download).
+# Build builder first:
+#   docker build -t ghcr.io/freeunitorg/freeunit-builder:php8.5-rust1.94.1 \
+#     -f ../Dockerfile.builder-php8.5 ..
+# Then build this variant:
+#   ../build-local.sh -b php8.5
+
+FROM ghcr.io/freeunitorg/freeunit-builder:php8.5-rust1.94.1 AS build
+
+RUN set -ex \
+    && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
+    && mkdir -p /usr/src/unit \
+    && cd /usr/src/unit \
+    && git clone --depth 1 -b 1.35.5 https://github.com/freeunitorg/freeunit unit \
+    && cd unit \
+    && NCPU="$(getconf _NPROCESSORS_ONLN)" \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \
+    && CC_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_CFLAGS_MAINT_APPEND="-fPIC" dpkg-buildflags --get CFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && LD_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed -pie" dpkg-buildflags --get LDFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && CONFIGURE_ARGS_MODULES="--prefix=/usr \
+                --statedir=/var/lib/unit \
+                --control=unix:/var/run/control.unit.sock \
+                --runstatedir=/var/run \
+                --pid=/var/run/unit.pid \
+                --logdir=/var/log \
+                --log=/var/log/unit.log \
+                --tmpdir=/var/tmp \
+                --user=unit \
+                --group=unit \
+                --openssl \
+                --libdir=/usr/lib/$DEB_HOST_MULTIARCH" \
+    && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
+                --njs \
+                --otel \
+                --zlib \
+                --zstd \
+                --brotli" \
+    && make -j $NCPU -C pkg/contrib .njs \
+    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && ./configure php \
+    && make -j $NCPU php-install \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
+    && ./configure php \
+    && make -j $NCPU php-install \
+    && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
+        ldd $f | awk '/=>/{print $(NF-1)}' \
+          | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done \
+          | grep -v '^diversion' \
+          | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+       done
+
+FROM php:8.5-cli-trixie
+
+LABEL org.opencontainers.image.title="FreeUnit (php8.5)"
+LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
+LABEL org.opencontainers.image.url="https://freeunit.org"
+LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
+LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
+LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
+LABEL org.opencontainers.image.version="1.35.5"
+
+COPY --from=build /usr/sbin/unitd         /usr/sbin/unitd
+COPY --from=build /usr/sbin/unitd-debug   /usr/sbin/unitd-debug
+COPY --from=build /usr/lib/unit/          /usr/lib/unit/
+COPY --from=build /requirements.apt       /requirements.apt
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y install \
+         curl $(cat /requirements.apt) \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /requirements.apt \
+    && mkdir -p /var/lib/unit/ \
+    && mkdir -p /docker-entrypoint.d/ \
+    && groupadd --gid 999 unit \
+    && useradd \
+         --uid 999 \
+         --gid unit \
+         --no-create-home \
+         --home /nonexistent \
+         --comment "unit user" \
+         --shell /bin/false \
+         unit \
+    && ldconfig \
+    && ln -sf /dev/stderr /var/log/unit.log
+
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY welcome.* /usr/share/unit/welcome/
+COPY seccomp-no-af-alg.json /usr/share/unit/
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+EXPOSE 80
+CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/local/Dockerfile.wasm
+++ b/pkg/docker/local/Dockerfile.wasm
@@ -1,0 +1,108 @@
+# Fast local build — uses pre-built builder image (no apt/Rust download).
+# Builder: ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1
+# (same as minimal — wasmtime Rust build is included in that builder)
+
+FROM ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1 AS build
+
+RUN set -ex \
+    && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
+    && mkdir -p /usr/src/unit \
+    && cd /usr/src/unit \
+    && git clone --depth 1 -b 1.35.5 https://github.com/freeunitorg/freeunit unit \
+    && cd unit \
+    && NCPU="$(getconf _NPROCESSORS_ONLN)" \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \
+    && CC_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_CFLAGS_MAINT_APPEND="-fPIC" dpkg-buildflags --get CFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && LD_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed -pie" dpkg-buildflags --get LDFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && CONFIGURE_ARGS_MODULES="--prefix=/usr \
+                --statedir=/var/lib/unit \
+                --control=unix:/var/run/control.unit.sock \
+                --runstatedir=/var/run \
+                --pid=/var/run/unit.pid \
+                --logdir=/var/log \
+                --log=/var/log/unit.log \
+                --tmpdir=/var/tmp \
+                --user=unit \
+                --group=unit \
+                --openssl \
+                --libdir=/usr/lib/$DEB_HOST_MULTIARCH" \
+    && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
+                --njs \
+                --otel \
+                --zlib \
+                --zstd \
+                --brotli" \
+    && make -j $NCPU -C pkg/contrib .njs \
+    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
+    && make clean \
+    && make -C pkg/contrib .wasmtime \
+    && install -pm 755 pkg/contrib/wasmtime/artifacts/lib/libwasmtime.so \
+         /usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/ \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && ./configure wasm --include-path=`pwd`/pkg/contrib/wasmtime/artifacts/include \
+         --lib-path=/usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/ \
+    && ./configure wasm-wasi-component \
+    && make -j $NCPU wasm-install wasm-wasi-component-install \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
+    && ./configure wasm --include-path=`pwd`/pkg/contrib/wasmtime/artifacts/include \
+         --lib-path=/usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/ \
+    && ./configure wasm-wasi-component \
+    && make -j $NCPU wasm-install wasm-wasi-component-install \
+    && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
+        ldd $f | awk '/=>/{print $(NF-1)}' \
+          | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done \
+          | grep -v '^diversion' \
+          | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+       done
+
+FROM debian:trixie-slim
+
+LABEL org.opencontainers.image.title="FreeUnit (wasm)"
+LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
+LABEL org.opencontainers.image.url="https://freeunit.org"
+LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
+LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
+LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
+LABEL org.opencontainers.image.version="1.35.5"
+
+COPY --from=build /usr/sbin/unitd         /usr/sbin/unitd
+COPY --from=build /usr/sbin/unitd-debug   /usr/sbin/unitd-debug
+COPY --from=build /usr/lib/unit/          /usr/lib/unit/
+COPY --from=build /requirements.apt       /requirements.apt
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y install \
+         curl $(cat /requirements.apt) \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /requirements.apt \
+    && mkdir -p /var/lib/unit/ \
+    && mkdir -p /docker-entrypoint.d/ \
+    && groupadd --gid 999 unit \
+    && useradd \
+         --uid 999 \
+         --gid unit \
+         --no-create-home \
+         --home /nonexistent \
+         --comment "unit user" \
+         --shell /bin/false \
+         unit \
+    && ln -sf /dev/stderr /var/log/unit.log
+
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY welcome.* /usr/share/unit/welcome/
+COPY seccomp-no-af-alg.json /usr/share/unit/
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+EXPOSE 80
+CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/local/Dockerfile.wasm
+++ b/pkg/docker/local/Dockerfile.wasm
@@ -57,7 +57,8 @@ RUN set -ex \
     && ./configure wasm-wasi-component \
     && make -j $NCPU wasm-install wasm-wasi-component-install \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' \
           | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done \
           | grep -v '^diversion' \
           | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \

--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -80,7 +80,8 @@ RUN set -ex \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
-        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
        done \
     && apt-mark showmanual | xargs apt-mark auto > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \


### PR DESCRIPTION
### Proposed changes
add builder mode, parallel default, reference build stats

  - -b flag: pre-built builder images skip apt+Rust download for
    minimal/wasm/php8.5 variants (~170 MB saved per build)
  - default parallelism: nproc/2 instead of 1
  - local/Dockerfile.{minimal,wasm,php8.5}: multi-stage variants for -b
  - Dockerfile.builder-{trixie,php8.5}: builder image sources
  - README: document builder mode, add reference build timings
    (Ryzen 7 5700X, 32 GiB, NVMe — 23 variants in ~58 min)
  - TODO: OpenTelemetry 0.24→0.32 upgrade plan with fake_otlp design

### Checklist
- [ ] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] If applicable, I have added tests
- [ ] If applicable, I have updated documentation