### PR TITLE
fix(conf): reject embedded NUL in rootfs and cgroup path validation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -78,6 +78,10 @@ Changes with FreeUnit 1.35.6                                     25 Jun 2026
        openat2(RESOLVE_BENEATH), and resolve relative cgroup paths against the
        child's /proc/<pid>/cgroup.
 
+    *) Bugfix: reject embedded NUL bytes in the "rootfs" and cgroup "path"
+       isolation options, and validate "rootfs" as an absolute path other
+       than "/" at configuration time.
+
     *) Bugfix: cap JSON parser depth and element counts in the controller,
        scrub PHP TrueAsync exception state before the prototype fork, and bind
        the Ruby rack.input / rack.errors handles to their originating request.

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -246,6 +246,11 @@ static nxt_int_t nxt_conf_vldt_cgroup_path(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 #endif
 
+#if (NXT_HAVE_ISOLATION_ROOTFS)
+static nxt_int_t nxt_conf_vldt_rootfs_path(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t *value, void *data);
+#endif
+
 #if (NXT_HAVE_NJS)
 static nxt_int_t nxt_conf_vldt_js_module(nxt_conf_validation_t *vldt,
      nxt_conf_value_t *value, void *data);
@@ -1365,6 +1370,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_app_isolation_members[] = {
     {
         .name       = nxt_string("rootfs"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_rootfs_path,
     }, {
         .name       = nxt_string("automount"),
         .type       = NXT_CONF_VLDT_OBJECT,
@@ -3458,12 +3464,58 @@ nxt_conf_vldt_cgroup_path(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
                                    &cgpath);
     }
 
-    sprintf(path, "/%*s/", (int) cgpath.length, cgpath.start);
-
-    if (cgpath.length == 0 || strstr(path, "/../") != NULL) {
+    if (cgpath.length == 0
+        || memchr(cgpath.start, '\0', cgpath.length) != NULL)
+    {
         return nxt_conf_vldt_error(vldt,
                                    "The cgroup path \"%V\" is invalid.",
                                    &cgpath);
+    }
+
+    snprintf(path, sizeof(path), "/%.*s/", (int) cgpath.length, cgpath.start);
+
+    if (strstr(path, "/../") != NULL) {
+        return nxt_conf_vldt_error(vldt,
+                                   "The cgroup path \"%V\" is invalid.",
+                                   &cgpath);
+    }
+
+    return NXT_OK;
+}
+
+#endif
+
+
+#if (NXT_HAVE_ISOLATION_ROOTFS)
+
+static nxt_int_t
+nxt_conf_vldt_rootfs_path(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
+    void *data)
+{
+    size_t     trimmed_len;
+    nxt_str_t  rootfs;
+
+    nxt_conf_get_string(value, &rootfs);
+
+    /*
+     * "//" resolves to "/" and is rejected like "/"; the NUL scan below
+     * covers the full, untrimmed length.
+     */
+    trimmed_len = rootfs.length;
+
+    while (trimmed_len > 1 && rootfs.start[trimmed_len - 1] == '/') {
+        trimmed_len--;
+    }
+
+    if (trimmed_len <= 1
+        || rootfs.start[0] != '/'
+        || memchr(rootfs.start, '\0', rootfs.length) != NULL)
+    {
+        return nxt_conf_vldt_error(vldt,
+                                   "The \"rootfs\" path \"%V\" is invalid; "
+                                   "an absolute path other than \"/\" "
+                                   "is required.",
+                                   &rootfs);
     }
 
     return NXT_OK;

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -502,15 +502,15 @@ nxt_isolation_set_rootfs(nxt_task_t *task, nxt_conf_value_t *isolation,
     if (obj != NULL) {
         nxt_conf_get_string(obj, &str);
 
+        while (str.length > 1 && str.start[str.length - 1] == '/') {
+            str.length--;
+        }
+
         if (nxt_slow_path(str.length <= 1 || str.start[0] != '/')) {
             nxt_log(task, NXT_LOG_ERR, "rootfs requires an absolute path other "
                     "than \"/\" but given \"%V\"", &str);
 
             return NXT_ERROR;
-        }
-
-        if (str.start[str.length - 1] == '/') {
-            str.length--;
         }
 
         process->isolation.rootfs = nxt_mp_alloc(process->mem_pool,

--- a/test/test_python_isolation.py
+++ b/test/test_python_isolation.py
@@ -225,3 +225,33 @@ def test_python_isolation_cgroup_invalid(require):
     check_invalid('')
     check_invalid('../scope')
     check_invalid('scope/../python')
+    check_invalid('scope\0python')
+
+
+def test_python_isolation_rootfs_invalid():
+    def check_invalid(rootfs):
+        script_path = f'{option.test_dir}/python/empty'
+        assert 'error' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "applications/empty"}},
+                "applications": {
+                    "empty": {
+                        "type": "python",
+                        "processes": {"spare": 0},
+                        "path": script_path,
+                        "working_directory": script_path,
+                        "module": "wsgi",
+                        "isolation": {
+                            'rootfs': rootfs,
+                        },
+                    }
+                },
+            }
+        )
+
+    check_invalid('')
+    check_invalid('/')
+    check_invalid('//')
+    check_invalid('///')
+    check_invalid('app/rootfs')
+    check_invalid('/app/rootfs\0/injected')


### PR DESCRIPTION
## Summary

Reworked salvage of the C-hardening half of the stale draft https://github.com/andypost/unit/pull/26 , rebased onto current `pre-1.35.6` and extended.

Two isolation config options — `isolation.cgroup.path` and `isolation.rootfs` — are validated as length-tracked strings but later reused as NUL-terminated C strings during isolation setup (cgroup path construction; `chroot`/`pivot_root`). An embedded NUL byte survives config validation and silently truncates the effective path downstream.

Changes in `nxt_conf_vldt_cgroup_path()` / new `nxt_conf_vldt_rootfs_path()`:

- Reject empty values and embedded NUL bytes (`memchr`) for both options.
- Validate `rootfs` as an absolute path other than `/` **at config time** — previously this was only enforced at runtime in `nxt_isolation_set_rootfs()`, so a bad value was accepted by the control API and only failed on app start.
- Replace `sprintf(path, "/%*s/", ...)` with `snprintf(path, sizeof(path), "/%.*s/", ...)`. `%*s` is a **width**, not a precision, specifier — it reads `cgpath.start` to a NUL terminator a length-tracked string does not guarantee. `%.*s` bounds the copy to the given length, and `snprintf` bounds the destination.

## What I deliberately left out of [#26](https://github.com/andypost/unit/pull/26)

- The Trivy CI workflow + `sort-trivy-results.py` — belongs in a separate `ci:` PR, SHA-pinned, schedule-only.
- `docs/security-audit-findings.md` — a public list of suspected-unfixed vulnerabilities; kept out of the repo for disclosure hygiene. The one actionable item there (rootfs embedded-NUL, "SA-001") is fixed by this PR.

## Testing

- New `unitd` built from this branch; drove the control API directly (`PUT /config`):
  - `rootfs`: relative path, `/`, and `/app\u0000/injected` → rejected with `Invalid configuration` + detail; `/srv/app` → passes validation.
  - `cgroup.path`: `scope\u0000python` and `scope/../python` → rejected; `scope/python` → passes.
  - Confirmed the JSON `\u0000` escape decodes to a real 0x00 byte (`nxt_utf8_encode`), so `memchr` catches it.
- Added negative cases to `test/test_python_isolation.py`: `test_python_isolation_cgroup_invalid` gains a NUL case; new `test_python_isolation_rootfs_invalid` covers empty, `/`, relative, and embedded-NUL.
- `nxt_conf_validation.o` and full `unitd` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)