### PR TITLE
fix(http): reject control characters in set_headers names and values

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -2849,10 +2849,48 @@ nxt_conf_vldt_object_conf_commands(nxt_conf_validation_t *vldt,
 #endif
 
 
+/*
+ * RFC 9110 token characters, the only bytes allowed in a header field
+ * name: "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+ * "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA.
+ */
+static nxt_bool_t
+nxt_conf_vldt_header_name_is_token(const nxt_str_t *name)
+{
+    u_char  c;
+    size_t  i;
+
+    for (i = 0; i < name->length; i++) {
+        c = name->start[i];
+
+        if ((c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9'))
+        {
+            continue;
+        }
+
+        switch (c) {
+        case '!': case '#': case '$': case '%': case '&': case '\'':
+        case '*': case '+': case '-': case '.': case '^': case '_':
+        case '`': case '|': case '~':
+            continue;
+        }
+
+        return 0;
+    }
+
+    return 1;
+}
+
+
 static nxt_int_t
 nxt_conf_vldt_response_header(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_conf_value_t *value)
 {
+    u_char      c;
+    size_t      i;
+    nxt_int_t   ret;
     nxt_str_t   str;
     nxt_uint_t  type;
 
@@ -2861,6 +2899,13 @@ nxt_conf_vldt_response_header(nxt_conf_validation_t *vldt, nxt_str_t *name,
     if (name->length == 0) {
         return nxt_conf_vldt_error(vldt, "The response header name "
                                          "must not be empty.");
+    }
+
+    if (!nxt_conf_vldt_header_name_is_token(name)) {
+        return nxt_conf_vldt_error(vldt, "The response header name \"%V\" "
+                                         "contains characters that are not "
+                                         "allowed in a header field name.",
+                                         name);
     }
 
     if (nxt_strstr_eq(name, &content_length)) {
@@ -2878,7 +2923,26 @@ nxt_conf_vldt_response_header(nxt_conf_validation_t *vldt, nxt_str_t *name,
         nxt_conf_get_string(value, &str);
 
         if (nxt_is_tstr(&str)) {
-            return nxt_conf_vldt_var(vldt, name, &str);
+            ret = nxt_conf_vldt_var(vldt, name, &str);
+            if (ret != NXT_OK) {
+                return ret;
+            }
+        }
+
+        /*
+         * Scan the raw configured value (template markup included, which is
+         * plain printable ASCII) so a literal control character in a static
+         * segment of a templated value is rejected at load time just like a
+         * non-templated one, closing the response-splitting bypass.
+         */
+        for (i = 0; i < str.length; i++) {
+            c = str.start[i];
+
+            if ((c < 0x20 && c != '\t') || c == 0x7F) {
+                return nxt_conf_vldt_error(vldt, "The \"%V\" response header "
+                                           "value must not contain control "
+                                           "characters.", name);
+            }
         }
 
         return NXT_OK;

--- a/src/nxt_http_set_headers.c
+++ b/src/nxt_http_set_headers.c
@@ -68,6 +68,37 @@ nxt_http_set_headers_init(nxt_router_conf_t *rtcf, nxt_http_action_t *action,
 }
 
 
+/*
+ * Reject values that would inject a header boundary into the response.
+ * Templated values (e.g. $uri, $arg_*) can carry CR/LF/NUL bytes if the
+ * client encodes them in the request, and writing those bytes verbatim
+ * into the wire serialiser yields HTTP response splitting.  Static
+ * config values are operator-controlled and trusted, but the check is
+ * cheap enough to apply to both paths.
+ *
+ * Per the RFC 9110 field-value grammar, all control bytes other than
+ * HTAB are rejected, including DEL (0x7F); lenient downstream proxies
+ * may otherwise reinterpret them.  HTAB and high (0x80+) bytes are
+ * left alone.
+ */
+static nxt_bool_t
+nxt_http_header_value_is_safe(const nxt_str_t *v)
+{
+    u_char  c;
+    size_t  i;
+
+    for (i = 0; i < v->length; i++) {
+        c = v->start[i];
+
+        if ((c < 0x20 && c != '\t') || c == 0x7F) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+
 static nxt_http_field_t *
 nxt_http_resp_header_find(nxt_http_request_t *r, u_char *name, size_t length)
 {
@@ -94,6 +125,7 @@ nxt_http_resp_header_find(nxt_http_request_t *r, u_char *name, size_t length)
 nxt_int_t
 nxt_http_set_headers(nxt_http_request_t *r)
 {
+    u_char                 *rejected;
     nxt_int_t              ret;
     nxt_uint_t             i, n;
     nxt_str_t              *value;
@@ -122,6 +154,11 @@ nxt_http_set_headers(nxt_http_request_t *r)
         return NXT_ERROR;
     }
 
+    rejected = nxt_mp_zalloc(r->mem_pool, n);
+    if (nxt_slow_path(rejected == NULL)) {
+        return NXT_ERROR;
+    }
+
     for (i = 0; i < n; i++) {
         hv = &header[i];
 
@@ -144,9 +181,32 @@ nxt_http_set_headers(nxt_http_request_t *r)
                 return NXT_ERROR;
             }
         }
+
+        if (value[i].start != NULL
+            && nxt_slow_path(!nxt_http_header_value_is_safe(&value[i])))
+        {
+            nxt_log(&r->task, NXT_LOG_INFO,
+                    "set_headers \"%V\": dropping value containing control "
+                    "bytes (HTTP response-splitting protection)",
+                    &hv->name);
+
+            /*
+             * Mark the entry as rejected instead of clearing the value:
+             * a NULL value means "delete this header", and letting an
+             * attacker-triggered rejection remove an existing response
+             * header (e.g. an app-emitted X-Frame-Options) would fail
+             * open.  Rejected entries are skipped entirely below, so a
+             * pre-existing same-named header survives untouched.
+             */
+            rejected[i] = 1;
+        }
     }
 
     for (i = 0; i < n; i++) {
+        if (rejected[i]) {
+            continue;
+        }
+
         hv = &header[i];
 
         f = nxt_http_resp_header_find(r, hv->name.start, hv->name.length);


### PR DESCRIPTION
## Summary

Reject HTTP control characters in `set_headers` header **names** and **values**
to prevent response-header injection / response splitting.

`set_headers` values can be templated (`$uri`, `$arg_*`), so a client can encode
CR/LF/NUL into a request and have it written verbatim into the response header
block — HTTP response splitting.

- **Runtime value check** (`nxt_http_set_headers.c`): reject all control bytes
  `< 0x20` except HTAB, plus DEL (`0x7F`), per the RFC 9110 field-value grammar.
  HTAB and high/UTF-8 bytes are preserved.
- **Fails closed, not open.** A rejected value is *skipped*, not cleared —
  clearing a value means "delete this header", so an attacker-triggered
  rejection would otherwise *remove* an existing same-named response header
  (e.g. an app-emitted `X-Frame-Options`). Rejected entries are marked and
  skipped so a pre-existing header survives untouched; the legitimate
  `"Header": null` delete path is unchanged.
- **Config-time name validation** (`nxt_conf_validation.c`): enforce the RFC 9110
  token grammar on response-header names and reject control bytes in static
  string values, so a control-API client cannot define a name/value carrying
  CRLF and operator typos fail at config load rather than silently per-request.

## Files

- `src/nxt_http_set_headers.c`
- `src/nxt_conf_validation.c`

## Tests

`./configure --openssl && make` builds clean with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
