### PR TITLE
fix(isolation): close rootfs automount reload race (#83)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,13 @@ Changes with FreeUnit 1.35.6                                     25 Jun 2026
     *) Bugfix: remove unreachable Protocol::HttpJson dead-code arm from the
        OTel exporter; only HttpBinary was ever selected.
 
+    *) Bugfix: fix a rootfs automount reload race: sever the worker's mount
+       namespace propagation (MS_REC|MS_PRIVATE) before mounting and let a
+       per-worker automount be reaped with the namespace instead of being
+       unmounted from the host, so a configuration reload no longer races the
+       previous worker generation's teardown against the new prototype's
+       procfs mount (freeunitorg/freeunit#83).
+
 
 Changes with FreeUnit 1.35.5                                     29 May 2026
 

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -757,6 +757,22 @@ nxt_isolation_unmount_all(nxt_task_t *task, nxt_process_t *process)
 
     nxt_debug(task, "unmount all (%s)", process->name);
 
+#if (NXT_HAVE_CLONE_NEWNS)
+    /*
+     * A worker that ran in its own mount namespace had all of its mounts
+     * reaped by the kernel when that namespace died on process exit.
+     * Unmounting the same host paths here is both pointless (the mounts are
+     * not present in the host namespace — this is the EINVAL we used to log)
+     * and unsafe: it races the next worker generation's prototype, which
+     * mounts the identical <rootfs>/proc path (freeunitorg/freeunit#83).
+     * The non-namespaced (chroot) path below still needs the host-side
+     * umount2, so only skip when CLONE_NEWNS was in effect.
+     */
+    if (nxt_is_clone_flag_set(process->isolation.clone.flags, NEWNS)) {
+        return;
+    }
+#endif
+
     automount = &process->isolation.automount;
     mounts = process->isolation.mounts;
     n = mounts->nelts;
@@ -790,6 +806,30 @@ nxt_isolation_prepare_rootfs(nxt_task_t *task, nxt_process_t *process)
 
     n = mounts->nelts;
     mnt = mounts->elts;
+
+#if (NXT_HAVE_CLONE_NEWNS)
+    /*
+     * unshare(CLONE_NEWNS) copies the host mount tree *and* its propagation
+     * type.  On a systemd host "/" (and "/tmp", where a rootfs often lives) is
+     * MS_SHARED, so the new namespace starts as a peer of the host and the
+     * mounts below would propagate out to it.  pivot_root() only severs
+     * propagation later (nxt_isolation_pivot_root), so during this loop a
+     * concurrent host-side umount2(<rootfs>/proc) from the previous worker
+     * generation's teardown races our mount of the same path, yielding a
+     * transient "mount(...proc...) ENOENT" and a respawn storm
+     * (freeunitorg/freeunit#83).
+     *
+     * Detach the whole namespace from the host peer group *before* mounting.
+     * MS_PRIVATE (not MS_SLAVE) is required: a slave still receives propagation
+     * from its former master, so a host umount would propagate back in.
+     */
+    if (nxt_is_clone_flag_set(process->isolation.clone.flags, NEWNS)) {
+        if (nxt_slow_path(mount("", "/", "", MS_REC | MS_PRIVATE, "") != 0)) {
+            nxt_alert(task, "mount(\"/\", MS_REC|MS_PRIVATE) %E", nxt_errno);
+            return NXT_ERROR;
+        }
+    }
+#endif
 
     for (i = 0; i < n; i++) {
         dst = mnt[i].dst;


### PR DESCRIPTION
## Summary

Fixes the rootfs automount reload race tracked in #83 — the root cause behind the flaky `test_go_isolation_rootfs_automount_tmpfs[_regression]` failure on **go-1.25** (green on go-1.26 purely by timing; see PR #78 run `27793786107`).

> **Stacking note:** the substantive change is a single commit — `9b3f26cc fix(isolation): close rootfs automount reload race` (40 lines in `src/nxt_isolation.c`). Because the `pre-1.35.6` base does not yet carry the in-flight 1.35.6 hardening commits (incl. `03e6b0ee`, the `openat2(RESOLVE_BENEATH)` work this fix sits on top of), the diff currently also shows those commits. **Review the last commit.** Once the hardening lands on `pre-1.35.6`, this collapses to the one-commit fix.

## Root cause

For a `rootfs` app with `namespaces.mount: true`, the child sets up as:
`unshare(CLONE_NEWNS)` → `nxt_isolation_prepare_rootfs()` mounts `<rootfs>/proc` → **only then** `pivot_root()` severs propagation.

`unshare(CLONE_NEWNS)` copies the host mount tree **and its propagation type**; on a systemd host `/` (and `/tmp`, where the test rootfs lives) is `MS_SHARED`, so the new namespace starts as a peer of the host. During the mount loop the new `<rootfs>/proc` is still propagation-linked to the host — exactly while the previous worker generation's host-side teardown does `umount2(<rootfs>/proc, MNT_DETACH)` on the same path. They collide → `mount(...proc...) ENOENT` → prototype exits 1 → respawn storm → never converges (`status=None`) → ~53 leaked router fds.

## The fix — two additive, `CLONE_NEWNS`-gated changes in `src/nxt_isolation.c`

1. **`nxt_isolation_prepare_rootfs()`** — make the new namespace root recursively private (`mount("", "/", MS_REC|MS_PRIVATE)`) **before** the mount loop (above the `openat2` check). `MS_PRIVATE`, not `MS_SLAVE`: a slave still receives propagation inbound, so a host umount would propagate back in. Blocks both directions.
2. **`nxt_isolation_unmount_all()`** — when the worker had its own mount namespace, return early instead of host-side `umount2`. Those mounts are reaped with the namespace on exit; the host `umount2` was the `(22: Invalid argument)` no-op that raced the next generation.

The non-namespaced (chroot) path is unchanged and still unmounts in the host namespace. The `openat2 RESOLVE_BENEATH` check is untouched.

## Verification

- Builds clean (`make`, no warnings; `unitd` links).
- Authoritative check is the **go-1.25** matrix job (the failing toolchain) — local repro isn't possible on go-1.26.
  `sudo pytest-3 test/test_go_isolation.py::test_go_isolation_rootfs_automount_tmpfs_regression`
- The transient `mount(...proc...) (2: No such file or directory)` alert should no longer appear, and router fds should stay bounded across the 100× reload loop.

## Follow-up (separate commit, after this is green on go-1.25)

Remove `skip_alert(_TMPFS_RELOAD_ALERT)` in `test/test_go_isolation.py` (`:413`/`:422`) so the alert becomes a hard regression guard rather than being skipped.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
