### PR TITLE
fix(port): authorize privileged IPC senders by kernel-validated PID

### DIFF
--- a/src/nxt_cert.c
+++ b/src/nxt_cert.c
@@ -1175,12 +1175,20 @@ nxt_cert_store_get_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_runtime_t        *rt;
     nxt_port_msg_type_t  type;
 
-    port = nxt_runtime_port_find(task->thread->runtime, msg->port_msg.pid,
+    /*
+     * Look up the sender's port via the kernel-validated PID
+     * (SCM_CREDENTIALS).  msg->port_msg.pid is self-declared, so using
+     * it would let a compromised worker spoof the controller / router
+     * and pull arbitrary certificate material out of main.
+     */
+    port = nxt_runtime_port_find(task->thread->runtime,
+                                 nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
 
     if (nxt_slow_path(port == NULL)) {
         nxt_alert(task, "process port not found (pid %PI, reply_port %d)",
-                  msg->port_msg.pid, msg->port_msg.reply_port);
+                  nxt_recv_msg_cmsg_pid(msg), msg->port_msg.reply_port);
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -1188,7 +1196,8 @@ nxt_cert_store_get_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
                       && port->type != NXT_PROCESS_ROUTER))
     {
         nxt_alert(task, "process %PI cannot store certificates",
-                  msg->port_msg.pid);
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -1282,12 +1291,14 @@ nxt_cert_store_delete_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     if (nxt_slow_path(ctl_port == NULL)) {
         nxt_alert(task, "controller port not found");
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
     if (nxt_slow_path(nxt_recv_msg_cmsg_pid(msg) != ctl_port->pid)) {
         nxt_alert(task, "process %PI cannot delete certificates",
                   nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -632,16 +632,43 @@ nxt_main_process_created_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     rt = task->thread->runtime;
 
-    port = nxt_runtime_port_find(rt, msg->port_msg.pid,
+    /*
+     * Look up the sender's port via the kernel-validated PID
+     * (SCM_CREDENTIALS).  The PROCESS_CREATED message is sent by the
+     * newly created process itself (nxt_process_send_created()), and
+     * main registers that process's port under the same kernel PID
+     * (fork() return value, or the cmsg PID from the WHOAMI exchange),
+     * so this is a 1:1 replacement of the self-declared, spoofable
+     * msg->port_msg.pid.  Without it a compromised worker could pose
+     * as a process in the CREATING state and have main perform the
+     * privileged uid_map/gid_map writes at a moment of its choosing.
+     */
+    port = nxt_runtime_port_find(rt, nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
     if (nxt_slow_path(port == NULL)) {
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
+    /*
+     * Validate the process state at runtime rather than with nxt_assert():
+     * the assertions compile out in release builds (leaving no check) and
+     * abort main in debug builds.  Now that the sender is authenticated by
+     * kernel PID, only the process itself can reach here, but a compromised
+     * worker could still send a premature or duplicate PROCESS_CREATED for
+     * itself; reject anything not in the CREATING state instead of
+     * re-running the privileged uid_map/gid_map setup or crashing.
+     */
     process = port->process;
 
-    nxt_assert(process != NULL);
-    nxt_assert(process->state == NXT_PROCESS_STATE_CREATING);
+    if (nxt_slow_path(process == NULL
+                      || process->state != NXT_PROCESS_STATE_CREATING))
+    {
+        nxt_alert(task, "process %PI sent PROCESS_CREATED in unexpected state",
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
 
 #if (NXT_HAVE_LINUX_NS && NXT_HAVE_CLONE_NEWUSER)
     if (nxt_is_clone_flag_set(process->isolation.clone.flags, NEWUSER)) {
@@ -1118,16 +1145,25 @@ nxt_main_port_socket_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_listening_socket_t  ls;
     u_char                  message[2048];
 
-    port = nxt_runtime_port_find(task->thread->runtime, msg->port_msg.pid,
+    /*
+     * Look up the sender's port via the kernel-validated PID
+     * (SCM_CREDENTIALS).  msg->port_msg.pid is self-declared, so using
+     * it would let a compromised worker impersonate the router and
+     * ask main to bind a privileged listening socket.
+     */
+    port = nxt_runtime_port_find(task->thread->runtime,
+                                 nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
     if (nxt_slow_path(port == NULL)) {
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
     if (nxt_slow_path(port->type != NXT_PROCESS_ROUTER)) {
         nxt_alert(task, "process %PI cannot create listener sockets",
-                  msg->port_msg.pid);
+                  nxt_recv_msg_cmsg_pid(msg));
 
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -1333,17 +1369,34 @@ nxt_main_port_socket_unlink_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     size_t               i;
     nxt_buf_t            *b;
     const char           *filename;
+    nxt_port_t           *router_port;
     nxt_runtime_t        *rt;
     nxt_sockaddr_t       *sa;
     nxt_listen_socket_t  *ls;
+
+    rt = task->thread->runtime;
+
+    /*
+     * Privileged unlink of an attacker-controllable path.  Only accept
+     * from the router; identify the sender via SCM_CREDENTIALS so a
+     * compromised worker cannot spoof the message and have main remove
+     * arbitrary files.
+     */
+    router_port = rt->port_by_type[NXT_PROCESS_ROUTER];
+    if (nxt_slow_path(router_port == NULL
+                      || nxt_recv_msg_cmsg_pid(msg) != router_port->pid))
+    {
+        nxt_alert(task, "process %PI cannot unlink listener sockets",
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
 
     b = msg->buf;
     sa = (nxt_sockaddr_t *) b->mem.pos;
 
     filename = sa->u.sockaddr_un.sun_path;
     unlink(filename);
-
-    rt = task->thread->runtime;
 
     for (i = 0; i < rt->listen_sockets->nelts; i++) {
         const char  *name;
@@ -1448,8 +1501,22 @@ nxt_main_port_modules_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     rt = task->thread->runtime;
 
-    if (msg->port_msg.pid != rt->port_by_type[NXT_PROCESS_DISCOVERY]->pid) {
-        nxt_alert(task, "process %PI cannot send modules", msg->port_msg.pid);
+    /*
+     * Use the kernel-validated sender PID (SCM_CREDENTIALS) for both
+     * the authorisation check and the port lookup: msg->port_msg.pid
+     * is self-declared by the sender and a compromised worker can
+     * forge it to impersonate discovery / controller / router.  Guard
+     * against a NULL discovery slot — discovery exits after sending
+     * the modules message, so a late or duplicated message can arrive
+     * after rt->port_by_type[DISCOVERY] has been cleared.
+     */
+    if (nxt_slow_path(rt->port_by_type[NXT_PROCESS_DISCOVERY] == NULL
+                      || nxt_recv_msg_cmsg_pid(msg)
+                         != rt->port_by_type[NXT_PROCESS_DISCOVERY]->pid))
+    {
+        nxt_alert(task, "process %PI cannot send modules",
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -1458,7 +1525,8 @@ nxt_main_port_modules_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         return;
     }
 
-    port = nxt_runtime_port_find(task->thread->runtime, msg->port_msg.pid,
+    port = nxt_runtime_port_find(task->thread->runtime,
+                                 nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
 
     if (nxt_fast_path(port != NULL)) {
@@ -1620,8 +1688,20 @@ nxt_main_port_conf_store_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     ctl_port = rt->port_by_type[NXT_PROCESS_CONTROLLER];
 
-    if (nxt_slow_path(msg->port_msg.pid != ctl_port->pid)) {
-        nxt_alert(task, "process %PI cannot store conf", msg->port_msg.pid);
+    /*
+     * Use the kernel-validated sender PID (SCM_CREDENTIALS): msg->port_msg.pid
+     * is self-declared and a compromised worker can forge it to pose as the
+     * controller and have main rewrite the persistent configuration store —
+     * arbitrary configuration on the next reload is root code execution.
+     * The NULL guard covers the early-startup / late-teardown window in
+     * which the controller slot is unset.
+     */
+    if (nxt_slow_path(ctl_port == NULL
+                      || nxt_recv_msg_cmsg_pid(msg) != ctl_port->pid))
+    {
+        nxt_alert(task, "process %PI cannot store conf",
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -1728,10 +1808,30 @@ nxt_main_port_access_log_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     u_char               *path;
     nxt_int_t            ret;
     nxt_file_t           file;
-    nxt_port_t           *port;
+    nxt_port_t           *port, *router_port;
+    nxt_runtime_t        *rt;
     nxt_port_msg_type_t  type;
 
     nxt_debug(task, "opening access log file");
+
+    rt = task->thread->runtime;
+
+    /*
+     * Privileged file open as root with an attacker-controllable path.
+     * Only accept from the router; identify the sender via
+     * SCM_CREDENTIALS so a compromised worker cannot spoof the message
+     * and have main create / append to /etc/passwd or any other
+     * privileged path.
+     */
+    router_port = rt->port_by_type[NXT_PROCESS_ROUTER];
+    if (nxt_slow_path(router_port == NULL
+                      || nxt_recv_msg_cmsg_pid(msg) != router_port->pid))
+    {
+        nxt_alert(task, "process %PI cannot open access log",
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
 
     path = msg->buf->mem.pos;
 
@@ -1746,7 +1846,8 @@ nxt_main_port_access_log_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     type = (ret == NXT_OK) ? NXT_PORT_MSG_RPC_READY_LAST | NXT_PORT_MSG_CLOSE_FD
                            : NXT_PORT_MSG_RPC_ERROR;
 
-    port = nxt_runtime_port_find(task->thread->runtime, msg->port_msg.pid,
+    port = nxt_runtime_port_find(task->thread->runtime,
+                                 nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
 
     if (nxt_fast_path(port != NULL)) {

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -231,6 +231,31 @@ struct nxt_port_recv_msg_s {
 #define nxt_recv_msg_cmsg_pid_ref(msg)  (NULL)
 #endif
 
+
+/*
+ * Close any file descriptors the peer attached to a received message via
+ * SCM_RIGHTS.  A privileged handler that rejects a message (unauthorized
+ * or malformed sender) must call this before returning: the port
+ * dispatcher does not reclaim descriptors once the handler returns, and
+ * a compromised peer can attach fds to a forged message, so leaving them
+ * open on the reject path would let it exhaust the receiver's descriptor
+ * table.
+ */
+nxt_inline void
+nxt_port_recv_msg_close_fds(nxt_port_recv_msg_t *msg)
+{
+    if (msg->fd[0] != -1) {
+        nxt_fd_close(msg->fd[0]);
+        msg->fd[0] = -1;
+    }
+
+    if (msg->fd[1] != -1) {
+        nxt_fd_close(msg->fd[1]);
+        msg->fd[1] = -1;
+    }
+}
+
+
 typedef struct nxt_app_s  nxt_app_t;
 
 struct nxt_port_s {

--- a/src/nxt_port_socket.c
+++ b/src/nxt_port_socket.c
@@ -797,6 +797,14 @@ nxt_port_read_handler(nxt_task_t *task, void *obj, void *data)
             msg.fd[0] = -1;
             msg.fd[1] = -1;
 
+#if (NXT_USE_CMSG_PID)
+            /*
+             * Fail safe: a message without SCM_CREDENTIALS must never
+             * be attributed to a valid sender PID.
+             */
+            msg.cmsg_pid = -1;
+#endif
+
             ret = nxt_socket_msg_oob_get(&oob, msg.fd,
                                          nxt_recv_msg_cmsg_pid_ref(&msg));
             if (nxt_slow_path(ret != NXT_OK)) {
@@ -867,6 +875,22 @@ nxt_port_queue_read_handler(nxt_task_t *task, void *obj, void *data)
 
     for ( ;; ) {
 
+        /*
+         * Fail safe: messages dequeued from the shared memory queue carry
+         * neither file descriptors nor socket credentials.  Reset both up
+         * front so a queue message can never be seen carrying an fd or a
+         * sender PID left over from a socket message processed on a previous
+         * loop iteration.  The fd reset matters for the reject paths in the
+         * privileged handlers: they call nxt_port_recv_msg_close_fds(), which
+         * would otherwise close a stale descriptor in this process.  The
+         * socket and suspended-message paths overwrite these fields below.
+         */
+        msg.fd[0] = -1;
+        msg.fd[1] = -1;
+#if (NXT_USE_CMSG_PID)
+        msg.cmsg_pid = -1;
+#endif
+
         if (port->from_socket == 0) {
             n = nxt_port_queue_recv(queue, qmsg);
 
@@ -902,6 +926,10 @@ nxt_port_queue_read_handler(nxt_task_t *task, void *obj, void *data)
                 n = smsg->size;
                 msg.fd[0] = smsg->fd[0];
                 msg.fd[1] = smsg->fd[1];
+
+#if (NXT_USE_CMSG_PID)
+                msg.cmsg_pid = smsg->cmsg_pid;
+#endif
 
                 smsg->size = 0;
 
@@ -948,6 +976,11 @@ nxt_port_queue_read_handler(nxt_task_t *task, void *obj, void *data)
             if (n > 0) {
                 msg.fd[0] = -1;
                 msg.fd[1] = -1;
+
+#if (NXT_USE_CMSG_PID)
+                /* Fail safe, see nxt_port_read_handler(). */
+                msg.cmsg_pid = -1;
+#endif
 
                 ret = nxt_socket_msg_oob_get(&oob, msg.fd,
                                              nxt_recv_msg_cmsg_pid_ref(&msg));
@@ -1016,6 +1049,10 @@ nxt_port_queue_read_handler(nxt_task_t *task, void *obj, void *data)
                     smsg->size = n;
                     smsg->fd[0] = msg.fd[0];
                     smsg->fd[1] = msg.fd[1];
+
+#if (NXT_USE_CMSG_PID)
+                    smsg->cmsg_pid = msg.cmsg_pid;
+#endif
 
                     continue;
                 }

--- a/src/nxt_script.c
+++ b/src/nxt_script.c
@@ -541,12 +541,20 @@ nxt_script_store_get_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_runtime_t        *rt;
     nxt_port_msg_type_t  type;
 
-    port = nxt_runtime_port_find(task->thread->runtime, msg->port_msg.pid,
+    /*
+     * Look up the sender's port via the kernel-validated PID
+     * (SCM_CREDENTIALS).  msg->port_msg.pid is self-declared, so using
+     * it would let a compromised worker spoof the controller / router
+     * and pull arbitrary script material out of main.
+     */
+    port = nxt_runtime_port_find(task->thread->runtime,
+                                 nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
 
     if (nxt_slow_path(port == NULL)) {
         nxt_alert(task, "process port not found (pid %PI, reply_port %d)",
-                  msg->port_msg.pid, msg->port_msg.reply_port);
+                  nxt_recv_msg_cmsg_pid(msg), msg->port_msg.reply_port);
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -554,7 +562,8 @@ nxt_script_store_get_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
                       && port->type != NXT_PROCESS_ROUTER))
     {
         nxt_alert(task, "process %PI cannot store scripts",
-                  msg->port_msg.pid);
+                  nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -647,12 +656,14 @@ nxt_script_store_delete_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     if (nxt_slow_path(ctl_port == NULL)) {
         nxt_alert(task, "controller port not found");
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
     if (nxt_slow_path(nxt_recv_msg_cmsg_pid(msg) != ctl_port->pid)) {
         nxt_alert(task, "process %PI cannot delete scripts",
                   nxt_recv_msg_cmsg_pid(msg));
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 


### PR DESCRIPTION
## Summary

Authorize privileged inter-process (port) messages by the **kernel-validated
sender PID** (`SCM_CREDENTIALS` on Linux, `LOCAL_CREDS`/`cmsgcred` on FreeBSD)
instead of the self-declared `msg->port_msg.pid`, which any worker can forge.

The main process performs several privileged operations on behalf of other Unit
processes — binding listening sockets, unlinking socket files, opening the
access log as root, storing certificates/scripts/config, and writing
`uid_map`/`gid_map` for user-namespaced children. Each was gated on
`msg->port_msg.pid`, a value the sender writes itself, so a compromised language
worker could impersonate the router / controller / discovery and drive those
operations.

Every such handler now identifies the sender via the kernel credential PID:

- `nxt_main_port_socket_handler` — bind privileged listeners (router only).
- `nxt_main_port_socket_unlink_handler` — unlink an attacker-controllable path
  (router only).
- `nxt_main_port_access_log_handler` — open a root file at an
  attacker-controllable path (router only).
- `nxt_main_port_modules_handler` — accept modules (discovery only).
- `nxt_main_port_conf_store_handler` — rewrite the persistent config store
  (controller only); arbitrary config on the next reload is root code execution.
- `nxt_cert_store_get_handler` / `nxt_script_store_get_handler` — release
  certificate / script material (controller or router only).
- `nxt_main_process_created_handler` — the `uid_map`/`gid_map` write for
  `CLONE_NEWUSER` children. `PROCESS_CREATED` is sent by the created child itself
  and main registers its port under the same kernel PID, so this is a 1:1
  replacement of the spoofable field; previously a forged PID could trigger the
  root credential write against another process's creation window.

Also:

- NULL-slot guards on the discovery / controller port lookups (those slots are
  cleared on teardown).
- `cmsg_pid` is initialised to `-1` in the port read handlers so a
  credential-less message can never authorize, and is preserved across the queue
  suspend/restore path so a legitimately-deferred privileged message keeps its
  validated PID.

Credential-based sender authorization is enforced where `SO_PASSCRED` /
`LOCAL_CREDS` is available (Linux/FreeBSD); other platforms retain the prior
self-declared check via the `nxt_recv_msg_cmsg_pid` macro.

## Files

- `src/nxt_main_process.c`, `src/nxt_port_socket.c`, `src/nxt_cert.c`,
  `src/nxt_script.c`

## Tests

`./configure --openssl && make` builds clean. The process-creation / isolation
paths (incl. `CLONE_NEWPID` / `CLONE_NEWUSER`) are exercised by the suite's
isolation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
