### PR TITLE
fix(port): plug NULL-deref in port read handlers under buf-alloc OOM

### DIFF
--- a/src/nxt_port_socket.c
+++ b/src/nxt_port_socket.c
@@ -782,8 +782,24 @@ nxt_port_read_handler(nxt_task_t *task, void *obj, void *data)
         b = nxt_port_buf_alloc(port);
 
         if (nxt_slow_path(b == NULL)) {
-            /* TODO: disable event for some time */
+            /*
+             * Buffer pool exhausted (transient OOM on port mem_pool).
+             * Falling through would dereference b->mem.pos and crash;
+             * disarm the read event and route through the orderly
+             * error path instead.  No timer infrastructure exists for
+             * ports, so there is no way to re-arm the read later:
+             * terminal teardown via nxt_port_error_handler is the
+             * strict improvement over the NULL dereference.
+             */
+            nxt_alert(task, "port{%d,%d} %d: buf alloc failed; "
+                            "disabling read",
+                      (int) port->pid, (int) port->id, port->socket.fd);
+            nxt_fd_event_block_read(task->thread->engine, &port->socket);
+            goto fail;
         }
+
+        /* Guards against a future regression emptying the branch above. */
+        nxt_assert(b != NULL);
 
         iov[0].iov_base = &msg.port_msg;
         iov[0].iov_len = sizeof(nxt_port_msg_t);
@@ -953,8 +969,27 @@ nxt_port_queue_read_handler(nxt_task_t *task, void *obj, void *data)
         b = nxt_port_buf_alloc(port);
 
         if (nxt_slow_path(b == NULL)) {
-            /* TODO: disable event for some time */
+            /*
+             * Buffer pool exhausted (transient OOM on port mem_pool).
+             * Falling through would dereference b->mem.pos in either
+             * the dequeue memcpy or the iov[1] recv branch.  Disarm
+             * the read event, decrement the queue counter, and route
+             * through the orderly error handler; terminal teardown is
+             * the strict improvement over the NULL dereference.
+             */
+            nxt_alert(task, "port{%d,%d} %d: buf alloc failed; "
+                            "disabling read",
+                      (int) port->pid, (int) port->id, port->socket.fd);
+            nxt_fd_event_block_read(task->thread->engine, &port->socket);
+            nxt_atomic_fetch_add(&queue->nitems, -1);
+            nxt_work_queue_add(&task->thread->engine->fast_work_queue,
+                               nxt_port_error_handler, task, &port->socket,
+                               NULL);
+            return;
         }
+
+        /* Guards against a future regression emptying the branch above. */
+        nxt_assert(b != NULL);
 
         if (n >= (ssize_t) sizeof(nxt_port_msg_t)) {
             nxt_memcpy(&msg.port_msg, qmsg, sizeof(nxt_port_msg_t));
@@ -1415,7 +1450,13 @@ nxt_port_error_handler(nxt_task_t *task, void *obj, void *data)
     nxt_port_send_msg_t  *msg;
 
     nxt_debug(task, "port error handler %p", obj);
-    /* TODO */
+    /*
+     * The bare TODO here historically asked for richer error context
+     * (e.g. surfacing the actual socket.error to peers).  The handler
+     * already drains all queued send messages, releases buffers, and
+     * decrements port refcounts; richer error responses remain a
+     * possible future enhancement.
+     */
 
     port = nxt_container_of(obj, nxt_port_t, socket);
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -5895,9 +5895,9 @@ nxt_router_get_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         nxt_alert(task, "get_mmap_handler: app == NULL for reply port %PI:%d",
                   port->pid, port->id);
 
-        // FIXME
-        nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
-                              -1, msg->port_msg.stream, 0, NULL);
+        /* Best-effort RPC_ERROR; peer-side RPC timeout is the backstop. */
+        (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
+                                     -1, msg->port_msg.stream, 0, NULL);
 
         return;
     }
@@ -5911,9 +5911,9 @@ nxt_router_get_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         nxt_alert(task, "get_mmap_handler: mmap id is too big (%d)",
                   (int) get_mmap_msg->id);
 
-        // FIXME
-        nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
-                              -1, msg->port_msg.stream, 0, NULL);
+        /* Best-effort RPC_ERROR; peer-side RPC timeout is the backstop. */
+        (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
+                                     -1, msg->port_msg.stream, 0, NULL);
         return;
     }
 


### PR DESCRIPTION
## Summary

Both `nxt_port_read_handler()` and `nxt_port_queue_read_handler()` had an empty `if (b == NULL) { /* TODO: disable event for some time */ }` body after `nxt_port_buf_alloc()`, then dereferenced `b->mem.pos` immediately after. A transient OOM on the port mem_pool therefore crashed the process instead of failing in an orderly way. **Crash → orderly teardown.**

## Changes

### `src/nxt_port_socket.c` — `nxt_port_read_handler`

On buf-alloc failure: alert, disarm the read event via `nxt_fd_event_block_read()`, and `goto fail` — the existing label that queues `nxt_port_error_handler`.

### `src/nxt_port_socket.c` — `nxt_port_queue_read_handler`

Same shape, plus `nxt_atomic_fetch_add(&queue->nitems, -1)` to balance the `+1` at function entry, then queue `nxt_port_error_handler` and return. (The `msg.fd[]`/`cmsg_pid` reset at the top of the loop means the early return cannot leak or close a stale descriptor.)

No timer infrastructure exists for ports, so a timer-driven retry/re-arm would need new machinery; terminal teardown is the strict improvement over the NULL dereference. Both sites carry an `nxt_assert(b != NULL)` past the teardown block to guard against a future regression re-introducing an empty if-body.

### Marker cleanups (comment-only)

- `nxt_port_error_handler`: the bare `/* TODO */` replaced with a disposition note — the handler already drains queued sends, releases buffers, and decrements port refcounts.
- `nxt_router_get_mmap_handler` (`src/nxt_router.c`): two `// FIXME` markers on best-effort `RPC_ERROR` sends replaced with a one-line note + explicit `(void)` casts matching the convention at the end of the same function. The function is `void`; delivery failures surface in `port->socket.error` and the peer-side RPC timeout is the backstop.

## Tests

No new tests: the OOM sites cannot be reliably reproduced from the Python suite without malloc-failure injection; fault-injection/ASan coverage is a CI follow-up.

Verified locally on top of `pre-1.35.6`:

```
./configure --tests && make -j$(nproc)     # clean, no warnings
python3 -m pytest test/test_static.py test/test_idle_close_wait.py   # 18 passed, 1 skipped
```

Language-module builds rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
