### PR TITLE
fix(conn): route to error_handler on partial-write-then-error

### DIFF
--- a/src/nxt_conn_write.c
+++ b/src/nxt_conn_write.c
@@ -118,12 +118,8 @@ nxt_conn_io_write(nxt_task_t *task, void *obj, void *data)
         }
     }
 
-    if (ret == 0 || sb.sent != 0) {
-        /*
-         * ret == 0 means a sync buffer was processed.
-         * ret == NXT_ERROR is ignored here if some data was sent,
-         * the error will be handled on the next nxt_conn_write() call.
-         */
+    if (ret == 0 || (ret != NXT_ERROR && sb.sent != 0)) {
+        /* ret == 0 means a sync buffer was processed. */
         c->sent += sb.sent;
         nxt_work_queue_add(c->write_work_queue, c->write_state->ready_handler,
                            task, c, data);
@@ -132,6 +128,21 @@ nxt_conn_io_write(nxt_task_t *task, void *obj, void *data)
 
     if (ret != NXT_ERROR) {
         return;
+    }
+
+    if (sb.sent != 0) {
+        /*
+         * Route to error_handler immediately when a write returns
+         * NXT_ERROR after a partial send (e.g. peer closed
+         * mid-response).  Previously this case fell through to
+         * ready_handler and the error was deferred to the next
+         * nxt_conn_io_write() call via c->socket.error.  Mirrors the
+         * TLS path's fail-fast behaviour; see nxt_openssl_conn_test_error.
+         */
+        c->sent += sb.sent;
+        nxt_log(task, NXT_LOG_INFO,
+                "conn write: peer closed mid-response fd:%d sent:%O",
+                c->socket.fd, sb.sent);
     }
 
     nxt_fd_event_block_write(engine, &c->socket);


### PR DESCRIPTION
## Summary

Closes a silent-deferred-error gap in `nxt_conn_io_write()`: a write that returned `NXT_ERROR` after a partial send (e.g. ECONNRESET on the second writev/sendfile of the same call after the first succeeded) was routed to `ready_handler`, deferring detection until the next event-loop tick. The TLS path (`nxt_openssl_conn_test_error`) already fails fast on the equivalent condition; this PR extends that behaviour to plain HTTP.

## What changes

`src/nxt_conn_write.c` — the completion condition becomes

```c
if (ret == 0 || (ret != NXT_ERROR && sb.sent != 0)) {
```

and a new branch routes `NXT_ERROR`-with-partial-send to the `error:` label immediately, accounting `c->sent` and emitting one INFO record (`conn write: peer closed mid-response fd:%d sent:%O`) so operators can correlate the routing decision with the underlying syscall log emitted at `nxt_socket_error_level` (also INFO for ECONNRESET-class).

`NXT_AGAIN` with `sb.sent != 0` still routes to `ready_handler` (correct — the caller should retry). Only `NXT_ERROR` with `sb.sent != 0` is the new fast-fail path.

## No regression test

The new branch fires only when one `nxt_conn_io_write()` call has (a) one successful `sendbuf` followed by (b) one `NXT_ERROR` `sendbuf` in its do-while loop. On loopback with `SO_LINGER{1,0}+close`, the RST arrives before the first `sendbuf` in 100% of attempts, so `sb.sent` stays 0 and the branch is unreachable from a black-box test. Deterministic coverage needs syscall-failure injection; the fix is review-verified by inspection of the two-line boolean change plus the logging block.

## Verification

On top of `pre-1.35.6`:

```
./configure --tests && make -j$(nproc)     # clean, no warnings
python3 -m pytest test/test_static.py test/test_idle_close_wait.py   # 18 passed, 1 skipped
```

`test_static.py` exercises the share + writev/sendfile paths this touches; no behavioural change for normal-completion or NXT_AGAIN-mid-response traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
