### PR TITLE
test: cover 1.35.6 security hardening (routing, proxy, TLS, chunked, JSON, Ruby)

### DIFF
--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -43,6 +43,7 @@ fake_upstream --port <N> --mode <mode> [--requests <N>] [--size <MiB>] [--delay-
 | `abort-mid` | as `chunked-response`, but after `--size` bytes closes the socket **without** the terminal `0\r\n\r\n` — upstream dies mid-stream (#72 case 4) |
 | `slow-drip` | chunked, one 512-byte chunk every `--delay-ms` ms, proper terminal chunk — relay vs `proxy_read_timeout` (#72 case 5) |
 | `dup-te` | 200 with `Transfer-Encoding: chunked` header sent **twice** + valid chunked body — duplicate-TE relay (#72 case 6, nginx/unit#1088) |
+| `overrun-cl` | 200 with a fixed `Content-Length` (100) but 150 body bytes — upstream overruns its advertised length. FreeUnit must relay exactly the advertised bytes and drop the excess (no response splitting), then close the connection as inconsistent |
 
 Deterministic body: byte at global offset `i` is `"0123456789abcdef"[i % 16]`,
 so a test regenerates the exact sequence and verifies the relayed body
@@ -70,6 +71,7 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 | Port | Token | Mode (CLI) | Rust handler | pytest |
 |------|-------|-----------|--------------|--------|
+| 7989 | `overrun_cl` | `overrun-cl` | `respond_overrun_cl` | `test_proxy_overrun_cl` (Content-Length overrun → excess truncated, no response splitting) |
 | 7990 | `echo` | `echo` | `respond` (echo arm) | — (shared sanity) |
 | 7991 | `strict` | `strict` | `handle` (Strict arm) | chunked **request** → CL (#445, #58) |
 | 7992 | `requires_cl` | `requires-cl` | `handle` (RequiresCl arm) | backend demands `Content-Length` (#1278) |

--- a/test/fake_upstream/src/main.rs
+++ b/test/fake_upstream/src/main.rs
@@ -22,6 +22,12 @@
 ///                    terminal chunk (relay vs proxy_read_timeout, #72 case 5)
 ///   dup-te           Transfer-Encoding: chunked header sent twice + valid
 ///                    chunked body (nginx/unit#1088, #72 case 6)
+///   overrun-cl       200 + fixed Content-Length but MORE body bytes than it
+///                    advertises. FreeUnit must truncate the relayed body to
+///                    the advertised length (never forward the excess, which
+///                    would enable response splitting) and close the
+///                    connection as inconsistent. Mirrors pytest
+///                    test_proxy_overrun_cl.
 ///
 /// --requests N   exit after handling N connections (default: run forever)
 /// --size N       chunked-response: response body size in MiB (default: 1)
@@ -45,7 +51,16 @@ enum Mode {
     AbortMid,
     SlowDrip,
     DupTe,
+    OverrunCl,
 }
+
+/// Advertised Content-Length and the number of unadvertised excess bytes for
+/// the `overrun-cl` mode. Kept tiny and fixed so the whole response fits one
+/// TCP segment (the excess lands in the same relay read as the declared tail,
+/// which is what exercises the truncation branch) and the test can regenerate
+/// the exact expected bytes.
+const OVERRUN_DECLARED: usize = 100;
+const OVERRUN_EXCESS: usize = 50;
 
 // ---------------------------------------------------------------------------
 
@@ -374,6 +389,37 @@ fn respond_dup_te(stream: &mut TcpStream, size: usize) {
     let _ = stream.flush();
 }
 
+/// Send a `Content-Length: OVERRUN_DECLARED` header but write
+/// `OVERRUN_DECLARED + OVERRUN_EXCESS` deterministic body bytes — an upstream
+/// that overruns its own advertised length. FreeUnit must relay exactly the
+/// advertised bytes to the client and drop the excess (forwarding it past the
+/// Content-Length already sent downstream would enable response splitting),
+/// then close the connection as inconsistent. Mirrors pytest
+/// `test_proxy_overrun_cl`.
+///
+/// The whole response (head + body) is written in a single syscall so the
+/// excess arrives in the same relay read as the declared tail — that is the
+/// path the truncation guard in nxt_h1p_peer_body_process protects.
+fn respond_overrun_cl(stream: &mut TcpStream) {
+    let total = OVERRUN_DECLARED + OVERRUN_EXCESS;
+
+    let mut resp = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n",
+        OVERRUN_DECLARED
+    )
+    .into_bytes();
+
+    for i in 0..total {
+        resp.push(PATTERN[i % PATTERN.len()]);
+    }
+
+    let _ = stream.write_all(&resp);
+    let _ = stream.flush();
+}
+
 fn handle(mut stream: TcpStream, opts: &Opts) {
     let req = match read_request(&stream) {
         Ok(r) => r,
@@ -398,6 +444,10 @@ fn handle(mut stream: TcpStream, opts: &Opts) {
 
         Mode::DupTe => {
             respond_dup_te(&mut stream, opts.size);
+        }
+
+        Mode::OverrunCl => {
+            respond_overrun_cl(&mut stream);
         }
 
         Mode::Echo => {
@@ -456,7 +506,7 @@ fn usage() -> ! {
     eprintln!(
         "Usage: fake_upstream --port <N> \
          --mode <requires-cl|no-te|strict|echo|chunked-response|\
-         abort-mid|slow-drip|dup-te> \
+         abort-mid|slow-drip|dup-te|overrun-cl> \
          [--requests <N>] [--size <MiB>] [--delay-ms <N>]"
     );
     process::exit(1);
@@ -489,6 +539,7 @@ fn main() {
                     "abort-mid" => Some(Mode::AbortMid),
                     "slow-drip" => Some(Mode::SlowDrip),
                     "dup-te" => Some(Mode::DupTe),
+                    "overrun-cl" => Some(Mode::OverrunCl),
                     _ => None,
                 });
             }

--- a/test/ruby/input_read_retained/config.ru
+++ b/test/ruby/input_read_retained/config.ru
@@ -24,7 +24,7 @@ app = Proc.new do |env|
         out = "leaked[#{leaked}]"
     end
 
-    ['200', { 'Content-Length' => out.bytesize.to_s }, [out]]
+    [200, { 'Content-Length' => out.bytesize.to_s }, [out]]
 end
 
 run app

--- a/test/ruby/input_read_retained/config.ru
+++ b/test/ruby/input_read_retained/config.ru
@@ -1,0 +1,30 @@
+# Retain the rack.input handle from the first request in a global, then read
+# it during a later request handled by the same worker. Each handle is bound to
+# its originating request (rctx->req_seq snapshot), so a stale handle must
+# yield nil instead of the current request's body -- otherwise a client could
+# read another client's request body on a shared worker (cross-request
+# disclosure). Regression guard for fix b10a68b4.
+$saved_input = nil
+
+app = Proc.new do |env|
+    if $saved_input.nil?
+        # First request: stash the handle without consuming it.
+        $saved_input = env['rack.input']
+        out = 'stashed'
+    else
+        # Second request: read the retained handle from the first request
+        # before touching this request's own input. A request-bound handle
+        # returns nil here; only a leaky one would expose this body.
+        leaked =
+            begin
+                $saved_input.read.to_s
+            rescue StandardError => e
+                "err:#{e.class}"
+            end
+        out = "leaked[#{leaked}]"
+    end
+
+    ['200', { 'Content-Length' => out.bytesize.to_s }, [out]]
+end
+
+run app

--- a/test/test_chunked.py
+++ b/test/test_chunked.py
@@ -147,6 +147,14 @@ def test_chunked_invalid():
     check_body('1\r\n\r\n1\r\n0\r\n\r\n')
     check_body('1\r\n1\r\n\r\n0\r\n\r\n')
 
+    # Non-hex chunk size.
+    check_body('z\r\nX\r\n0\r\n\r\n')
+
+    # Chunk size that overflows the size accumulator must be rejected,
+    # not silently wrapped (guards nxt_size_is_sufficient in the chunk
+    # parser).  17 hex digits overshoot a 64-bit accumulator.
+    check_body('1' + 'f' * 16 + '\r\nX\r\n0\r\n\r\n')
+
     # invalid transfer encoding header
 
     assert (

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -464,3 +464,43 @@ def test_unprivileged_user_error(require, skip_alert):
         },
         'applications',
     ), 'setting user'
+
+
+def test_json_deep_nesting():
+    # The controller caps JSON nesting depth so a pathologically deep
+    # payload cannot exhaust its stack.  Well past the cap it must be
+    # rejected cleanly while the control socket keeps serving.
+    depth = 10000
+    payload = '[' * depth + ']' * depth
+
+    assert 'error' in client.conf(payload), 'deep nesting rejected'
+
+    # Controller survived and still applies a valid configuration.
+    assert 'success' in client.conf(
+        {"listeners": {}, "routes": [], "applications": {}}
+    ), 'controller alive after deep nesting'
+
+
+def test_json_too_many_array_elements():
+    # Per-array element count is capped to bound heap usage on a
+    # malformed payload; just over the cap must be rejected without
+    # taking the controller down.
+    payload = '[' + ','.join(['0'] * 100001) + ']'
+
+    assert 'error' in client.conf(payload), 'too many array elements rejected'
+
+    assert 'success' in client.conf(
+        {"listeners": {}, "routes": [], "applications": {}}
+    ), 'controller alive after large array'
+
+
+def test_json_too_many_object_members():
+    # Same cap applies to object members.
+    members = ','.join(f'"k{i}":0' for i in range(100001))
+    payload = '{' + members + '}'
+
+    assert 'error' in client.conf(payload), 'too many object members rejected'
+
+    assert 'success' in client.conf(
+        {"listeners": {}, "routes": [], "applications": {}}
+    ), 'controller alive after large object'

--- a/test/test_proxy_overrun_cl.py
+++ b/test/test_proxy_overrun_cl.py
@@ -52,7 +52,9 @@ def _run_overrun_cl(port=UPSTREAM_OVERRUN_PORT):
     proc = subprocess.Popen(
         [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', 'overrun-cl'],
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
+        # DEVNULL, not PIPE: nothing reads this stream, and an unread PIPE can
+        # deadlock the child if it ever fills the OS pipe buffer.
+        stderr=subprocess.DEVNULL,
     )
     # Tear the process down if it never binds — otherwise a waitforsocket
     # timeout would raise before the caller's try/finally and leak it.

--- a/test/test_proxy_overrun_cl.py
+++ b/test/test_proxy_overrun_cl.py
@@ -1,0 +1,94 @@
+"""Proxy Content-Length *overrun* relay regression test.
+
+An upstream that sends more body bytes than its Content-Length advertises must
+not have the excess relayed downstream: FreeUnit already sent that same
+Content-Length to the client, so forwarding the surplus would smuggle bytes
+into the next response on the connection (response splitting). The hardening in
+nxt_h1p_peer_body_process truncates the buf chain to the advertised length,
+flags the response inconsistent (disabling keep-alive) and closes the
+connection.
+
+Driven by the `overrun-cl` mode of the Rust mock upstream
+(test/fake_upstream/): it declares `Content-Length: 100` but writes 150 bytes.
+Deliberately language-module-free (gated only on the built-in proxy support) so
+it runs on the minimal test build.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from unit.applications.proto import ApplicationProto
+from unit.utils import waitforsocket
+
+client = ApplicationProto()
+
+# Deterministic body: byte at global offset i is PATTERN[i % 16] — mirrors the
+# fake_upstream PATTERN so the test regenerates the exact advertised bytes.
+PATTERN = '0123456789abcdef'
+
+# Must match OVERRUN_DECLARED / OVERRUN_EXCESS in test/fake_upstream/src/main.rs.
+DECLARED = 100
+EXCESS = 50
+
+# Reserved fake_upstream port for this case (see test/fake_upstream/README.md).
+UPSTREAM_OVERRUN_PORT = 7989
+
+FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
+
+_skipif_no_fake_upstream = pytest.mark.skipif(
+    not os.path.exists(FAKE_UPSTREAM_BIN),
+    reason=f'{FAKE_UPSTREAM_BIN} not installed (build via test/fake_upstream)',
+)
+
+
+def _run_overrun_cl(port=UPSTREAM_OVERRUN_PORT):
+    proc = subprocess.Popen(
+        [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', 'overrun-cl'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    waitforsocket(port)
+    return proc
+
+
+@_skipif_no_fake_upstream
+def test_proxy_overrun_cl(skip_alert):
+    # The router logs a warning about the upstream overrun; don't let it fail
+    # the run on the alert check.
+    skip_alert(r'upstream sent .* body bytes past Content-Length')
+
+    proc = _run_overrun_cl()
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {
+                        "action": {
+                            "proxy": f'http://127.0.0.1:{UPSTREAM_OVERRUN_PORT}'
+                        }
+                    }
+                ],
+            }
+        ), 'overrun-cl proxy configuration'
+
+        resp = client.get(port=8080)
+
+        assert resp['status'] == 200, 'status'
+        assert (
+            resp['headers']['Content-Length'] == str(DECLARED)
+        ), 'relayed Content-Length unchanged'
+
+        # The excess bytes must be dropped: the client sees exactly the
+        # advertised length, never DECLARED + EXCESS.
+        expected = (PATTERN * (DECLARED // len(PATTERN) + 1))[:DECLARED]
+        assert len(resp['body']) == DECLARED, (
+            f'relayed body not truncated to Content-Length: '
+            f'got {len(resp["body"])} bytes'
+        )
+        assert resp['body'] == expected, 'relayed body mismatch'
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/test/test_proxy_overrun_cl.py
+++ b/test/test_proxy_overrun_cl.py
@@ -2,11 +2,16 @@
 
 An upstream that sends more body bytes than its Content-Length advertises must
 not have the excess relayed downstream: FreeUnit already sent that same
-Content-Length to the client, so forwarding the surplus would smuggle bytes
-into the next response on the connection (response splitting). The hardening in
+Content-Length to the client, so forwarding the surplus is what would enable
+response splitting on a kept-alive connection. The hardening in
 nxt_h1p_peer_body_process truncates the buf chain to the advertised length,
 flags the response inconsistent (disabling keep-alive) and closes the
 connection.
+
+This test asserts the mechanism that prevents splitting -- the client receives
+exactly the advertised bytes and no more -- rather than driving a second
+pipelined request; a single request with `Connection: close` is enough to
+observe the truncation.
 
 Driven by the `overrun-cl` mode of the Rust mock upstream
 (test/fake_upstream/): it declares `Content-Length: 100` but writes 150 bytes.
@@ -49,7 +54,14 @@ def _run_overrun_cl(port=UPSTREAM_OVERRUN_PORT):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
     )
-    waitforsocket(port)
+    # Tear the process down if it never binds — otherwise a waitforsocket
+    # timeout would raise before the caller's try/finally and leak it.
+    try:
+        waitforsocket(port)
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
     return proc
 
 

--- a/test/test_response_headers.py
+++ b/test/test_response_headers.py
@@ -171,3 +171,66 @@ def test_response_headers_invalid(skip_alert):
 
     resp = check_invalid({"X-Foo": "$u"})
     assert 'detail' in resp and 'Unknown variable' in resp['detail']
+
+
+def test_response_headers_name_invalid():
+    # Response-header names must be RFC 9110 tokens; anything outside the
+    # token grammar (spaces, ':', CR/LF, HTAB) is rejected at config time so
+    # a control-API client can't define a name carrying a header boundary.
+    def check_invalid_name(name):
+        assert 'error' in client.conf(
+            {name: "v"}, 'routes/0/action/response_headers'
+        ), f'name {name!r} rejected'
+
+    check_invalid_name("X Foo")
+    check_invalid_name("X\tFoo")
+    check_invalid_name("X:Foo")
+    check_invalid_name("X\r\nEvil")
+    check_invalid_name("X\x00Foo")
+
+    # A name using the allowed token special characters still loads.
+    assert 'success' in client.conf(
+        {"X-Custom_Header.1": "v"}, 'routes/0/action/response_headers'
+    ), 'valid token name'
+
+
+def test_response_headers_value_control():
+    # Static values must not carry control bytes (< 0x20 except HTAB, plus
+    # DEL 0x7F) -- otherwise a CR/LF in a value splits the response header
+    # block. HTAB and high/UTF-8 bytes stay allowed.
+    def check_invalid_value(value):
+        assert 'error' in client.conf(
+            {"X-Foo": value}, 'routes/0/action/response_headers'
+        ), f'value {value!r} rejected'
+
+    check_invalid_value("a\rb")
+    check_invalid_value("a\nb")
+    check_invalid_value("a\x00b")
+    check_invalid_value("a\x7fb")
+
+    def check_valid_value(value):
+        assert 'success' in client.conf(
+            {"X-Foo": value}, 'routes/0/action/response_headers'
+        ), f'value {value!r} accepted'
+
+    check_valid_value("a\tb")
+    check_valid_value("naïve")
+
+
+def test_response_headers_var_control():
+    # A templated value can only be validated at request time. When it
+    # expands to bytes carrying a header boundary the value is dropped, not
+    # injected -- and it must not appear as a smuggled header either.
+    assert 'success' in client.conf(
+        {"X-Foo": "$arg_foo"}, 'routes/0/action/response_headers'
+    )
+
+    # Benign expansion passes through untouched.
+    assert client.get(url='/?foo=bar')['headers'].get('X-Foo') == 'bar'
+
+    # CR/LF expansion is rejected: no split-in "Evil" header, and the
+    # tainted X-Foo is dropped rather than emitted verbatim.
+    resp = client.get(url='/?foo=a%0d%0aEvil:%20injected')
+    assert resp['status'] == 200, 'request still served'
+    assert 'Evil' not in resp['headers'], 'response header injection'
+    assert 'X-Foo' not in resp['headers'], 'tainted value dropped'

--- a/test/test_return.py
+++ b/test/test_return.py
@@ -200,6 +200,40 @@ def test_return_location_edit():
     ), 'location with empty variable'
 
 
+def test_return_location_crlf_injection():
+    # A Location value carrying CR/LF must be percent-encoded on output, not
+    # emitted verbatim -- otherwise it splits the response header block.
+    # Existing coverage encodes control bytes generically but never asserts
+    # the anti-injection invariant, and the templated path is unchecked.
+
+    # Static value with a raw CR/LF.
+    assert 'success' in client.conf(
+        {"return": 301, "location": "/r\r\nEvil: injected"},
+        'routes/0/action',
+    ), 'configure static location'
+
+    resp = client.get()
+    assert resp['status'] == 301
+    assert 'Evil' not in resp['headers'], 'static location header injection'
+    loc = resp['headers']['Location']
+    assert '\r' not in loc and '\n' not in loc, 'static CRLF not emitted raw'
+    assert '%0d%0a' in loc.lower(), 'static CRLF percent-encoded'
+
+    # Templated value expanded from an untrusted request argument.
+    assert 'success' in client.conf(
+        '"$arg_to"', 'routes/0/action/location'
+    ), 'configure templated location'
+
+    assert client.get(url='/?to=/next')['headers']['Location'] == '/next'
+
+    resp = client.get(url='/?to=/r%0d%0aEvil:%20injected')
+    assert resp['status'] == 301
+    assert 'Evil' not in resp['headers'], 'templated location header injection'
+    loc = resp['headers']['Location']
+    assert '\r' not in loc and '\n' not in loc, 'templated CRLF not emitted raw'
+    assert '%0d%0a' in loc.lower(), 'templated CRLF percent-encoded'
+
+
 def test_return_invalid():
     def check_error(conf):
         assert 'error' in client.conf(conf, 'routes/0/action')

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -297,6 +297,21 @@ def test_routes_bad_regex(require):
         assert client.get(url='/nothing_z')['status'] == 500, '/nothing_z'
 
 
+def test_routes_match_regex_captures(require):
+    require({'modules': {'regex': True}})
+
+    # Capturing groups exercise the PCRE2 match ovector; the matcher
+    # must pass a non-zero ovector size (a zero size is undefined per
+    # PCRE2) and still return a correct boolean match.
+    route_match({"uri": "~^/(foo|bar)/([0-9]+)$"})
+
+    assert client.get(url='/foo/123')['status'] == 200, 'capture foo'
+    assert client.get(url='/bar/9')['status'] == 200, 'capture bar'
+    assert client.get(url='/baz/1')['status'] == 404, 'capture miss'
+    assert client.get(url='/foo/x')['status'] == 404, 'capture non-digit'
+    assert client.get(url='/foo/')['status'] == 404, 'capture empty'
+
+
 def test_routes_match_regex_case_sensitive(require):
     require({'modules': {'regex': True}})
 
@@ -699,6 +714,20 @@ def test_routes_match_uri_normalize():
     route_match({"uri": "/blah"})
 
     assert client.get(url='/%62%6c%61%68')['status'] == 200, 'normalize'
+
+
+def test_routes_match_uri_encoded_pattern():
+    # The configured pattern is percent-decoded at compile time the same
+    # way the request URI is decoded by the parser, so an encoded pattern
+    # must match the equivalent plain-text request and vice versa.
+    route_match({"uri": "/%62lah"})
+    assert client.get(url='/blah')['status'] == 200, 'encoded pattern exact'
+    assert client.get(url='/%62lah')['status'] == 200, 'encoded pattern encoded'
+    assert client.get(url='/xlah')['status'] == 404, 'encoded pattern miss'
+
+    route_match({"uri": "/%62*"})
+    assert client.get(url='/blah')['status'] == 200, 'encoded prefix'
+    assert client.get(url='/xlah')['status'] == 404, 'encoded prefix miss'
 
 
 def test_routes_match_empty_array():
@@ -1923,6 +1952,21 @@ def test_routes_match_source_invalid():
     route_match_invalid({"source": "*:"})
     route_match_invalid({"source": "*:1-a"})
     route_match_invalid({"source": "*:65536"})
+
+
+def test_routes_match_source_port_range_invalid():
+    # A dash at either end of a port range leaves an empty half that
+    # nxt_int_parse() must reject.  The pre-hardening parser silently
+    # accepted a trailing dash ("8-" was read as the single port 8),
+    # so these malformed ranges are explicit regression guards.
+    route_match_invalid({"source": "127.0.0.1:8-"})
+    route_match_invalid({"source": "127.0.0.1:-8"})
+    route_match_invalid({"source": "127.0.0.1:-"})
+    route_match_invalid({"source": "*:8-"})
+    route_match_invalid({"source": "*:-8"})
+    route_match_invalid({"source": "*:-"})
+    route_match_invalid({"source": "[::1]:8-"})
+    route_match_invalid({"source": "[::1]:-8"})
 
 
 def test_routes_match_source_none():

--- a/test/test_ruby_application.py
+++ b/test/test_ruby_application.py
@@ -183,7 +183,13 @@ def test_ruby_application_input_read_retained():
 
     assert resp['status'] == 200, 'second request status'
     assert resp['body'].startswith('leaked['), 'same worker handled both'
+    # The security invariant is "no disclosure": the retained handle must
+    # not expose this request's body.
     assert secret not in resp['body'], 'retained rack.input leaked next body'
+    # Exact match asserts the current fix behavior: a stale read returns
+    # nil -> '' (empty). If the fix ever switches to raising on a stale
+    # handle instead, config.ru would yield 'leaked[err:...]' and only this
+    # line needs updating -- the disclosure invariant above still holds.
     assert resp['body'] == 'leaked[]', 'stale handle reads nothing'
 
 

--- a/test/test_ruby_application.py
+++ b/test/test_ruby_application.py
@@ -164,6 +164,29 @@ def test_ruby_application_input_each():
     assert client.post(body=body)['body'] == body, 'input each'
 
 
+def test_ruby_application_input_read_retained():
+    client.load('input_read_retained')
+
+    # Pin a single persistent worker so both requests share one process
+    # (the retained rack.input handle lives in a Ruby global).
+    assert 'success' in client.conf(
+        '1', 'applications/input_read_retained/processes'
+    ), 'single process'
+
+    assert client.get()['body'] == 'stashed', 'first request stashes handle'
+
+    # The handle retained from the first request must not read this
+    # request's body -- that would be a cross-request body disclosure on a
+    # shared worker. A request-bound handle yields nil (empty) instead.
+    secret = 'SECRETBODY0123456789'
+    resp = client.post(body=secret)
+
+    assert resp['status'] == 200, 'second request status'
+    assert resp['body'].startswith('leaked['), 'same worker handled both'
+    assert secret not in resp['body'], 'retained rack.input leaked next body'
+    assert resp['body'] == 'leaked[]', 'stale handle reads nothing'
+
+
 @pytest.mark.skip('not yet')
 def test_ruby_application_syntax_error(skip_alert):
     skip_alert(

--- a/test/test_static.py
+++ b/test/test_static.py
@@ -209,6 +209,23 @@ def test_static_path():
     assert client.get(url='/../assets/')['status'] == 400, 'path invalid 5'
 
 
+def test_static_path_encoded():
+    # Percent-encoded and partially-encoded dot segments are decoded before
+    # path normalization, so an encoded "../" cannot bypass the traversal
+    # guard that rejects the plain form.
+    assert (
+        client.get(url='/dir/%2e%2e/dir/file')['status'] == 200
+    ), 'encoded relative stays in root'
+
+    assert client.get(url='/%2e%2e/')['status'] == 400, 'encoded ..'
+    assert client.get(url='/%2e%2e')['status'] == 400, 'encoded .. no slash'
+    assert client.get(url='/%2e./')['status'] == 400, 'partial encoded .. 1'
+    assert client.get(url='/.%2e/')['status'] == 400, 'partial encoded .. 2'
+    assert (
+        client.get(url='/%2e%2e/assets/')['status'] == 400
+    ), 'encoded traversal to sibling'
+
+
 def test_static_two_clients():
     sock = client.get(no_recv=True)
     sock2 = client.get(no_recv=True)

--- a/test/test_static.py
+++ b/test/test_static.py
@@ -106,6 +106,51 @@ def test_static_etag(temp_dir):
     assert etag != client.get(url='/')['headers']['ETag'], 'new ETag'
 
 
+def test_static_range_ignored():
+    # Unit does not implement byte-range requests for static files. Per
+    # RFC 7233 a server that does not support Range MUST ignore it and
+    # return the full 200 representation -- never a malformed 206.
+    resp = client.get(
+        url='/index.html',
+        headers={
+            'Host': 'localhost',
+            'Range': 'bytes=0-4',
+            'Connection': 'close',
+        },
+    )
+    assert resp['status'] == 200, 'range ignored -> full 200'
+    assert resp['body'] == '0123456789', 'full body returned'
+    assert 'Content-Range' not in resp['headers'], 'no Content-Range'
+
+
+def test_static_conditional_ignored():
+    # Conditional requests are not implemented; a matching validator must
+    # not produce a 304 (which would imply the body was withheld).
+    etag = client.get(url='/index.html')['headers']['ETag']
+
+    resp = client.get(
+        url='/index.html',
+        headers={
+            'Host': 'localhost',
+            'If-None-Match': etag,
+            'Connection': 'close',
+        },
+    )
+    assert resp['status'] == 200, 'if-none-match ignored'
+    assert resp['body'] == '0123456789', 'full body on matching etag'
+
+    resp = client.get(
+        url='/index.html',
+        headers={
+            'Host': 'localhost',
+            'If-Modified-Since': 'Thu, 01 Jan 2100 00:00:00 GMT',
+            'Connection': 'close',
+        },
+    )
+    assert resp['status'] == 200, 'if-modified-since ignored'
+    assert resp['body'] == '0123456789', 'full body on future date'
+
+
 def test_static_redirect():
     resp = client.get(url='/dir')
     assert resp['status'] == 301, 'redirect status'

--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -185,13 +185,14 @@ def test_tls_certificate_update():
     ), 'update certificate'
 
 
-@pytest.mark.skip('not yet')
 def test_tls_certificate_key_incorrect():
     client.load('empty')
 
     client.certificate('first', False)
     client.certificate('second', False)
 
+    # A cert paired with a foreign private key is rejected at config time
+    # (SSL_CTX_check_private_key), not left to fail at the first handshake.
     assert 'error' in client.certificate_load(
         'first', 'second'
     ), 'key incorrect'

--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -185,17 +185,29 @@ def test_tls_certificate_update():
     ), 'update certificate'
 
 
-def test_tls_certificate_key_incorrect():
+def test_tls_certificate_key_incorrect(skip_alert):
+    skip_alert(r'nxt_openssl_chain_file\(\) failed', r'failed to apply new conf')
+
     client.load('empty')
 
     client.certificate('first', False)
     client.certificate('second', False)
 
-    # A cert paired with a foreign private key is rejected at config time
-    # (SSL_CTX_check_private_key), not left to fail at the first handshake.
-    assert 'error' in client.certificate_load(
+    # A structurally valid bundle (a private key + a certificate) is stored
+    # fine -- the cert store only checks PEM structure. The key/cert
+    # *mismatch* is caught later, when the router builds the listener's
+    # SSL_CTX (SSL_CTX_check_private_key), rather than being left to fail at
+    # the first handshake.
+    assert 'success' in client.certificate_load(
         'first', 'second'
-    ), 'key incorrect'
+    ), 'mismatched bundle stored'
+
+    # pass at the existing app so the mismatched cert is the only reason
+    # the listener config can be rejected.
+    assert 'error' in client.conf(
+        {"pass": "applications/empty", "tls": {"certificate": 'first'}},
+        'listeners/*:8080',
+    ), 'mismatched key/cert rejected at listener config'
 
 
 def test_tls_certificate_change():

--- a/test/test_tls_sni.py
+++ b/test/test_tls_sni.py
@@ -297,6 +297,26 @@ def test_tls_sni_empty_san():
         }
     }
     ctx = config_bundles(bundles)
+
+    # Guard against an openssl/libressl version silently dropping the empty
+    # SAN: the generated cert must actually carry the zero-length entry,
+    # otherwise this test would pass without exercising the over-read guard
+    # at all.  The SAN line reads "DNS:, DNS:alt.localhost.com" -> two
+    # "DNS:" tokens; a dropped empty entry leaves only one.
+    cert_text = subprocess.check_output(
+        [
+            'openssl',
+            'x509',
+            '-in',
+            f'{option.temp_dir}/localhost.crt',
+            '-noout',
+            '-text',
+        ],
+        stderr=subprocess.STDOUT,
+        encoding='utf-8',
+    )
+    assert cert_text.count('DNS:') == 2, 'empty SAN entry preserved in cert'
+
     add_tls(["localhost"])
 
     resp, sock = client.get_ssl(

--- a/test/test_tls_sni.py
+++ b/test/test_tls_sni.py
@@ -284,6 +284,40 @@ def test_tls_sni_empty_cn():
     assert sock.getpeercert()['subjectAltName'][0][1] == 'alt.localhost.com'
 
 
+def test_tls_sni_empty_san():
+    # A certificate carrying a zero-length SAN entry must not trigger a
+    # one-byte over-read in the wildcard-name SAN matcher during the
+    # bundle-hash insert / SNI lookup.  The empty entry is treated as a
+    # plain (non-wildcard) name; the bundle still loads and the valid
+    # names keep resolving.
+    bundles = {
+        "localhost": {
+            "subj": "empty-san",
+            "alt_names": ['', 'alt.localhost.com'],
+        }
+    }
+    ctx = config_bundles(bundles)
+    add_tls(["localhost"])
+
+    resp, sock = client.get_ssl(
+        headers={
+            'Host': 'alt.localhost.com',
+            'Content-Length': '0',
+            'Connection': 'close',
+        },
+        start=True,
+        context=ctx,
+    )
+
+    assert resp['status'] == 200
+    san = [
+        name
+        for typ, name in sock.getpeercert()['subjectAltName']
+        if typ == 'DNS'
+    ]
+    assert 'alt.localhost.com' in san, 'valid SAN still resolves'
+
+
 def test_tls_sni_invalid():
     _ = config_bundles({"localhost": {"subj": "subj1", "alt_names": ''}})
     add_tls(["localhost"])


### PR DESCRIPTION
## Summary

Behavioral regression tests for the **1.35.6 security hardening stack** (#85).
Each case pins a fix by observable behavior over the control API / HTTP, so a
future regression fails loudly instead of silently reopening a vector. Test-only
— no runtime code changes.

Where a vector was already exercised by the existing suite (e.g. the Autobahn
WebSocket port already covers RFC 6455 §5.2 64-bit length via
`test_asgi_websockets_length_long`), no duplicate was added; these fill the
genuine gaps.

## Coverage

| Test | Hardening it guards | Vector |
|------|--------------------|--------|
| `test_routing.py::test_routes_match_source_port_range_invalid` | reject malformed port ranges (trailing/leading dash `8-`, `-8`) | `fix(routing)` — V2 ACL-bypass |
| `test_routing.py::test_routes_match_uri_encoded_pattern` | symmetric percent-decode of route pattern vs request URI | `fix(routing)` — V2 |
| `test_routing.py::test_routes_match_regex_captures` | non-zero PCRE2 ovector on capturing-group patterns | `fix(routing)` — V2 |
| `test_configuration.py::test_json_deep_nesting` | JSON nesting-depth cap (100) — controller survives | `fix(controller)` — V4 |
| `test_configuration.py::test_json_too_many_array_elements` / `_object_members` | per-array/object element cap (100k) | `fix(controller)` — V4 |
| `test_chunked.py::test_chunked_invalid` (extended) | chunk-size overflow + non-hex rejected (`nxt_size_is_sufficient`) | chunked relay guard |
| `test_proxy_overrun_cl.py::test_proxy_overrun_cl` | upstream Content-Length overrun → excess truncated, no response splitting | `fix(http)` — V1 proxy CL |
| `test_tls.py::test_tls_certificate_key_incorrect` (un-skipped) | cert/key pair validated at config time (`SSL_CTX_check_private_key`) | `fix(tls)` — V3 |
| `test_tls_sni.py::test_tls_sni_empty_san` | zero-length SAN entry no longer over-reads the wildcard matcher | `fix(tls)` — wildcard SAN OOB |
| `test_ruby_application.py::test_ruby_application_input_read_retained` | `rack.input` bound to originating request — no cross-request body disclosure | `fix(controller)` — V8 Ruby `rack.input` bleed |

## New test infrastructure

- **`fake_upstream` mode `overrun-cl`** (`test/fake_upstream/`): declares
  `Content-Length: 100` but writes 150 bytes, in one segment so the excess lands
  in the same relay read as the declared tail. New reserved port `7989` + README
  registry entry; three-way name mirroring (`overrun-cl` ↔ `respond_overrun_cl`
  ↔ `test_proxy_overrun_cl`) kept intact.
- **Ruby app `input_read_retained`** (`test/ruby/`): stashes `rack.input` in a
  global on the first request and reads it on the next; the test pins
  `processes: 1` so both requests share one worker.

## Notes / scope

- Test-only; safe to land independently of the hardening commits it guards
  (assumes they are present in the base branch).
- The empty-SAN cert is produced through the existing `config_bundles` CSR + CA
  pipeline with an empty `DNS:` entry (verified openssl preserves it via
  `copy_extensions = copy`).
- `overrun-cl` and the Ruby app are gated the same way as their neighbors
  (`fake_upstream` binary presence; `ruby` module), so the suite skips cleanly
  where the dependency is absent.
- Not covered here (out of scope for pytest-level behavior): SAPI per-language
  arg-bounds (Java/WASM/PHP), port/shmem/sptr internals, FD/CLOEXEC lifetime,
  isolation rootfs-separator (privilege-gated) — these are C-unit-test / gated-CI
  territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
