### PR TITLE
fix(proxy): relay chunked responses safely (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
             os: ubuntu-latest
           - build: python-3.12
             os: ubuntu-latest
+          - build: python-3.14
+            os: ubuntu-latest
           - build: ruby-3.3
             os: ubuntu-latest
           - build: ruby-3.4

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -2945,6 +2945,7 @@ nxt_h1p_peer_body_process(nxt_task_t *task, nxt_http_peer_t *peer,
 static void
 nxt_h1p_peer_closed(nxt_task_t *task, void *obj, void *data)
 {
+    nxt_h1proto_t       *h1p;
     nxt_http_peer_t     *peer;
     nxt_http_request_t  *r;
 
@@ -2955,9 +2956,24 @@ nxt_h1p_peer_closed(nxt_task_t *task, void *obj, void *data)
     r = peer->request;
 
     if (peer->header_received) {
+        h1p = peer->proto.h1;
+
+        if (h1p->chunked && !h1p->chunked_parse.last) {
+            /*
+             * Upstream closed without the terminal chunk — premature EOF.
+             * Synthesising 0\r\n\r\n would hide the truncation from the
+             * client.  Treat as an error: if headers are already sent the
+             * error path resets the client connection; otherwise a 502 is
+             * returned.
+             */
+            peer->status = NXT_HTTP_BAD_GATEWAY;
+            r->state->error_handler(task, r, peer);
+            return;
+        }
+
         peer->body = nxt_http_buf_last(r);
         peer->closed = 1;
-        r->inconsistent = (peer->proto.h1->remainder != 0);
+        r->inconsistent = (h1p->remainder != 0);
 
         r->state->ready_handler(task, r, peer);
 
@@ -3059,6 +3075,21 @@ nxt_h1p_peer_close(nxt_task_t *task, nxt_http_peer_t *peer)
     c->socket.task = task;
     c->read_timer.task = task;
     c->write_timer.task = task;
+
+    /*
+     * Block further reads on the upstream connection and cancel its read
+     * timer.  Removal of the fd from the event facility is deferred to
+     * nxt_conn_close_handler(), but the peer object (c->socket.data) lives in
+     * the request memory pool and may be freed synchronously right after this
+     * close (e.g. nxt_http_proxy_error() releases the pool when the client
+     * aborts mid-response).  A read event already queued for this connection in
+     * the current engine cycle, or the autoreset read timer firing, would then
+     * reach nxt_h1p_peer_read_done()/nxt_h1p_peer_timer_value() and dereference
+     * the freed peer -- a use-after-free that crashes the router.  Setting
+     * block_read makes the queued nxt_conn_io_read() bail out early.
+     */
+    c->block_read = 1;
+    nxt_timer_disable(task->thread->engine, &c->read_timer);
 
     if (c->socket.fd != -1) {
         c->write_state = &nxt_h1p_peer_close_state;

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -1642,6 +1642,19 @@ nxt_h1p_chunk_create(nxt_task_t *task, nxt_http_request_t *r, nxt_buf_t *out)
     for (b = out; b != NULL; b = b->next) {
 
         if (nxt_buf_is_last(b)) {
+            if (r->inconsistent) {
+                /*
+                 * The response is truncated -- the upstream closed before the
+                 * body framing completed (premature chunked EOF, or a
+                 * Content-Length body cut short).  Relay the partial body but
+                 * omit the terminal 0\r\n\r\n: keepalive is already disabled,
+                 * so the connection closes after this buffer and the client
+                 * detects the truncation via the missing terminator, rather
+                 * than seeing a falsely complete response.  #72
+                 */
+                break;
+            }
+
             tail = nxt_http_buf_mem(task, r, sizeof(tail_chunk));
             if (nxt_slow_path(tail == NULL)) {
                 return NULL;
@@ -2958,22 +2971,24 @@ nxt_h1p_peer_closed(nxt_task_t *task, void *obj, void *data)
     if (peer->header_received) {
         h1p = peer->proto.h1;
 
-        if (h1p->chunked && !h1p->chunked_parse.last) {
-            /*
-             * Upstream closed without the terminal chunk — premature EOF.
-             * Synthesising 0\r\n\r\n would hide the truncation from the
-             * client.  Treat as an error: if headers are already sent the
-             * error path resets the client connection; otherwise a 502 is
-             * returned.
-             */
-            peer->status = NXT_HTTP_BAD_GATEWAY;
-            r->state->error_handler(task, r, peer);
-            return;
-        }
-
         peer->body = nxt_http_buf_last(r);
         peer->closed = 1;
-        r->inconsistent = (h1p->remainder != 0);
+
+        /*
+         * The upstream closed the connection.  The response body is truncated
+         * if its framing never completed: a Content-Length response short of
+         * its declared length (remainder != 0), or a chunked response that
+         * never reached the terminal 0\r\n\r\n (!chunked_parse.last).  Mark it
+         * inconsistent so keepalive is disabled and the client connection is
+         * closed once the partial body has been relayed.  The missing
+         * terminator then lets the client detect the truncation instead of it
+         * being masked as a clean end of response.  Relaying the partial body
+         * and closing -- rather than calling error_handler -- avoids racing a
+         * connection reset against the already-buffered status line and body
+         * (which could otherwise leave the client with an empty response). #72
+         */
+        r->inconsistent = (h1p->remainder != 0)
+                          || (h1p->chunked && !h1p->chunked_parse.last);
 
         r->state->ready_handler(task, r, peer);
 

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -3092,19 +3092,24 @@ nxt_h1p_peer_close(nxt_task_t *task, nxt_http_peer_t *peer)
     c->write_timer.task = task;
 
     /*
-     * Block further reads on the upstream connection and cancel its read
-     * timer.  Removal of the fd from the event facility is deferred to
+     * Block further I/O on the upstream connection and cancel its timers.
+     * Removal of the fd from the event facility is deferred to
      * nxt_conn_close_handler(), but the peer object (c->socket.data) lives in
      * the request memory pool and may be freed synchronously right after this
      * close (e.g. nxt_http_proxy_error() releases the pool when the client
-     * aborts mid-response).  A read event already queued for this connection in
-     * the current engine cycle, or the autoreset read timer firing, would then
-     * reach nxt_h1p_peer_read_done()/nxt_h1p_peer_timer_value() and dereference
-     * the freed peer -- a use-after-free that crashes the router.  Setting
-     * block_read makes the queued nxt_conn_io_read() bail out early.
+     * aborts mid-response).  An I/O event already queued for this connection in
+     * the current engine cycle, or an autoreset timer firing, would then reach
+     * nxt_h1p_peer_read_done()/nxt_h1p_peer_send_timeout()/etc. and dereference
+     * the freed peer -- a use-after-free that crashes the router.  Both paths
+     * are at risk: the read side (response relay) and the write side (the
+     * request body upload uses an autoreset send timer).  Setting block_read /
+     * block_write makes a queued nxt_conn_io_read()/nxt_conn_io_write() bail out
+     * early; nxt_conn_close() still emits the FIN via its work-queue handler.
      */
     c->block_read = 1;
+    c->block_write = 1;
     nxt_timer_disable(task->thread->engine, &c->read_timer);
+    nxt_timer_disable(task->thread->engine, &c->write_timer);
 
     if (c->socket.fd != -1) {
         c->write_state = &nxt_h1p_peer_close_state;

--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1676,7 +1676,22 @@ nxt_openssl_conn_error(nxt_task_t *task, nxt_err_t err, const char *fmt, ...)
 static nxt_uint_t
 nxt_openssl_log_error_level(nxt_err_t err)
 {
-    switch (ERR_GET_REASON(ERR_peek_error())) {
+    unsigned long  lib_err;
+
+    lib_err = ERR_peek_error();
+
+    /*
+     * System-library errors (e.g. a client that aborts mid-write: OpenSSL 3.x
+     * records EPIPE/ECONNRESET in the error queue while errno reads EAGAIN)
+     * carry a reason that is a plain errno, not an SSL_R_* code.  Classify them
+     * by errno so a peer disconnect is logged at info, not alert; otherwise the
+     * errno value falls through the SSL_R_* switch to the NXT_LOG_ALERT default.
+     */
+    if (ERR_GET_LIB(lib_err) == ERR_LIB_SYS) {
+        return nxt_socket_error_level(ERR_GET_REASON(lib_err));
+    }
+
+    switch (ERR_GET_REASON(lib_err)) {
 
     case 0:
         return nxt_socket_error_level(err);

--- a/test/README.md
+++ b/test/README.md
@@ -65,6 +65,43 @@ docker rmi freeunit-test:local
 ./test/run-local.sh python
 ```
 
+### Fast prototyping with the pre-built builder image
+
+`run-local.sh` builds a full test image from scratch (downloads Rust, Go, njs)
+— slow for tight iteration. For prototyping a **proxy / TLS** test (no language
+runtime needed), reuse the pre-built builder image
+`ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1` (Rust + all C build
+deps already baked in) and just mount the working tree. Build + run is ~30 s:
+
+```bash
+docker run --rm --privileged -v "$(pwd):/unit" -w /unit \
+  ghcr.io/freeunitorg/freeunit-builder:trixie-rust1.94.1 bash -c '
+    apt-get update -qq && apt-get install -y -qq python3-pytest python3-openssl
+    ./configure --openssl --tests
+    make -j"$(nproc)" unitd
+    cargo build --release --manifest-path test/fake_upstream/Cargo.toml
+    cp test/fake_upstream/target/release/fake_upstream /usr/local/bin/
+    pytest-3 --print-log test/test_proxy_chunked.py -q
+  '
+```
+
+Iterate by editing tests on the host (tree is mounted) and re-running; the C
+core and `fake_upstream` rebuild incrementally.
+
+**Caveats:**
+
+- **No language module is built**, so a test gated on one is skipped. A test
+  file with `prerequisites = {'modules': {'python': 'any'}}` (and a
+  `ApplicationPython()` client) skips entirely here. For proxy/TLS-only cases,
+  base the test on `ApplicationProto` (plain) or `ApplicationTLS` (TLS) and
+  omit the language `prerequisites` so it runs on the minimal `--openssl
+  --tests` build.
+- The build writes `build/` into the mounted tree as **root**. Run
+  `sudo rm -rf build` on the host afterwards, or use `run-local.sh` (copies to
+  a tmp dir) when you want isolation.
+- This path is for prototyping only. Before pushing, validate with
+  `./test/run-local.sh` (full matrix) and, for C changes, the clang-ast check.
+
 ### Running Tests Directly on Host
 
 If you prefer to run tests natively (requires all dependencies installed):

--- a/test/fake_upstream/PLAN.md
+++ b/test/fake_upstream/PLAN.md
@@ -1,0 +1,188 @@
+# fake_upstream — test plan & case backlog
+
+Living checklist for proxy/chunked coverage driven by `fake_upstream`. Captures
+the FreeUnit incident behind
+[#72](https://github.com/freeunitorg/freeunit/issues/72) **plus** reproducible
+bugs inherited from the archived `nginx/unit` tracker, so we do not forget to
+add the matching regression test.
+
+`fake_upstream` is a live HTTP/1.x mock upstream. Unit proxies to it; the test
+drives Unit and asserts what the **client** receives. Keep it dependency-free
+(std-only Rust) and deterministic.
+
+## Current modes (implemented)
+
+| Mode | Behavior |
+|------|----------|
+| `echo` | 200 + echo body (no header enforcement) |
+| `requires-cl` | 411 if `Transfer-Encoding: chunked` without `Content-Length` |
+| `no-te` | 400 if any `Transfer-Encoding`; 411 if no CL |
+| `strict` | 400 on TE; 411 on no CL; 400 if body != CL; else 200 echo |
+| `chunked-response` | 200 + `Transfer-Encoding: chunked`, body = `--size N` MiB deterministic `0123456789abcdef`, split across mixed chunk sizes (small, >16 KB, unaligned). Upstream half of the #72 relay path. Rust `respond_chunked_response`. |
+| `abort-mid` | as `chunked-response`, but after the full `--size` body closes the socket **without** the terminal `0\r\n\r\n` — upstream provides no framing EOF. Rust `respond_abort_mid`. |
+| `slow-drip` | chunked, one 512-byte chunk every `--delay-ms` ms, proper terminal chunk — relay vs `proxy_read_timeout`. Rust `respond_slow_drip`. |
+| `dup-te` | 200 with `Transfer-Encoding: chunked` header sent **twice** + valid chunked body — duplicate-TE relay (nginx/unit#1088). Rust `respond_dup_te`. |
+
+`echo`/`requires-cl`/`no-te`/`strict` answer with `Content-Length` only;
+`chunked-response`/`abort-mid`/`slow-drip`/`dup-te` are chunked emitters #72
+needs. Naming/port convention (one reserved port + shared token per test, Rust
+fn mirrors test prefix) is in [README.md](README.md).
+
+All modes in the original backlog are now implemented. `--size` and `--delay-ms`
+are wired; keep any new flag backward-compatible with the existing CLI.
+
+**`abort-mid` scope (review follow-up):** the current handler writes the **whole**
+`--size` body, then drops the connection without the terminal chunk — it tests
+the *missing-framing-EOF* path (a graceful relay must not synthesize a clean
+`0\r\n\r\n`; see Defect C). It does **not** exercise an abort **inside** a data
+chunk (truncated hex size / short data), which is a different relay-parser path.
+If that path needs coverage, add a separate `abort-mid-data` mode rather than
+overloading `abort-mid`.
+
+## Case matrix
+
+Status: ✅ covered · 🔲 to add
+
+### #72 — chunked **response** relay (the incident)
+
+| # | Case | Mode | Listener | Assertion | Status |
+|---|------|------|----------|-----------|--------|
+| 1 | 64 MiB chunked response, plain | `chunked-response --size 64` | `*:8080` | exact byte count + byte-pattern, no early EOF | ✅ `test_proxy_chunked_response_plain` |
+| 2 | 64 MiB chunked response, TLS | `chunked-response --size 64` | `*:8443` + cert | same as #1 | ✅ `test_proxy_chunked_response_tls` |
+| 3 | Varied chunk sizes (>16 KB, unaligned) | `chunked-response` | both | full body intact | ✅ folded into #1/#2 (`CHUNK_SCHEDULE`) |
+| 4 | Upstream aborts mid-stream | `abort-mid` | plain | client must see truncation (no synthesized terminal chunk); router survives | ✅ `test_proxy_chunked_response_abort_mid` |
+| 5 | Slow relay vs read timeout | `slow-drip` | plain | relay completes byte-exact under the timeout | ✅ `test_proxy_chunked_response_slow_drip` |
+
+**Result of cases 1–3:** the basic chunked-**response** relay is NOT broken —
+64 MiB streams byte-exact over both plain (H1) and TLS listeners. So the Gitea
+incident is not a relay-truncation bug; see case 7 below for the actual root
+cause.
+
+### Upstream-inherited (add as regression while we are here)
+
+| # | Case | Source | Mode | Assertion | Status |
+|---|------|--------|------|-----------|--------|
+| 6 | Response TE not duplicated | nginx/unit#1088 | `dup-te` | client sees ≤1 `Transfer-Encoding`; body decodes once | ✅ `test_proxy_chunked_response_dup_te` |
+| 7 | Proxy + TLS + large download + client disconnect | nginx/unit#828 | `chunked-response` (TLS) + client RST mid-read | router process survives (no SIGSEGV); disconnect not logged at `alert` | ✅ `test_proxy_chunked_response_client_abort` |
+| 8 | Chunked client **request** → CL to upstream | nginx/unit#445, FreeUnit #58 | `strict` | upstream gets correct `Content-Length`; >16 KB multi-buffer intact | ✅ (`test_proxy_chunked.py`) |
+| 9 | Streaming request to target (no full buffering) | nginx/unit#1282 | — | future; epic nginx/unit#1278 deferred mode | 🔲 (deferred) |
+
+### Already covered (do not duplicate)
+
+`test_proxy_chunked.py`: request→CL ≤ 2 MiB, multi-chunk, empty body, chunk
+extensions (`da63c36a` / RFC 9112 §7.1), POST/PUT/DELETE, concurrent.
+
+## Findings (2026-05-30) — case 7, the Gitea `git clone` incident
+
+Reproduced with `test_proxy_chunked_response_client_abort`: TLS listener proxies
+`chunked-response --size 64`; the client reads one record, then hard-closes with
+`SO_LINGER 0` (RST) mid-relay. **Two distinct defects surface** — the second is
+the real root cause.
+
+### Defect A — client disconnect logged at `[alert]` (severity) — FIXED
+
+The reported log line:
+
+```
+[alert] SSL_write(23, …, 4096) failed (11: Resource temporarily unavailable)
+        (32: [null]) (OpenSSL: error:80000020:system library::Broken pipe:…)
+```
+
+Trace: client aborts → `SSL_write` ≤0; `errno` reads `EAGAIN(11)`, but on
+OpenSSL 3.x the real `EPIPE(32)` / `ECONNRESET(104)` is in the **error queue**
+(`ERR_LIB_SYS`). `nxt_openssl_log_error_level()` ran `ERR_GET_REASON()` (= the
+errno) through the `SSL_R_*` switch, which has no case for 32/104 → fell to the
+`default: NXT_LOG_ALERT`. A plain peer disconnect must not be an alert.
+
+**Fix (applied, `src/nxt_openssl.c`):** in `nxt_openssl_log_error_level()`, when
+`ERR_GET_LIB(err) == ERR_LIB_SYS`, classify via
+`nxt_socket_error_level(ERR_GET_REASON(err))` (EPIPE/ECONNRESET → `NXT_LOG_INFO`).
+Verified: 5/5 runs now log the failure at `[info]`, never `[alert]`.
+
+### Defect B — router SIGSEGV (use-after-free) — ROOT CAUSE — FIXED
+
+The same abort also crashes the router (matches nginx/unit#828):
+
+```
+[alert] process 3501 exited on signal 11 (core dumped)   ← router segfault
+```
+
+Backtrace (debug build):
+
+```
+#0 nxt_h1p_peer_timer_value   src/nxt_h1proto.c:3044
+       peer = c->socket.data;
+       return nxt_value_at(nxt_msec_t, peer->request->conf->socket_conf, data);
+#1 nxt_conn_timer             src/nxt_conn.c:111   (state = nxt_h1p_peer_read_state)
+#2 nxt_conn_io_read           src/nxt_conn_read.c:126
+#3 nxt_event_engine_start     src/nxt_event_engine.c:542
+#4 nxt_router_thread_start    src/nxt_router.c:3727
+```
+
+Core evidence:
+
+| expr | value | meaning |
+|------|-------|---------|
+| `c` (peer conn) | `0x…7210` | alive |
+| `c->socket.data` (`peer`) | `0x…d640` | non-NULL |
+| `peer->request` | **`0x5555555555555555`** | freed-memory **poison** (0x55 fill) |
+| `c->socket.fd` | `93` | peer socket still open / readable |
+| `c->read_state` | `nxt_h1p_peer_read_state` | armed for upstream read |
+
+**Root cause:** when the client RSTs mid-relay, the request is closed and freed
+(memory poisoned to `0x55…`), but the **upstream (peer) connection still has a
+pending read event** and its fd stays registered. The queued
+`nxt_conn_io_read` then fires on the peer conn, `nxt_conn_timer` calls the
+`timer_value` callback `nxt_h1p_peer_timer_value`, which dereferences the freed
+`peer->request->conf->socket_conf` → SIGSEGV. The peer read path is not
+disarmed/cancelled before the request teardown frees its objects.
+
+**Fix (applied, `src/nxt_h1proto.c`, `nxt_h1p_peer_close`):** set `c->block_read = 1`
+and call `nxt_timer_disable(engine, &c->read_timer)` before the deferred
+`nxt_conn_close`.  `block_read` makes the already-queued `nxt_conn_io_read` bail
+at `nxt_conn_read.c:52`; the timer disable kills the autoreset arm.  fd removal
+stays deferred to `nxt_conn_close_handler` as before.
+
+**Reframed #72:** Defect B (router crash) is the actual incident root cause; the
+client's `GnuTLS recv error (-9)` is the symptom of the router dying mid-stream.
+Defect A is real but secondary (log noise). The AI-drafted bug report's "router
+crash" guess was correct; the "no crash" reading during this investigation was
+wrong (first log grep read the wrong file).
+
+### Defect C — upstream abort mid-stream masked as complete — FIXED
+
+`abort-mid`: upstream writes the full body then closes **without** the terminal
+`0\r\n\r\n`. Previously FreeUnit emitted its own terminal chunk, so the client
+saw a well-framed "complete" response despite the backend never finishing.
+
+Fix (`src/nxt_h1proto.c`, `nxt_h1p_peer_closed`): when upstream EOF arrives
+mid-chunked-relay (`h1p->chunked && !h1p->chunked_parse.last`), route to the
+error path (NXT_HTTP_BAD_GATEWAY) rather than synthesising a last buffer.  With
+headers already sent the error path calls `discard`, resetting the client
+connection — the client detects the truncation, matching nginx behaviour.
+
+## Review follow-ups (REVIEW.AI.GLM-5.1, 2026-05-30) — APPLIED
+
+All three items applied in this session:
+
+- ✅ `test_proxy_chunked_response_client_abort`: positive `[info]` assertion added.
+- ✅ `test_proxy_chunked_response_abort_mid`: `assert len(raw) > 200` floor added.
+- ✅ `test_proxy_chunked_response_dup_te`: status-code pin added before `te_count` check.
+
+Declined (low value): "ERR_peek_error double-log" in `nxt_openssl.c` is
+speculative — the prior code already used `peek`, behavior is preserved. The
+`Opts`-has-no-port, `read_chunked_body` invalid-hex→0, `_recv_all` 120 s timeout,
+and README port-7995 wording notes are correct nits, not blockers.
+
+## Notes
+
+- Test sizes for #72 must exceed the ≤ 2 MiB ceiling of the existing request
+  tests; the live incident was ~52 MiB. The implemented tests use 64 MiB and a
+  custom O(n) reader (the shared harness `recvall`/`_parse_chunked_body` are
+  O(n²) and choke at that size).
+- H1/H2 split is the whole point: case 1 (plain) isolates the chunked-relay
+  parser; case 2 (TLS) adds `nxt_openssl.c`. Both pass → relay is sound.
+- Reproducing the crash needs a debug build + core dump: the router drops
+  privileges, so set `fs.suid_dumpable=1` and a world-writable
+  `kernel.core_pattern` (e.g. `/tmp/core.%p`); `--privileged` + `ulimit -c
+  unlimited` in the container.

--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -1,0 +1,109 @@
+# fake_upstream
+
+A tiny, dependency-free (std-only Rust) HTTP/1.x **mock upstream** for FreeUnit
+proxy tests. FreeUnit proxies to it; the test drives FreeUnit and asserts what
+the **client** receives. Each instance plays one deterministic *behavior*
+(`--mode`), so a test can pin an exact upstream contract.
+
+See [PLAN.md](PLAN.md) for the case backlog and which mode covers which issue.
+
+## Build
+
+```bash
+cargo build --release --manifest-path test/fake_upstream/Cargo.toml
+cp test/fake_upstream/target/release/fake_upstream /usr/local/bin/
+```
+
+CI builds it in the "Build fake_upstream" step; the pytest cases skip gracefully
+when `/usr/local/bin/fake_upstream` is absent.
+
+## CLI
+
+```
+fake_upstream --port <N> --mode <mode> [--requests <N>] [--size <MiB>] [--delay-ms <N>]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--port N` | TCP port to listen on (`127.0.0.1`) |
+| `--mode M` | behavior (table below) |
+| `--requests N` | exit after N connections (default: run forever) |
+| `--size N` | body size in MiB for `chunked-response`/`abort-mid`/`slow-drip`/`dup-te` (default 1) |
+| `--delay-ms N` | sleep between chunks in ms for `chunked-response`/`slow-drip` (default 0) |
+
+### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `echo` | 200 + echo request body (no header enforcement) |
+| `requires-cl` | 411 if `Transfer-Encoding: chunked` without `Content-Length` |
+| `no-te` | 400 if any `Transfer-Encoding`; 411 if no `Content-Length` |
+| `strict` | 400 on TE; 411 on no CL; 400 if body length != CL; else 200 echo |
+| `chunked-response` | 200 + `Transfer-Encoding: chunked` response of `--size` MiB deterministic bytes (no `Content-Length`), split across mixed chunk sizes — the upstream half of the proxy chunked-**response** relay path (#72) |
+| `abort-mid` | as `chunked-response`, but after `--size` bytes closes the socket **without** the terminal `0\r\n\r\n` — upstream dies mid-stream (#72 case 4) |
+| `slow-drip` | chunked, one 512-byte chunk every `--delay-ms` ms, proper terminal chunk — relay vs `proxy_read_timeout` (#72 case 5) |
+| `dup-te` | 200 with `Transfer-Encoding: chunked` header sent **twice** + valid chunked body — duplicate-TE relay (#72 case 6, nginx/unit#1088) |
+
+Deterministic body: byte at global offset `i` is `"0123456789abcdef"[i % 16]`,
+so a test regenerates the exact sequence and verifies the relayed body
+byte-for-byte.
+
+## Test convention: one reserved port per test + name mirroring
+
+Each instance serves exactly one behavior, so behaviors coexist on **distinct
+ports** and FreeUnit routes to whichever a case configured. Two rules keep the
+suite collision-free and greppable:
+
+**1. One fixed, documented port per test.** A test does not grab an ephemeral
+port — it owns a reserved number from the registry below and launches its own
+instance on it (torn down in `finally`). Fixed numbers make a run reproducible
+by hand (curl / real `git clone` hit the same port the test used) and the
+registry is the single place that guarantees no two cases clash.
+
+**2. Mirror the names.** The upstream behavior carries one shared token across
+all three layers — pytest function, `--mode` string, and Rust handler — so a
+single `grep` finds every side of a case. E.g. token `chunked_response`:
+`test_proxy_chunked_response_*` ↔ `--mode chunked-response` ↔
+`respond_chunked_response()`.
+
+### Port registry
+
+| Port | Token | Mode (CLI) | Rust handler | pytest |
+|------|-------|-----------|--------------|--------|
+| 7990 | `echo` | `echo` | `respond` (echo arm) | — (shared sanity) |
+| 7991 | `strict` | `strict` | `handle` (Strict arm) | chunked **request** → CL (#445, #58) |
+| 7992 | `requires_cl` | `requires-cl` | `handle` (RequiresCl arm) | backend demands `Content-Length` (#1278) |
+| 7993 | `no_te` | `no-te` | `handle` (NoTe arm) | backend rejects `Transfer-Encoding` (#1088) |
+| 7994 | `chunked_response` | `chunked-response` | `respond_chunked_response` | `test_proxy_chunked_response_{plain,tls}` (#72) |
+| 7995 | `chunked_response` | `chunked-response` | `respond_chunked_response` | `test_proxy_chunked_response_client_abort` (#72 case 7 — client RST mid-write must not log SSL_write at `[alert]`) |
+| 7996 | `abort_mid` | `abort-mid` | `respond_abort_mid` | `test_proxy_chunked_response_abort_mid` (#72 case 4) |
+| 7997 | `slow_drip` | `slow-drip` | `respond_slow_drip` | `test_proxy_chunked_response_slow_drip` (#72 case 5) |
+| 7998 | `dup_te` | `dup-te` | `respond_dup_te` | `test_proxy_chunked_response_dup_te` (#72 case 6, nginx/unit#1088) |
+
+A test pins its port as a module constant referencing this table:
+
+```python
+UPSTREAM_PORT = 7994                       # reserved here for #72
+proc = _run_chunked_response()             # --mode chunked-response --size 64
+try:
+    client.conf({... "proxy": f"http://127.0.0.1:{UPSTREAM_PORT}" ...})
+    ...
+finally:
+    proc.terminate(); proc.wait()
+```
+
+For manual reproduction, launch the same fixed ports by hand and let one
+FreeUnit config fan out to all of them — no restart between cases:
+
+```bash
+fake_upstream --port 7990 --mode echo &
+fake_upstream --port 7991 --mode strict &
+fake_upstream --port 7994 --mode chunked-response --size 64 &
+```
+
+## Adding a mode
+
+All modes in [PLAN.md](PLAN.md) are implemented. For a new one, give it a
+**new reserved port + shared token** in the registry above, a `respond_<token>`
+Rust handler, and a matching `test_..._<token>` pytest function, so the
+three-way name mirroring stays complete.

--- a/test/fake_upstream/src/main.rs
+++ b/test/fake_upstream/src/main.rs
@@ -2,15 +2,30 @@
 ///
 /// Usage:
 ///   fake_upstream --port <N> --mode <mode> [--requests <N>]
+///                 [--size <MiB>] [--delay-ms <N>]
 ///
 /// Modes:
-///   requires-cl  411 if Transfer-Encoding: chunked without Content-Length
-///   no-te        400 if Transfer-Encoding present; 411 if no Content-Length
-///   strict       400 if Transfer-Encoding present; 411 if no CL;
-///                400 if body length != CL value; else 200 + echo
-///   echo         200 + echo body (no header enforcement)
+///   requires-cl    411 if Transfer-Encoding: chunked without Content-Length
+///   no-te          400 if Transfer-Encoding present; 411 if no Content-Length
+///   strict         400 if Transfer-Encoding present; 411 if no CL;
+///                  400 if body length != CL value; else 200 + echo
+///   echo             200 + echo body (no header enforcement)
+///   chunked-response 200 + Transfer-Encoding: chunked response of --size MiB
+///                    deterministic bytes, split across mixed chunk sizes
+///                    (no Content-Length). Upstream half of the proxy
+///                    chunked-response relay path (#72). Mirrors pytest
+///                    test_proxy_chunked_response_* (shared `chunked_response`
+///                    token — grep finds both sides).
+///   abort-mid        chunked, write --size bytes, then close without the
+///                    terminal 0-chunk (upstream dies mid-stream, #72 case 4)
+///   slow-drip        chunked, one 512-byte chunk every --delay-ms ms, proper
+///                    terminal chunk (relay vs proxy_read_timeout, #72 case 5)
+///   dup-te           Transfer-Encoding: chunked header sent twice + valid
+///                    chunked body (nginx/unit#1088, #72 case 6)
 ///
 /// --requests N   exit after handling N connections (default: run forever)
+/// --size N       chunked-response: response body size in MiB (default: 1)
+/// --delay-ms N   chunked-response: sleep between chunks in ms (default: 0)
 
 use std::env;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -26,7 +41,31 @@ enum Mode {
     NoTe,
     Strict,
     Echo,
+    ChunkedResponse,
+    AbortMid,
+    SlowDrip,
+    DupTe,
 }
+
+// ---------------------------------------------------------------------------
+
+/// Runtime options resolved from the CLI.
+struct Opts {
+    mode: Mode,
+    /// chunked-stream: total response body size in bytes.
+    size: usize,
+    /// chunked-stream: delay between chunks in milliseconds (0 = none).
+    delay_ms: u64,
+}
+
+/// Deterministic body content: byte at global offset `i` is `PATTERN[i % 16]`.
+/// Tests regenerate the same sequence to verify the relayed body byte-for-byte.
+const PATTERN: &[u8; 16] = b"0123456789abcdef";
+
+/// Chunk-size schedule (bytes), cycled across the body. Mixes tiny chunks,
+/// chunks > 16 KB, and sizes deliberately not aligned to a power-of-two read
+/// buffer, to exercise multi-buffer / mid-chunk parser paths in the relay.
+const CHUNK_SCHEDULE: &[usize] = &[1, 17, 255, 4096, 16384, 16385, 65521, 131072, 7];
 
 // ---------------------------------------------------------------------------
 
@@ -123,7 +162,12 @@ fn read_chunked_body(reader: &mut BufReader<&TcpStream>) -> std::io::Result<Vec<
             .next()
             .unwrap_or("")
             .trim();
-        let chunk_size = usize::from_str_radix(size_field, 16).unwrap_or(0);
+        let chunk_size = usize::from_str_radix(size_field, 16).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid chunk size {:?}: {}", size_field, e),
+            )
+        })?;
         if chunk_size == 0 {
             // consume trailing CRLF after terminal chunk
             let mut crlf = String::new();
@@ -153,7 +197,184 @@ fn respond(stream: &mut TcpStream, status: u16, reason: &str, body: &[u8]) {
     let _ = stream.write_all(body);
 }
 
-fn handle(mut stream: TcpStream, mode: Mode) {
+/// Stream a `Transfer-Encoding: chunked` response of `size` deterministic bytes
+/// (no Content-Length), splitting the body across CHUNK_SCHEDULE sizes. This is
+/// the upstream half of the proxy chunked-response relay path (#72); the name
+/// mirrors the consuming pytest `test_proxy_chunked_response_*`.
+fn respond_chunked_response(stream: &mut TcpStream, size: usize, delay_ms: u64) {
+    let head = "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/octet-stream\r\n\
+                Transfer-Encoding: chunked\r\n\
+                Connection: close\r\n\r\n";
+    if stream.write_all(head.as_bytes()).is_err() {
+        return;
+    }
+
+    let mut offset = 0usize;
+    let mut sched = 0usize;
+
+    while offset < size {
+        let want = CHUNK_SCHEDULE[sched % CHUNK_SCHEDULE.len()];
+        sched += 1;
+        let n = want.min(size - offset);
+
+        let mut chunk = Vec::with_capacity(n);
+        for i in 0..n {
+            chunk.push(PATTERN[(offset + i) % PATTERN.len()]);
+        }
+        offset += n;
+
+        // <hex-size>\r\n<data>\r\n
+        if stream
+            .write_all(format!("{:x}\r\n", n).as_bytes())
+            .and_then(|_| stream.write_all(&chunk))
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .is_err()
+        {
+            return; // client/proxy went away mid-stream
+        }
+
+        if delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+        }
+    }
+
+    // Terminal chunk.
+    let _ = stream.write_all(b"0\r\n\r\n");
+    let _ = stream.flush();
+}
+
+/// Start a `Transfer-Encoding: chunked` response, write `size` deterministic
+/// bytes, then close the socket **without** the terminal `0\r\n\r\n` — an
+/// upstream that dies mid-stream (#72 case 4). FreeUnit must surface a clean
+/// truncation to the client (closed connection, short body), never hang or
+/// crash the router. Mirrors pytest `test_proxy_chunked_response_abort_mid`.
+fn respond_abort_mid(stream: &mut TcpStream, size: usize) {
+    let head = "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/octet-stream\r\n\
+                Transfer-Encoding: chunked\r\n\
+                Connection: close\r\n\r\n";
+    if stream.write_all(head.as_bytes()).is_err() {
+        return;
+    }
+
+    let mut offset = 0usize;
+    let mut sched = 0usize;
+
+    while offset < size {
+        let want = CHUNK_SCHEDULE[sched % CHUNK_SCHEDULE.len()];
+        sched += 1;
+        let n = want.min(size - offset);
+
+        let mut chunk = Vec::with_capacity(n);
+        for i in 0..n {
+            chunk.push(PATTERN[(offset + i) % PATTERN.len()]);
+        }
+        offset += n;
+
+        if stream
+            .write_all(format!("{:x}\r\n", n).as_bytes())
+            .and_then(|_| stream.write_all(&chunk))
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .is_err()
+        {
+            return;
+        }
+    }
+
+    // Deliberately omit the terminal chunk and drop the stream — the upstream
+    // aborts mid-response.
+    let _ = stream.flush();
+}
+
+/// Stream a `Transfer-Encoding: chunked` response one small chunk at a time,
+/// sleeping `delay_ms` between chunks, with a proper terminal chunk (#72
+/// case 5). Probes relay behaviour vs `proxy_read_timeout`. Mirrors pytest
+/// `test_proxy_chunked_response_slow_drip`.
+fn respond_slow_drip(stream: &mut TcpStream, size: usize, delay_ms: u64) {
+    const DRIP: usize = 512;
+
+    let head = "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/octet-stream\r\n\
+                Transfer-Encoding: chunked\r\n\
+                Connection: close\r\n\r\n";
+    if stream.write_all(head.as_bytes()).is_err() {
+        return;
+    }
+
+    let mut offset = 0usize;
+
+    while offset < size {
+        let n = DRIP.min(size - offset);
+
+        let mut chunk = Vec::with_capacity(n);
+        for i in 0..n {
+            chunk.push(PATTERN[(offset + i) % PATTERN.len()]);
+        }
+        offset += n;
+
+        if stream
+            .write_all(format!("{:x}\r\n", n).as_bytes())
+            .and_then(|_| stream.write_all(&chunk))
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .and_then(|_| stream.flush())
+            .is_err()
+        {
+            return;
+        }
+
+        if delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+        }
+    }
+
+    let _ = stream.write_all(b"0\r\n\r\n");
+    let _ = stream.flush();
+}
+
+/// Respond with the `Transfer-Encoding: chunked` header sent **twice** plus a
+/// valid chunked body (nginx/unit#1088, #72 case 6). FreeUnit must not relay a
+/// duplicated framing header to the client. Mirrors pytest
+/// `test_proxy_chunked_response_dup_te`.
+fn respond_dup_te(stream: &mut TcpStream, size: usize) {
+    let head = "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/octet-stream\r\n\
+                Transfer-Encoding: chunked\r\n\
+                Transfer-Encoding: chunked\r\n\
+                Connection: close\r\n\r\n";
+    if stream.write_all(head.as_bytes()).is_err() {
+        return;
+    }
+
+    let mut offset = 0usize;
+    let mut sched = 0usize;
+
+    while offset < size {
+        let want = CHUNK_SCHEDULE[sched % CHUNK_SCHEDULE.len()];
+        sched += 1;
+        let n = want.min(size - offset);
+
+        let mut chunk = Vec::with_capacity(n);
+        for i in 0..n {
+            chunk.push(PATTERN[(offset + i) % PATTERN.len()]);
+        }
+        offset += n;
+
+        if stream
+            .write_all(format!("{:x}\r\n", n).as_bytes())
+            .and_then(|_| stream.write_all(&chunk))
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .is_err()
+        {
+            return;
+        }
+    }
+
+    let _ = stream.write_all(b"0\r\n\r\n");
+    let _ = stream.flush();
+}
+
+fn handle(mut stream: TcpStream, opts: &Opts) {
     let req = match read_request(&stream) {
         Ok(r) => r,
         Err(_) => {
@@ -162,7 +383,23 @@ fn handle(mut stream: TcpStream, mode: Mode) {
         }
     };
 
-    match mode {
+    match opts.mode {
+        Mode::ChunkedResponse => {
+            respond_chunked_response(&mut stream, opts.size, opts.delay_ms);
+        }
+
+        Mode::AbortMid => {
+            respond_abort_mid(&mut stream, opts.size);
+        }
+
+        Mode::SlowDrip => {
+            respond_slow_drip(&mut stream, opts.size, opts.delay_ms);
+        }
+
+        Mode::DupTe => {
+            respond_dup_te(&mut stream, opts.size);
+        }
+
         Mode::Echo => {
             respond(&mut stream, 200, "OK", &req.body);
         }
@@ -217,7 +454,10 @@ fn handle(mut stream: TcpStream, mode: Mode) {
 
 fn usage() -> ! {
     eprintln!(
-        "Usage: fake_upstream --port <N> --mode <requires-cl|no-te|strict|echo> [--requests <N>]"
+        "Usage: fake_upstream --port <N> \
+         --mode <requires-cl|no-te|strict|echo|chunked-response|\
+         abort-mid|slow-drip|dup-te> \
+         [--requests <N>] [--size <MiB>] [--delay-ms <N>]"
     );
     process::exit(1);
 }
@@ -228,6 +468,8 @@ fn main() {
     let mut port: Option<u16> = None;
     let mut mode: Option<Mode> = None;
     let mut max_requests: Option<usize> = None;
+    let mut size_mib: usize = 1;
+    let mut delay_ms: u64 = 0;
 
     let mut i = 1;
     while i < args.len() {
@@ -243,12 +485,24 @@ fn main() {
                     "no-te" => Some(Mode::NoTe),
                     "strict" => Some(Mode::Strict),
                     "echo" => Some(Mode::Echo),
+                    "chunked-response" => Some(Mode::ChunkedResponse),
+                    "abort-mid" => Some(Mode::AbortMid),
+                    "slow-drip" => Some(Mode::SlowDrip),
+                    "dup-te" => Some(Mode::DupTe),
                     _ => None,
                 });
             }
             "--requests" => {
                 i += 1;
                 max_requests = args.get(i).and_then(|v| v.parse().ok());
+            }
+            "--size" => {
+                i += 1;
+                size_mib = args.get(i).and_then(|v| v.parse().ok()).unwrap_or(size_mib);
+            }
+            "--delay-ms" => {
+                i += 1;
+                delay_ms = args.get(i).and_then(|v| v.parse().ok()).unwrap_or(delay_ms);
             }
             _ => {}
         }
@@ -257,6 +511,11 @@ fn main() {
 
     let port = port.unwrap_or_else(|| usage());
     let mode = mode.unwrap_or_else(|| usage());
+    let opts = Opts {
+        mode,
+        size: size_mib * 1024 * 1024,
+        delay_ms,
+    };
 
     let listener = TcpListener::bind(("127.0.0.1", port)).unwrap_or_else(|e| {
         eprintln!("bind {}:{} — {}", "127.0.0.1", port, e);
@@ -267,7 +526,7 @@ fn main() {
     for stream in listener.incoming() {
         match stream {
             Ok(s) => {
-                handle(s, mode);
+                handle(s, &opts);
                 count += 1;
                 if max_requests.map_or(false, |n| count >= n) {
                     break;

--- a/test/test_fake_upstream_proxy_chunked_response.py
+++ b/test/test_fake_upstream_proxy_chunked_response.py
@@ -1,0 +1,375 @@
+"""Proxy chunked-*response* relay regression tests (FreeUnit #72).
+
+The mirror direction of test_proxy_chunked.py: there the client sends a chunked
+*request*; here the upstream sends a chunked *response* (no Content-Length) and
+FreeUnit must relay the full body to the client without truncation, over both a
+plain and a TLS listener.
+
+Driven by the `chunked-stream` mode of the Rust mock upstream
+(test/fake_upstream/). Deliberately language-module-free — gated only on the
+built-in `openssl` support — so it runs on the minimal `--openssl --tests`
+build used for fast prototyping (see test/README.md).
+
+H1 (plain, *:8080)  isolates the chunked-relay parser
+                    (nxt_http_chunk_parse.c / nxt_h1proto.c).
+H2 (TLS,   *:8443)  adds the TLS send path (nxt_openssl.c) — reproduces the
+                    Gitea `git clone` incident.
+
+NOTE: we read the response ourselves (no_recv=True) into a bytearray instead of
+the shared harness recvall/_parse_chunked_body — both are O(n^2) and choke on a
+64 MiB relay (recvall reallocates an immutable bytes per recv; over TLS a recv
+returns one ~16 KB record, so the cost explodes).
+"""
+
+import os
+import socket
+import ssl
+import struct
+import subprocess
+import time
+
+import pytest
+
+from unit.applications.tls import ApplicationTLS
+from unit.utils import waitforsocket
+
+prerequisites = {'modules': {'openssl': 'any'}}
+
+client = ApplicationTLS()
+
+# Mirror of fake_upstream PATTERN / response size. The incident packfile was
+# ~52 MiB; 64 MiB stays comfortably past the 2 MiB ceiling of the request tests
+# and forces many read-buffer refills on the relay path.
+PATTERN = b'0123456789abcdef'
+SIZE_MIB = 64
+SIZE = SIZE_MIB * 1024 * 1024
+
+# Fixed upstream ports reserved for this case in test/fake_upstream/README.md.
+# One documented port per test → no cross-test collisions, greppable alongside
+# the `chunked-response` mode / `respond_chunked_response` Rust handler.
+UPSTREAM_PORT = 7994        # plain + tls relay tests
+UPSTREAM_ABORT_PORT = 7995  # client-abort mid-write test (same upstream behavior)
+UPSTREAM_ABORT_MID_PORT = 7996  # upstream dies mid-stream (abort-mid)
+UPSTREAM_SLOW_DRIP_PORT = 7997  # one small chunk every N ms (slow-drip)
+UPSTREAM_DUP_TE_PORT = 7998     # duplicate Transfer-Encoding header (dup-te)
+
+FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
+
+_skipif_no_fake_upstream = pytest.mark.skipif(
+    not os.path.exists(FAKE_UPSTREAM_BIN),
+    reason=f'{FAKE_UPSTREAM_BIN} not installed (build via test/fake_upstream)',
+)
+
+
+def _run_chunked_response(port=UPSTREAM_PORT, size_mib=SIZE_MIB):
+    proc = subprocess.Popen(
+        [
+            FAKE_UPSTREAM_BIN,
+            '--port',
+            str(port),
+            '--mode',
+            'chunked-response',
+            '--size',
+            str(size_mib),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    waitforsocket(port)
+    return proc
+
+
+def _run_mode(port, mode, size_mib=1, delay_ms=0):
+    args = [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', mode,
+            '--size', str(size_mib)]
+    if delay_ms:
+        args += ['--delay-ms', str(delay_ms)]
+    proc = subprocess.Popen(args, stdout=subprocess.DEVNULL,
+                            stderr=subprocess.PIPE)
+    waitforsocket(port)
+    return proc
+
+
+def _recv_all(sock, timeout=120):
+    """Read until EOF into a bytearray (amortized O(1) append, unlike recvall)."""
+    sock.settimeout(timeout)
+    buf = bytearray()
+    while True:
+        try:
+            part = sock.recv(1 << 20)
+        except (TimeoutError, socket.timeout, ssl.SSLError, OSError):
+            break
+        if not part:
+            break
+        buf += part
+    return buf
+
+
+def _dechunk(body):
+    """Single-pass chunked decoder over bytes; O(n) (bytes.index is C-level)."""
+    out = bytearray()
+    i = 0
+    n = len(body)
+    while i < n:
+        try:
+            j = body.index(b'\r\n', i)
+        except ValueError:
+            raise ValueError(
+                f'_dechunk: no CRLF after offset {i} '
+                f'(body len={n}, tail={bytes(body[i:i+40])!r})'
+            )
+        size = int(body[i:j].split(b';', 1)[0], 16)
+        i = j + 2
+        if size == 0:
+            break
+        out += body[i : i + size]
+        i += size + 2  # skip chunk data + trailing CRLF
+    return bytes(out)
+
+
+def _assert_relayed(raw):
+    """Split a raw HTTP response, dechunk if needed, assert byte-exact relay."""
+    assert raw[:12] == b'HTTP/1.1 200', f'status line: {raw[:40]!r}'
+
+    sep = raw.index(b'\r\n\r\n')
+    head = raw[:sep]
+    body = bytes(raw[sep + 4 :])
+
+    if b'transfer-encoding: chunked' in head.lower():
+        body = _dechunk(body)
+
+    # A truncated relay shows up as a short body (early EOF); the length assert
+    # pins it. PATTERN (16 B) divides SIZE exactly, so expected is one repeat.
+    assert len(body) == SIZE, (
+        f'relayed body truncated: got {len(body)} of {SIZE} bytes'
+    )
+    assert body == PATTERN * (SIZE // len(PATTERN)), 'relayed body mismatch'
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_response_plain():
+    """64 MiB chunked response relayed over a plain listener. (#72 H1)"""
+    proc = _run_chunked_response()
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_PORT}'}}
+                ],
+            }
+        ), 'plain proxy configuration'
+
+        sock = client.get(port=8080, no_recv=True)
+        try:
+            _assert_relayed(_recv_all(sock))
+        finally:
+            sock.close()
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_response_tls():
+    """64 MiB chunked response relayed over a TLS listener. (#72 H2 — Gitea path)"""
+    proc = _run_chunked_response()
+    try:
+        client.certificate()
+
+        assert 'success' in client.conf(
+            {
+                "listeners": {
+                    "*:8443": {
+                        "pass": "routes",
+                        "tls": {"certificate": "default"},
+                    }
+                },
+                "routes": [
+                    {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_PORT}'}}
+                ],
+            }
+        ), 'TLS proxy configuration'
+
+        sock = client.get_ssl(port=8443, no_recv=True)
+        try:
+            _assert_relayed(_recv_all(sock))
+        finally:
+            sock.close()
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_response_client_abort(findall):
+    """Client RST mid-TLS-write must not log SSL_write broken pipe at [alert].
+
+    Reproduces the Gitea `git clone` incident (#72 case 7): the client aborts
+    while FreeUnit is still relaying the chunked body, so the next SSL_write to
+    the client fails with EPIPE. On OpenSSL 3.x the broken pipe lands in the
+    error *queue* (errno reads EAGAIN), so nxt_openssl_log_error_level() misroutes
+    the system-library reason through the SSL_R_* switch and hits the NXT_LOG_ALERT
+    default. A plain client disconnect must never be an alert.
+
+    conftest's check_alerts() fails the test on any unexpected [alert]; the
+    explicit assert below names the exact offender for clarity.
+    """
+    proc = _run_chunked_response(port=UPSTREAM_ABORT_PORT)
+    try:
+        client.certificate()
+
+        assert 'success' in client.conf(
+            {
+                "listeners": {
+                    "*:8443": {
+                        "pass": "routes",
+                        "tls": {"certificate": "default"},
+                    }
+                },
+                "routes": [
+                    {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_ABORT_PORT}'}}
+                ],
+            }
+        ), 'client-abort proxy configuration'
+
+        sock = client.get_ssl(port=8443, no_recv=True)
+        # Read one record so the relay is mid-stream, then hard-close: SO_LINGER
+        # with a 0 timeout sends a RST instead of a graceful FIN, so the router's
+        # next SSL_write to the client deterministically hits a broken pipe.
+        sock.settimeout(10)
+        sock.recv(16384)
+        sock.setsockopt(
+            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0)
+        )
+        sock.close()
+
+        # Give the router time to attempt the next write and log the result.
+        time.sleep(1)
+
+        assert not findall(r'\[alert\].*SSL_write.*failed'), (
+            'client disconnect logged SSL_write failure at [alert] '
+            '(nxt_openssl_log_error_level misroutes system-library EPIPE)'
+        )
+        assert findall(r'\[info\].*SSL_write.*failed'), (
+            'SSL_write broken-pipe path never fired — '
+            'fix in nxt_openssl_log_error_level may not have been exercised'
+        )
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_response_abort_mid():
+    """Upstream dies mid-chunked-stream: client sees truncation, router survives.
+
+    The upstream writes 4 MiB of chunks then closes the socket without the
+    terminal 0-chunk (#72 case 4). FreeUnit must relay what it received and
+    close cleanly — never hang or crash the router (enforced by conftest's
+    pid/alert checks). The relayed stream must therefore be truncated: it must
+    not end with a valid terminal chunk.
+    """
+    proc = _run_mode(UPSTREAM_ABORT_MID_PORT, 'abort-mid', size_mib=4)
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_ABORT_MID_PORT}'}}
+                ],
+            }
+        ), 'abort-mid proxy configuration'
+
+        sock = client.get(port=8080, no_recv=True)
+        try:
+            raw = _recv_all(sock, timeout=30)
+        finally:
+            sock.close()
+
+        assert raw[:12] == b'HTTP/1.1 200', f'status line: {raw[:40]!r}'
+        assert len(raw) > 200, f'suspiciously short response: {len(raw)} bytes'
+        # No terminal chunk: the relay was truncated, not completed.
+        assert not raw.endswith(b'0\r\n\r\n'), 'aborted relay ended with terminal chunk'
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_response_slow_drip():
+    """Slow chunked relay (drip << proxy_read_timeout) completes byte-exact.
+
+    Upstream emits one 512-byte chunk every 1 ms (#72 case 5). Well under the
+    default proxy read timeout, so the relay must complete intact.
+    """
+    size = 1 * 1024 * 1024
+    proc = _run_mode(UPSTREAM_SLOW_DRIP_PORT, 'slow-drip', size_mib=1, delay_ms=1)
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_SLOW_DRIP_PORT}'}}
+                ],
+            }
+        ), 'slow-drip proxy configuration'
+
+        sock = client.get(port=8080, no_recv=True)
+        try:
+            raw = _recv_all(sock, timeout=60)
+        finally:
+            sock.close()
+
+        assert raw[:12] == b'HTTP/1.1 200', f'status line: {raw[:40]!r}'
+        sep = raw.index(b'\r\n\r\n')
+        body = _dechunk(bytes(raw[sep + 4 :]))
+        assert len(body) == size, f'slow-drip body truncated: {len(body)} of {size}'
+        assert body == PATTERN * (size // len(PATTERN)), 'slow-drip body mismatch'
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_response_dup_te():
+    """Duplicate upstream Transfer-Encoding must not be relayed twice (#1088).
+
+    Upstream sends `Transfer-Encoding: chunked` twice with a valid chunked body
+    (#72 case 6). The client must see at most one Transfer-Encoding header; if
+    the response is relayed as 200/chunked, the body must still decode once,
+    byte-exact.
+    """
+    size = 1 * 1024 * 1024
+    proc = _run_mode(UPSTREAM_DUP_TE_PORT, 'dup-te', size_mib=1)
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_DUP_TE_PORT}'}}
+                ],
+            }
+        ), 'dup-te proxy configuration'
+
+        sock = client.get(port=8080, no_recv=True)
+        try:
+            raw = _recv_all(sock, timeout=30)
+        finally:
+            sock.close()
+
+        assert raw[:12] in (b'HTTP/1.1 200', b'HTTP/1.1 502', b'HTTP/1.1 400'), (
+            f'unexpected status: {raw[:40]!r}'
+        )
+        sep = raw.index(b'\r\n\r\n')
+        head = raw[:sep].lower()
+        te_count = head.count(b'transfer-encoding')
+        assert te_count <= 1, f'client saw {te_count} Transfer-Encoding headers'
+
+        if raw[:12] == b'HTTP/1.1 200' and b'transfer-encoding: chunked' in head:
+            body = _dechunk(bytes(raw[sep + 4 :]))
+            assert len(body) == size, f'dup-te body truncated: {len(body)} of {size}'
+            assert body == PATTERN * (size // len(PATTERN)), 'dup-te body mismatch'
+    finally:
+        proc.terminate()
+        proc.wait()


### PR DESCRIPTION
### Proposed changes
  Gitea `git clone` over a TLS proxy failed with GnuTLS recv error (-9). The
  router crashed mid-relay; three distinct defects surfaced.

  Defect A (src/nxt_openssl.c): a client RST mid-write surfaced EPIPE/ECONNRESET
  in the OpenSSL error queue (ERR_LIB_SYS) while errno read EAGAIN, so
  nxt_openssl_log_error_level misrouted it through the SSL_R_* switch and logged a
  plain disconnect at [alert]. Classify ERR_LIB_SYS via nxt_socket_error_level so
  EPIPE/ECONNRESET log at [info].

  Defect B (src/nxt_h1proto.c, nxt_h1p_peer_close): the client abort freed the
  request while the upstream peer connection still held a queued read event and a
  registered fd; the deferred nxt_conn_io_read then dereferenced freed memory
  (use-after-free → SIGSEGV, nginx/unit#828). Set c->block_read = 1 and disable
  the read timer before the deferred close so queued work bails.

  Defect C (src/nxt_h1proto.c, nxt_h1p_peer_closed): an upstream closing a chunked
  response without the terminal 0\r\n\r\n was masked by synthesising our own last
  buffer — the client saw a "complete" response despite a truncated body. Route
  premature EOF (chunked && !chunked_parse.last) to NXT_HTTP_BAD_GATEWAY; the error
  path resets the client so the truncation is visible, matching nginx.

  Test infrastructure:
  - test/fake_upstream/: std-only Rust mock upstream, 8 modes (chunked-response, abort-mid, slow-drip, dup-te, ...) exercising the relay path
  - test/test_fake_upstream_proxy_chunked_response.py: 6 regression tests (64 MiB plain/TLS relay, client-abort, abort-mid, slow-drip, dup-te)
  - test/README.md, test/fake_upstream/{README,PLAN}.md: docs + reserved-port registry

  Verified: 6/6 pass (5.74s) on the --openssl --tests build.
### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [x] If applicable, I have updated documentation