### PR TITLE
fix(ci): isolate unitctl releases under their own tag

### DIFF
--- a/.github/workflows/unitctl.yml
+++ b/.github/workflows/unitctl.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           artifacts: "unitctl-*"
           prerelease: ${{ github.event_name == 'workflow_dispatch' }}
-          tag: ${{ inputs.version && format('unitctl/{0}', inputs.version) || github.ref_name }}
+          tag: ${{ inputs.version && format('unitctl/{0}', inputs.version) || format('unitctl/{0}', github.ref_name) }}
           body: >
             ## Unitctl
 


### PR DESCRIPTION


### Proposed changes
  The unitctl workflow ran on plain version tags (1.35.5) and, with
  allowUpdates: true, overwrote the main FreeUnit release body with a
  generic unitctl description. Always prefix the unitctl release tag
  with unitctl/ so it never collides with the application release.
  
### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [x] If applicable, I have updated documentation