### PR TITLE
fix(lifecycle): free timer batching array; gate sendmsg log severity on lifecycle

### DIFF
--- a/src/nxt_event_engine.c
+++ b/src/nxt_event_engine.c
@@ -456,7 +456,19 @@ nxt_event_engine_free(nxt_event_engine_t *engine)
 
     engine->event.free(engine);
 
-    /* TODO: free timers */
+    /*
+     * Release the timer subsystem's heap-owned state.
+     *
+     * The timer rbtree itself is *not* walked here: every nxt_timer_t is
+     * embedded inside a containing struct (nxt_runtime_t::timer,
+     * nxt_listen_event_t::idle_timer, request/connection timers in
+     * nxt_h1proto.c and nxt_router.c, etc.) and is owned by that subsystem.
+     * Calling nxt_free() on an embedded node would corrupt the heap.
+     * The only allocation owned by nxt_timers_t itself is the `changes`
+     * batching array allocated by nxt_timers_init() via nxt_malloc().
+     */
+    nxt_free(engine->timers.changes);
+    engine->timers.changes = NULL;
 
     nxt_free(engine);
 }

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -6159,9 +6159,10 @@ static ssize_t
 nxt_unit_sendmsg(nxt_unit_ctx_t *ctx, int fd,
     const void *buf, size_t buf_size, const nxt_send_oob_t *oob)
 {
-    int            err;
-    ssize_t        n;
-    struct iovec   iov[1];
+    int                  err;
+    ssize_t              n;
+    struct iovec         iov[1];
+    nxt_unit_ctx_impl_t  *ctx_impl;
 
     iov[0].iov_base = (void *) buf;
     iov[0].iov_len = buf_size;
@@ -6178,11 +6179,35 @@ retry:
         }
 
         /*
-         * FIXME: This should be "alert" after router graceful shutdown
-         * implementation.
+         * Severity is conditional on the context's lifecycle state:
+         *
+         *   - online (steady state OR deferred graceful drain): the
+         *     peer should still be reachable, sendmsg failure
+         *     indicates a real problem -> nxt_unit_alert.
+         *   - !online (nxt_unit_quit() has flipped the context out of
+         *     service): the peer is going away by design, so
+         *     EPIPE/ECONNRESET-class errors are expected and would
+         *     otherwise spam the log -> warn.
+         *
+         * Note: ctx_impl->quit_param is NOT a "shutdown in progress"
+         * flag.  It is initialised to NXT_QUIT_GRACEFUL in
+         * nxt_unit_ctx_init() as the default
+         * "intended quit semantics" for the context, and is
+         * re-asserted to GRACEFUL inside nxt_unit_quit's NORMAL branch
+         * for broadcast purposes -- so it is GRACEFUL at steady state
+         * too and cannot be used to distinguish steady state from
+         * shutdown.  The unambiguous flag is ctx_impl->online.
          */
-        nxt_unit_warn(ctx, "sendmsg(%d, %d) failed: %s (%d)",
-                      fd, (int) buf_size, strerror(err), err);
+        ctx_impl = nxt_container_of(ctx, nxt_unit_ctx_impl_t, ctx);
+
+        if (ctx_impl->online) {
+            nxt_unit_alert(ctx, "sendmsg(%d, %d) failed: %s (%d)",
+                           fd, (int) buf_size, strerror(err), err);
+
+        } else {
+            nxt_unit_warn(ctx, "sendmsg(%d, %d) failed: %s (%d)",
+                          fd, (int) buf_size, strerror(err), err);
+        }
 
     } else {
         nxt_unit_debug(ctx, "sendmsg(%d, %d, %d): %d", fd, (int) buf_size,


### PR DESCRIPTION
## Summary

Closes two long-standing engine-teardown markers.

### `src/nxt_event_engine.c` — `/* TODO: free timers */`

Every `nxt_timer_t` is embedded inside a containing struct (`nxt_runtime_t::timer`, `nxt_listen_event_t::idle_timer`, request/connection timers in `nxt_h1proto.c` and `nxt_router.c`, …) and is owned by that subsystem — walking the rbtree and freeing nodes would corrupt the embedding subsystem's heap. The only allocation owned by `nxt_timers_t` itself is the `changes` batching array from `nxt_timers_init()`; that is what `nxt_event_engine_free()` now releases.

### `src/nxt_unit.c` — sendmsg severity FIXME

The FIXME asked for `nxt_unit_warn` → `nxt_unit_alert` "after router graceful shutdown is implemented". libunit already tracks the needed lifecycle state in `ctx_impl->online` (`nxt_unit_quit()` zeroes it when the quit decision is made), so the gate is satisfiable today:

- **online** (steady state or deferred graceful drain) → `alert` — the peer should be reachable; a sendmsg failure is a real problem.
- **!online** (context out of service) → `warn` — the peer is going away by design; EPIPE/ECONNRESET-class errors are expected and would otherwise spam the log.

`ctx_impl->quit_param` deliberately **cannot** be the gate: it is initialised to `NXT_QUIT_GRACEFUL` in `nxt_unit_ctx_init()` and re-asserted GRACEFUL in `nxt_unit_quit`'s NORMAL branch, so it is GRACEFUL at steady state too — testing it would route every steady-state sendmsg failure to `warn`, the opposite of the FIXME's intent. The inline comment documents the pitfall.

## Deferred

The `nxt_lib.c` "stop engines" TODO: `nxt_lib_stop()` is `NXT_EXPORT` with no in-tree caller; closing it cleanly needs to walk `rt->engines`, i.e. a public-ABI signature change or a global. Either deserves its own PR with explicit ABI review.

## Verification

On top of `pre-1.35.6`:

```
./configure --tests && make -j$(nproc)     # clean, no warnings
python3 -m pytest test/test_static.py test/test_idle_close_wait.py   # 18 passed, 1 skipped
```

Language-module builds rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
