### PR TITLE
test: expand proxy/OTel/Java coverage and run the C unit suite in CI

### DIFF
--- a/.github/workflows/analysis-clang-ast.yml
+++ b/.github/workflows/analysis-clang-ast.yml
@@ -70,6 +70,14 @@ jobs:
       - name: Build C tests
         run: make -j4 tests
 
+      # Actually execute the C unit-test suite (nxt_tests.c runner): parser,
+      # port/IPC fault-injection, lvlhsh, mp, rbtree, base64, utf8, clone
+      # creds, etc. It was only ever compiled before, so regressions in these
+      # units went uncaught. This job runs as root in a container, which is the
+      # right environment for the privilege-sensitive cases (e.g. clone creds).
+      - name: Run C tests
+        run: ./build/tests
+
       - name: Build Perl language module
         run: ./configure perl && make -j4 perl
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -485,3 +485,28 @@ jobs:
             sudo -E pytest-3 --print-log ${{ steps.metadata.outputs.testpath }}
           fi
         if: steps.metadata.outputs.module != 'wasm'
+
+  # C unit-test suite (src/test/ -> build/tests): HTTP parser, port/IPC
+  # fault-injection, lvlhsh, mp, rbtree, base64, utf8, clone creds, etc.
+  # Previously compiled but never executed in CI; runs here on every PR as its
+  # own check, like the language tests. sudo mirrors the pytest suite so
+  # privilege-sensitive cases (clone creds) work.
+  c-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install build-essential libssl-dev libpcre2-dev
+
+      - name: Configure unit (--tests)
+        run: ./configure --openssl --tests
+
+      - name: Build C tests
+        run: make -j4 tests
+
+      - name: Run C tests
+        run: sudo ./build/tests

--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,12 @@ Changes with FreeUnit 1.35.6                                     07 Jul 2026
        groundwork for graceful connection draining; connection accounting
        in the "/status" API is exact on all close paths.
 
+    *) Change: broaden the regression test suite — proxy Content-Length and
+       chunked-response relay framing, OpenTelemetry 5xx tracing and inbound
+       traceparent handling, and Java ServletInputStream bounds — and run
+       the C unit-test suite in CI, which was previously compiled but never
+       executed.
+
     *) Bugfix: authorize privileged IPC message types by the kernel-validated
        sender PID (SCM_CREDENTIALS), close any received descriptors on every
        rejected privileged message, and cap port queue item size at the slot

--- a/auto/sources
+++ b/auto/sources
@@ -172,6 +172,9 @@ NXT_TEST_SRCS=" \
     src/test/nxt_http_parse_test.c \
     src/test/nxt_strverscmp_test.c \
     src/test/nxt_base64_test.c \
+    src/test/nxt_string_test.c \
+    src/test/nxt_http_chunk_parse_test.c \
+    src/test/nxt_conf_parse_test.c \
     src/test/nxt_port_fail_test.c \
 "
 

--- a/src/test/nxt_conf_parse_test.c
+++ b/src/test/nxt_conf_parse_test.c
@@ -1,0 +1,149 @@
+
+/*
+ * Copyright (C) FreeUnit
+ */
+
+#include <nxt_main.h>
+#include <nxt_conf.h>
+#include <nxt_http_route_addr.h>
+#include "nxt_tests.h"
+
+
+/*
+ * JSON nesting-depth cap (hardening b10a68b4): a payload deeper than
+ * NXT_CONF_JSON_MAX_DEPTH (100) must be rejected instead of recursing and
+ * blowing the controller's stack.
+ */
+nxt_int_t
+nxt_conf_json_depth_test(nxt_thread_t *thr)
+{
+    nxt_mp_t          *mp;
+    nxt_uint_t        i, k, n;
+    nxt_conf_value_t  *value;
+    u_char            buf[512];
+
+    /*
+     * Exercise the exact NXT_CONF_JSON_MAX_DEPTH (100) boundary: 100 nested
+     * arrays are accepted, 101 rejected -- so an off-by-one in the cap is
+     * caught, not just gross over-nesting.
+     */
+    static const struct {
+        nxt_uint_t  depth;
+        nxt_bool_t  valid;
+    } depths[] = {
+        {  50, 1 },
+        { 100, 1 },   /* at the cap */
+        { 101, 0 },   /* one past the cap */
+        { 150, 0 },
+    };
+
+    nxt_thread_time_update(thr);
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (mp == NULL) {
+        return NXT_ERROR;
+    }
+
+    for (k = 0; k < nxt_nitems(depths); k++) {
+        n = depths[k].depth;
+
+        for (i = 0; i < n; i++) {
+            buf[i] = '[';
+            buf[n + i] = ']';
+        }
+
+        value = nxt_conf_json_parse(mp, buf, buf + 2 * n, NULL);
+
+        if ((value != NULL) != (depths[k].valid != 0)) {
+            nxt_log_alert(thr->log, "nxt_conf_json_parse() %d-deep nesting: "
+                          "got %s, expected %s", (int) n,
+                          value != NULL ? "accept" : "reject",
+                          depths[k].valid ? "accept" : "reject");
+            goto fail;
+        }
+    }
+
+    nxt_mp_destroy(mp);
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "nxt_conf_json_parse() depth-cap test passed");
+
+    return NXT_OK;
+
+fail:
+
+    nxt_mp_destroy(mp);
+
+    return NXT_ERROR;
+}
+
+
+/*
+ * Address/port pattern parser (hardening 68f079b6): malformed port ranges
+ * (a dash at either end) and out-of-range CIDR are rejected, while a /32
+ * single-host and normal forms are accepted.
+ */
+nxt_int_t
+nxt_http_route_addr_test(nxt_thread_t *thr)
+{
+    nxt_mp_t          *mp;
+    nxt_int_t         ret;
+    nxt_bool_t        ok;
+    nxt_uint_t        i;
+    nxt_conf_value_t  *cv;
+
+    nxt_http_route_addr_pattern_t  pattern;
+
+    static const struct {
+        nxt_str_t   json;   /* a JSON string literal (quotes included) */
+        nxt_bool_t  ok;     /* expect NXT_OK */
+    } tests[] = {
+        { nxt_string("\"127.0.0.1\""),      1 },
+        { nxt_string("\"127.0.0.1:8080\""), 1 },
+        { nxt_string("\"127.0.0.1/32\""),   1 },   /* /32 single-host */
+        { nxt_string("\"*:0-65535\""),      1 },
+        { nxt_string("\"127.0.0.1:8-\""),   0 },   /* trailing dash */
+        { nxt_string("\"127.0.0.1:-8\""),   0 },   /* leading dash */
+        { nxt_string("\"11.0.0.0/33\""),    0 },   /* CIDR out of range */
+        { nxt_string("\"256.0.0.1\""),      0 },   /* invalid octet */
+    };
+
+    nxt_thread_time_update(thr);
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (mp == NULL) {
+        return NXT_ERROR;
+    }
+
+    for (i = 0; i < nxt_nitems(tests); i++) {
+        cv = nxt_conf_json_parse(mp, tests[i].json.start,
+                                 tests[i].json.start + tests[i].json.length,
+                                 NULL);
+        if (cv == NULL) {
+            nxt_log_alert(thr->log, "route_addr test: JSON parse of %V failed",
+                          &tests[i].json);
+            nxt_mp_destroy(mp);
+            return NXT_ERROR;
+        }
+
+        nxt_memzero(&pattern, sizeof(nxt_http_route_addr_pattern_t));
+
+        ret = nxt_http_route_addr_pattern_parse(mp, &pattern, cv);
+        ok = (ret == NXT_OK);
+
+        if (ok != tests[i].ok) {
+            nxt_log_alert(thr->log, "nxt_http_route_addr_pattern_parse(%V) "
+                          "test failed: ret=%d, expected %s", &tests[i].json,
+                          (int) ret, tests[i].ok ? "NXT_OK" : "error");
+            nxt_mp_destroy(mp);
+            return NXT_ERROR;
+        }
+    }
+
+    nxt_mp_destroy(mp);
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "nxt_http_route_addr_pattern_parse() test passed");
+
+    return NXT_OK;
+}

--- a/src/test/nxt_http_chunk_parse_test.c
+++ b/src/test/nxt_http_chunk_parse_test.c
@@ -1,0 +1,64 @@
+
+/*
+ * Copyright (C) FreeUnit
+ */
+
+#include <nxt_main.h>
+#include "nxt_tests.h"
+
+
+nxt_int_t
+nxt_http_chunk_parse_test(nxt_thread_t *thr)
+{
+    nxt_uint_t              i;
+    nxt_http_chunk_parse_t  hcp;
+    nxt_buf_t               b;
+
+    /*
+     * Only error / terminal inputs are exercised: they are resolved inside the
+     * parser's inner loop (goto chunk_error / return), before any data buffer
+     * is allocated from mem_pool or the work queue is touched -- so a bare
+     * stack nxt_buf_t and the test task suffice. The chunk-size overflow cases
+     * guard nxt_size_is_sufficient() against a wrapped size (hardening).
+     */
+    static const struct {
+        nxt_str_t  input;
+        uint8_t    chunk_error;
+        uint8_t    last;      /* terminal 0-chunk seen */
+    } tests[] = {
+        { nxt_string("0\r\n\r\n"),             0, 1 },  /* clean last-chunk */
+        { nxt_string("z\r\n"),                 1, 0 },  /* non-hex size */
+        { nxt_string("g0\r\n"),                1, 0 },  /* non-hex size 2 */
+        { nxt_string("1ffffffffffffffff\r\n"), 1, 0 },  /* size overflow */
+        { nxt_string("10000000000000000\r\n"), 1, 0 },  /* size overflow */
+    };
+
+    nxt_thread_time_update(thr);
+
+    for (i = 0; i < nxt_nitems(tests); i++) {
+        nxt_memzero(&hcp, sizeof(nxt_http_chunk_parse_t));
+        nxt_memzero(&b, sizeof(nxt_buf_t));
+
+        b.mem.pos = tests[i].input.start;
+        b.mem.free = tests[i].input.start + tests[i].input.length;
+
+        (void) nxt_http_chunk_parse(thr->task, &hcp, &b);
+
+        if (hcp.chunk_error != tests[i].chunk_error
+            || hcp.last != tests[i].last)
+        {
+            nxt_log_alert(thr->log,
+                          "nxt_http_chunk_parse(\"%V\") test failed: "
+                          "chunk_error=%d/%d last=%d/%d (got/expected)",
+                          &tests[i].input, (int) hcp.chunk_error,
+                          (int) tests[i].chunk_error, (int) hcp.last,
+                          (int) tests[i].last);
+            return NXT_ERROR;
+        }
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "nxt_http_chunk_parse() test passed");
+
+    return NXT_OK;
+}

--- a/src/test/nxt_string_test.c
+++ b/src/test/nxt_string_test.c
@@ -1,0 +1,100 @@
+
+/*
+ * Copyright (C) FreeUnit
+ */
+
+#include <nxt_main.h>
+#include "nxt_tests.h"
+
+
+nxt_int_t
+nxt_string_test(nxt_thread_t *thr)
+{
+    u_char      *p;
+    nxt_uint_t  i;
+    nxt_bool_t  enc;
+
+    static const u_char  abc[] = "abc";
+
+    /*
+     * nxt_rmemstrn(): backward substring search. The length guard
+     * (length == 0 || length > buffer) must reject out-of-range lookups
+     * without an over-read / size_t underflow (hardening 740e9bd5).
+     */
+    static const struct {
+        nxt_str_t  haystack;
+        nxt_str_t  needle;
+        nxt_int_t  offset;   /* expected match offset, or -1 for NULL */
+    } rmem[] = {
+        { nxt_string("abcXYZdef"), nxt_string("XYZ"),  3 },
+        { nxt_string("abcXYZdef"), nxt_string("def"),  6 },
+        { nxt_string("aXYbXYc"),   nxt_string("XY"),   4 },  /* last match */
+        { nxt_string("abcdef"),    nxt_string("QQ"),  -1 },  /* not found */
+        { nxt_string("ab"),        nxt_string("XYZ"), -1 },  /* len > buffer */
+    };
+
+    /*
+     * nxt_is_complex_uri_encoded(): a trailing '%' with fewer than two hex
+     * digits must be rejected before reading src+1/src+2 (off-by-one fix
+     * 740e9bd5 / V13: "end - src < 3").
+     */
+    static const struct {
+        nxt_str_t   uri;
+        nxt_bool_t  encoded;
+    } cplx[] = {
+        { nxt_string("/some/path"), 1 },
+        { nxt_string("%2F"),        1 },
+        { nxt_string("a%20b"),      1 },
+        { nxt_string("%2"),         0 },   /* off-by-one guard: 2 bytes */
+        { nxt_string("%"),          0 },   /* 1 byte */
+        { nxt_string("%ZZ"),        0 },   /* invalid hex */
+        { nxt_string(" "),          0 },   /* space must be escaped */
+    };
+
+    nxt_thread_time_update(thr);
+
+    for (i = 0; i < nxt_nitems(rmem); i++) {
+        p = nxt_rmemstrn(rmem[i].haystack.start,
+                         rmem[i].haystack.start + rmem[i].haystack.length,
+                         (char *) rmem[i].needle.start, rmem[i].needle.length);
+
+        if (rmem[i].offset < 0) {
+            if (p != NULL) {
+                nxt_log_alert(thr->log, "nxt_rmemstrn(\"%V\", \"%V\") failed: "
+                              "expected NULL", &rmem[i].haystack,
+                              &rmem[i].needle);
+                return NXT_ERROR;
+            }
+
+            continue;
+        }
+
+        if (p != rmem[i].haystack.start + rmem[i].offset) {
+            nxt_log_alert(thr->log, "nxt_rmemstrn(\"%V\", \"%V\") failed: "
+                          "wrong offset", &rmem[i].haystack, &rmem[i].needle);
+            return NXT_ERROR;
+        }
+    }
+
+    /* Zero-length needle must be rejected (no size_t underflow). */
+
+    if (nxt_rmemstrn(abc, abc + 3, "", 0) != NULL) {
+        nxt_log_alert(thr->log, "nxt_rmemstrn() zero-length test failed");
+        return NXT_ERROR;
+    }
+
+    for (i = 0; i < nxt_nitems(cplx); i++) {
+        enc = nxt_is_complex_uri_encoded(cplx[i].uri.start, cplx[i].uri.length);
+
+        if (enc != cplx[i].encoded) {
+            nxt_log_alert(thr->log, "nxt_is_complex_uri_encoded(\"%V\") failed: "
+                          "got %d, expected %d", &cplx[i].uri, (int) enc,
+                          (int) cplx[i].encoded);
+            return NXT_ERROR;
+        }
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "nxt_string helpers test passed");
+
+    return NXT_OK;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -166,6 +166,22 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_string_test(thr) != NXT_OK) {
+        return 1;
+    }
+
+    if (nxt_http_chunk_parse_test(thr) != NXT_OK) {
+        return 1;
+    }
+
+    if (nxt_conf_json_depth_test(thr) != NXT_OK) {
+        return 1;
+    }
+
+    if (nxt_http_route_addr_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_fail_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -65,6 +65,10 @@ nxt_int_t nxt_utf8_test(nxt_thread_t *thr);
 nxt_int_t nxt_http_parse_test(nxt_thread_t *thr);
 nxt_int_t nxt_strverscmp_test(nxt_thread_t *thr);
 nxt_int_t nxt_base64_test(nxt_thread_t *thr);
+nxt_int_t nxt_string_test(nxt_thread_t *thr);
+nxt_int_t nxt_http_chunk_parse_test(nxt_thread_t *thr);
+nxt_int_t nxt_conf_json_depth_test(nxt_thread_t *thr);
+nxt_int_t nxt_http_route_addr_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);
 

--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -44,6 +44,10 @@ fake_upstream --port <N> --mode <mode> [--requests <N>] [--size <MiB>] [--delay-
 | `slow-drip` | chunked, one 512-byte chunk every `--delay-ms` ms, proper terminal chunk — relay vs `proxy_read_timeout` (#72 case 5) |
 | `dup-te` | 200 with `Transfer-Encoding: chunked` header sent **twice** + valid chunked body — duplicate-TE relay (#72 case 6, nginx/unit#1088) |
 | `overrun-cl` | 200 with a fixed `Content-Length` (100) but 150 body bytes — upstream overruns its advertised length. FreeUnit must relay exactly the advertised bytes and drop the excess (no response splitting), then close the connection as inconsistent |
+| `bad-cl` | 200 with a syntactically invalid `Content-Length: notanumber` + a short body — FreeUnit must log and mark the response inconsistent instead of mis-framing the relayed body |
+| `overrun-cl-ka` | as `overrun-cl` but keep-alive-able (no `Connection: close`) — isolates the *inconsistent* flag: only FreeUnit's own decision can close the downstream connection |
+| `chunked-trailer` | chunked 40-byte body + a trailer field after the terminal `0` chunk — relay must keep the body intact |
+| `chunked-ext` | chunked 40-byte body with a `;ext=val` chunk-extension on each size line — relay must strip extensions and keep the body intact |
 
 Deterministic body: byte at global offset `i` is `"0123456789abcdef"[i % 16]`,
 so a test regenerates the exact sequence and verifies the relayed body
@@ -71,6 +75,10 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 | Port | Token | Mode (CLI) | Rust handler | pytest |
 |------|-------|-----------|--------------|--------|
+| 7985 | `chunked_ext` | `chunked-ext` | `respond_chunked_edge` | `test_proxy_chunked_ext` (chunk-extensions stripped, body intact) |
+| 7986 | `chunked_trailer` | `chunked-trailer` | `respond_chunked_edge` | `test_proxy_chunked_trailer` (trailer after terminal chunk, body intact) |
+| 7987 | `overrun_cl_ka` | `overrun-cl-ka` | `respond_overrun_cl_ka` | `test_proxy_overrun_cl_keepalive` (inconsistent flag closes downstream conn) |
+| 7988 | `bad_cl` | `bad-cl` | `respond_bad_cl` | `test_proxy_bad_cl` (invalid upstream Content-Length → logged + inconsistent, no mis-framing) |
 | 7989 | `overrun_cl` | `overrun-cl` | `respond_overrun_cl` | `test_proxy_overrun_cl` (Content-Length overrun → excess truncated, no response splitting) |
 | 7990 | `echo` | `echo` | `respond` (echo arm) | — (shared sanity) |
 | 7991 | `strict` | `strict` | `handle` (Strict arm) | chunked **request** → CL (#445, #58) |

--- a/test/fake_upstream/src/main.rs
+++ b/test/fake_upstream/src/main.rs
@@ -52,7 +52,24 @@ enum Mode {
     SlowDrip,
     DupTe,
     OverrunCl,
+    BadCl,
+    OverrunClKa,
+    ChunkedTrailer,
+    ChunkedExt,
 }
+
+/// Small fixed body (bytes) for the `chunked-trailer` / `chunked-ext` modes.
+/// Deterministic (PATTERN by offset) so the test regenerates it exactly; split
+/// into two chunks by CHUNKED_EDGE_SPLIT.
+const CHUNKED_EDGE_LEN: usize = 40;
+const CHUNKED_EDGE_SPLIT: usize = 16;
+
+/// Deterministic body for the `bad-cl` mode and the exact (invalid)
+/// Content-Length value it advertises. The value is non-numeric so the
+/// upstream Content-Length parse fails (n < 0), exercising the "log and
+/// flag inconsistent" branch in nxt_http_proxy_content_length.
+const BAD_CL_BODY: &[u8] = b"0123456789";
+const BAD_CL_VALUE: &str = "notanumber";
 
 /// Advertised Content-Length and the number of unadvertised excess bytes for
 /// the `overrun-cl` mode. Kept tiny and fixed so the whole response fits one
@@ -420,6 +437,100 @@ fn respond_overrun_cl(stream: &mut TcpStream) {
     let _ = stream.flush();
 }
 
+/// Send a response whose Content-Length is syntactically invalid
+/// (non-numeric), followed by a small body, then close. FreeUnit's
+/// nxt_http_proxy_content_length must log and mark the response
+/// inconsistent rather than leaving content_length_n at -1 and
+/// mis-framing the relayed body. Mirrors pytest `test_proxy_bad_cl`.
+fn respond_bad_cl(stream: &mut TcpStream) {
+    let mut resp = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n",
+        BAD_CL_VALUE
+    )
+    .into_bytes();
+
+    resp.extend_from_slice(BAD_CL_BODY);
+
+    let _ = stream.write_all(&resp);
+    let _ = stream.flush();
+}
+
+/// Like `overrun-cl` but the response is keep-alive-able (HTTP/1.1, no
+/// `Connection: close`). The point is to prove that FreeUnit closes the
+/// *downstream* connection because it flagged the response inconsistent —
+/// not merely because the upstream asked to close. Mirrors pytest
+/// `test_proxy_overrun_cl_keepalive`.
+fn respond_overrun_cl_ka(stream: &mut TcpStream) {
+    let total = OVERRUN_DECLARED + OVERRUN_EXCESS;
+
+    let mut resp = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Length: {}\r\n\r\n",
+        OVERRUN_DECLARED
+    )
+    .into_bytes();
+
+    for i in 0..total {
+        resp.push(PATTERN[i % PATTERN.len()]);
+    }
+
+    let _ = stream.write_all(&resp);
+    let _ = stream.flush();
+}
+
+/// Write CHUNKED_EDGE_LEN deterministic bytes as two chunks. `ext` adds a
+/// chunk-extension to each chunk-size line; `trailer` appends a trailer field
+/// after the terminal chunk. Both must be relayed transparently: the client
+/// gets the exact body, extensions stripped, and (per Unit) trailers dropped.
+fn respond_chunked_edge(stream: &mut TcpStream, ext: bool, trailer: bool) {
+    let head = "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/octet-stream\r\n\
+                Transfer-Encoding: chunked\r\n\
+                Connection: close\r\n\r\n";
+    if stream.write_all(head.as_bytes()).is_err() {
+        return;
+    }
+
+    let sizes = [CHUNKED_EDGE_SPLIT, CHUNKED_EDGE_LEN - CHUNKED_EDGE_SPLIT];
+    let mut offset = 0usize;
+
+    for n in sizes {
+        let mut chunk = Vec::with_capacity(n);
+        for i in 0..n {
+            chunk.push(PATTERN[(offset + i) % PATTERN.len()]);
+        }
+        offset += n;
+
+        let size_line = if ext {
+            format!("{:x};ext=val\r\n", n)
+        } else {
+            format!("{:x}\r\n", n)
+        };
+
+        if stream
+            .write_all(size_line.as_bytes())
+            .and_then(|_| stream.write_all(&chunk))
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .is_err()
+        {
+            return;
+        }
+    }
+
+    let terminal: &[u8] = if trailer {
+        b"0\r\nX-Trailer-Test: trailed\r\n\r\n"
+    } else {
+        b"0\r\n\r\n"
+    };
+
+    let _ = stream.write_all(terminal);
+    let _ = stream.flush();
+}
+
 fn handle(mut stream: TcpStream, opts: &Opts) {
     let req = match read_request(&stream) {
         Ok(r) => r,
@@ -448,6 +559,22 @@ fn handle(mut stream: TcpStream, opts: &Opts) {
 
         Mode::OverrunCl => {
             respond_overrun_cl(&mut stream);
+        }
+
+        Mode::BadCl => {
+            respond_bad_cl(&mut stream);
+        }
+
+        Mode::OverrunClKa => {
+            respond_overrun_cl_ka(&mut stream);
+        }
+
+        Mode::ChunkedTrailer => {
+            respond_chunked_edge(&mut stream, false, true);
+        }
+
+        Mode::ChunkedExt => {
+            respond_chunked_edge(&mut stream, true, false);
         }
 
         Mode::Echo => {
@@ -506,7 +633,8 @@ fn usage() -> ! {
     eprintln!(
         "Usage: fake_upstream --port <N> \
          --mode <requires-cl|no-te|strict|echo|chunked-response|\
-         abort-mid|slow-drip|dup-te|overrun-cl> \
+         abort-mid|slow-drip|dup-te|overrun-cl|bad-cl|\
+         overrun-cl-ka|chunked-trailer|chunked-ext> \
          [--requests <N>] [--size <MiB>] [--delay-ms <N>]"
     );
     process::exit(1);
@@ -540,6 +668,10 @@ fn main() {
                     "slow-drip" => Some(Mode::SlowDrip),
                     "dup-te" => Some(Mode::DupTe),
                     "overrun-cl" => Some(Mode::OverrunCl),
+                    "bad-cl" => Some(Mode::BadCl),
+                    "overrun-cl-ka" => Some(Mode::OverrunClKa),
+                    "chunked-trailer" => Some(Mode::ChunkedTrailer),
+                    "chunked-ext" => Some(Mode::ChunkedExt),
                     _ => None,
                 });
             }

--- a/test/java/input_readline_bounds/app.java
+++ b/test/java/input_readline_bounds/app.java
@@ -1,0 +1,46 @@
+import java.io.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/*
+ * Calls ServletInputStream.readLine(buf, off, len) with a length that
+ * overruns the target array. The native readLine (nxt_jni_InputStream.c)
+ * must reject the out-of-bounds (off, len) rather than perform an OOB write
+ * past the array's heap allocation. Post-fix that surfaces as an
+ * IllegalStateException; the worker must stay alive.
+ */
+@WebServlet("/")
+public class app extends HttpServlet
+{
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException
+    {
+        ServletInputStream in = request.getInputStream();
+        byte[] buf = new byte[8];
+        String result;
+
+        try {
+            /* len (1000) far exceeds buf.length (8) -> must be rejected. */
+            in.readLine(buf, 0, 1000);
+            result = "no-exception";
+
+        } catch (IllegalStateException e) {
+            result = "rejected";
+
+        } catch (Throwable t) {
+            result = "other:" + t.getClass().getSimpleName();
+        }
+
+        byte[] out = result.getBytes("UTF-8");
+
+        response.setContentType("text/plain");
+        response.setContentLength(out.length);
+        response.getOutputStream().write(out);
+    }
+}

--- a/test/test_java_application.py
+++ b/test/test_java_application.py
@@ -1032,3 +1032,26 @@ def test_java_application_threads():
         sock.close()
 
     assert len(socks) == len(threads), 'threads differs'
+
+
+def test_java_input_readline_bounds():
+    client.load('input_readline_bounds')
+
+    # The app calls ServletInputStream.readLine(buf, 0, 1000) into an 8-byte
+    # buffer. The native readLine must reject the out-of-bounds (off, len)
+    # (IllegalStateException) instead of writing past the array; the worker
+    # must stay alive to serve the follow-up request.
+    resp = client.post(
+        headers={'Host': 'localhost', 'Connection': 'close'},
+        body='0123456789',
+    )
+    assert resp['status'] == 200, f'status: {resp}'
+    assert resp['body'] == 'rejected', f'bad readLine bounds not rejected: {resp}'
+
+    # Worker survived the guarded call.
+    assert (
+        client.post(
+            headers={'Host': 'localhost', 'Connection': 'close'}, body='x'
+        )['status']
+        == 200
+    ), 'worker survived'

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -1,3 +1,4 @@
+import json
 import os
 import socket
 import subprocess
@@ -117,15 +118,18 @@ def _response_headers_lower(resp):
     return {k.lower(): v for k, v in resp['headers'].items()}
 
 
-def _get_until_header(header, retries=50, delay=0.1, **kwargs):
+def _get_until_header(header, retries=150, delay=0.1, **kwargs):
     """Re-issue GET until `header` is present in the response, or retries run out.
 
     OTel (re)initialises asynchronously in the router *after* the control API
     has already accepted the telemetry config, so the very first request can
     race ahead of the tracer being ready: no span is created, hence no
-    traceparent is injected. Poll briefly to absorb that init lag. A header that
-    never appears still fails the caller's assertion, so a real regression is
-    not masked. Extra kwargs are forwarded to `client.get` (e.g. headers).
+    traceparent is injected. Poll to absorb that init lag -- the gRPC exporter
+    in particular can take several seconds to establish on a loaded CI runner,
+    which the previous 5s budget occasionally missed. The loop returns the
+    moment the header appears, so a larger cap costs nothing on the happy path;
+    a header that never appears still fails the caller's assertion, so a real
+    regression is not masked. Extra kwargs are forwarded to `client.get`.
     """
     resp = client.get(**kwargs)
     for _ in range(retries):
@@ -165,6 +169,102 @@ def test_otel_span_exported_with_service_name(tmp_path, protocol):
         assert b'http.request.method' in body, 'span must carry semconv method attr'
         assert b'url.path' in body, 'span must carry semconv url.path attr'
         assert b'http.response.status_code' in body, 'span must carry status attr'
+    finally:
+        _kill(proc)
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_span_5xx_status(tmp_path, protocol):
+    """A 5xx response is still traced and the span records the error status.
+
+    The status_code attribute is emitted as a string (sprintf "%d"), so the
+    literal `503` travels in the OTLP payload. Per the 1.35.6 fix, 503 >= 500
+    also marks the span Status::Error (nxt_otel_rs_set_error); that enum is not
+    asserted here (it is not a literal in the protobuf), but the status_code
+    value is the concrete, reliable signal.
+    """
+    port = _get_free_port()
+    dump = str(tmp_path / 'otlp_dump.bin')
+    # Run forever and accumulate every export into the dump, so the readiness
+    # phase (200 spans) does not consume a one-shot budget before the 503 span.
+    proc = _run_fake_otlp(port, dump=dump, protocol=protocol)
+    try:
+        _configure_or_skip(port, protocol=protocol)
+
+        # OTel inits asynchronously; wait until the tracer is ready on the
+        # default 200 route (traceparent injected) before the error path.
+        ready = _get_until_header('traceparent')
+        assert (
+            ready['status'] == 200
+            and 'traceparent' in _response_headers_lower(ready)
+        ), 'tracer did not become ready'
+
+        assert 'success' in client.conf(
+            '503', 'routes/0/action/return'
+        ), 'switch route to return 503'
+
+        # Fire 503s until the error span reaches the collector. status_code is
+        # emitted as the string "503" (sprintf "%d"); per the 1.35.6 fix,
+        # 503 >= 500 also marks the span Status::Error (not asserted here -- it
+        # is a protobuf enum, not a literal). Only the 503 requests can add the
+        # "503" bytes, so the readiness 200 spans don't false-positive.
+        body = b''
+        found = False
+        for _ in range(int(EXPORT_TIMEOUT * 10)):
+            resp = client.get()
+            assert resp['status'] == 503, f'expected 503: {resp}'
+
+            # The exporter may not have created the dump on the first pass.
+            if os.path.exists(dump):
+                with open(dump, 'rb') as f:
+                    body = f.read()
+
+                if b'503' in body:
+                    found = True
+                    break
+
+            time.sleep(0.1)
+
+        assert found, 'span with status_code=503 was not exported'
+        assert b'http.response.status_code' in body, 'status_code attr missing'
+    finally:
+        _kill(proc)
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.xfail(
+    reason=(
+        'Suspected bug: a malformed inbound traceparent returns HTTP 500 '
+        'instead of being ignored. nxt_otel_parse_traceparent() returns '
+        'NXT_ERROR on a length/format mismatch (src/nxt_otel.c ~445-476), and a '
+        'header-parse callback returning NXT_ERROR fails the request. W3C '
+        'Trace Context 3.2.2.3 requires an unparseable traceparent to be '
+        'ignored and the trace restarted, not to reject the request -- so on '
+        'an OTel-enabled listener any client can force a 500 with '
+        '"traceparent: x". Deterministic, so strict=True: once #109 is fixed '
+        'the test xpasses -> fails, forcing removal of this marker. '
+        'See freeunitorg/freeunit#109.'
+    ),
+    strict=True,
+)
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_traceparent_malformed(protocol):
+    """A malformed inbound traceparent should be ignored (the trace is
+    restarted), not turned into an error response."""
+    port = _get_free_port()
+    proc = _run_fake_otlp(port, protocol=protocol)  # run forever, absorb exports
+    try:
+        _configure_or_skip(port, protocol=protocol)
+
+        resp = client.get(
+            headers={
+                'Host': 'localhost',
+                'traceparent': 'this-is-not-a-valid-traceparent',
+                'Connection': 'close',
+            }
+        )
+        assert resp['status'] == 200, f'malformed traceparent must not error: {resp}'
     finally:
         _kill(proc)
 
@@ -316,3 +416,22 @@ def test_otel_sampling_ratio_bounds_accepted(ratio):
     _require_otel()
     conf = client.conf(_config(_valid_telemetry(1, sampling_ratio=ratio)))
     assert 'success' in conf, f'sampling_ratio={ratio} must be accepted: {conf}'
+
+
+def test_otel_sampling_ratio_nonfinite_rejected():
+    """A sampling_ratio that overflows to a non-finite double is rejected.
+
+    Closest reachable proxy for the NaN-validator fix (33c7f0e0): strict JSON
+    cannot express NaN, but a huge exponent (`1e400`) parses to +Inf, which
+    must still land in the error path (> 1). Injected as a raw JSON number
+    literal -- json.dumps() of a Python float would emit `Infinity`, testing
+    the parser instead of the validator.
+    """
+    _require_otel()
+
+    body = json.dumps(_config(_valid_telemetry(1)))
+    body = body.replace('"sampling_ratio": 1.0', '"sampling_ratio": 1e400')
+    assert '1e400' in body, 'sampling_ratio literal not injected'
+
+    conf = client.conf(body)
+    assert 'error' in conf, f'non-finite sampling_ratio must be rejected: {conf}'

--- a/test/test_proxy_bad_cl.py
+++ b/test/test_proxy_bad_cl.py
@@ -1,0 +1,96 @@
+"""Proxy invalid upstream Content-Length regression test.
+
+When a proxied upstream sends a syntactically invalid Content-Length (a value
+that does not parse or overflows nxt_off_t), FreeUnit must not leave
+content_length_n at -1 and mis-frame the relayed body. The hardening in
+nxt_http_proxy_content_length logs the bad value and marks the response
+inconsistent (disabling keep-alive, closing the connection).
+
+Client-observable outcome, confirmed on CI: Unit relays the response (200 +
+body) and even forwards the unusable `Content-Length` header verbatim, but the
+inconsistent flag forces `Connection: close` -- so the broken framing is bounded
+by connection close and cannot desync a kept-alive connection. The invalid
+value is also logged at [warn]. This test pins that outcome; assertions carry
+the full response so a future behavior change surfaces the actual response.
+
+Driven by the `bad-cl` mode of the Rust mock upstream (test/fake_upstream/): it
+sends `Content-Length: notanumber` followed by a short body, then closes.
+Language-module-free (gated only on built-in proxy support).
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from unit.applications.proto import ApplicationProto
+from unit.utils import waitforsocket
+
+client = ApplicationProto()
+
+# Must match BAD_CL_BODY / BAD_CL_VALUE in test/fake_upstream/src/main.rs.
+BAD_CL_BODY = '0123456789'
+BAD_CL_VALUE = 'notanumber'
+
+# Reserved fake_upstream port for this case (see test/fake_upstream/README.md).
+UPSTREAM_BAD_CL_PORT = 7988
+
+FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
+
+_skipif_no_fake_upstream = pytest.mark.skipif(
+    not os.path.exists(FAKE_UPSTREAM_BIN),
+    reason=f'{FAKE_UPSTREAM_BIN} not installed (build via test/fake_upstream)',
+)
+
+
+def _run_bad_cl(port=UPSTREAM_BAD_CL_PORT):
+    proc = subprocess.Popen(
+        [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', 'bad-cl'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        waitforsocket(port)
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
+    return proc
+
+
+@_skipif_no_fake_upstream
+def test_proxy_bad_cl(skip_alert):
+    # The router logs a warning about the invalid upstream Content-Length;
+    # it is [warn] not [alert], but suppress it defensively.
+    skip_alert(r'upstream Content-Length .* is invalid')
+
+    proc = _run_bad_cl()
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {
+                        "action": {
+                            "proxy": f'http://127.0.0.1:{UPSTREAM_BAD_CL_PORT}'
+                        }
+                    }
+                ],
+            }
+        ), 'bad-cl proxy configuration'
+
+        resp = client.get(port=8080)
+
+        # The response is relayed with its body intact...
+        assert resp['status'] == 200, f'unexpected status: {resp}'
+        assert resp['body'] == BAD_CL_BODY, f'body not relayed intact: {resp}'
+
+        # ...but the invalid Content-Length marks the response inconsistent, so
+        # the connection is closed rather than kept alive -- bounding the
+        # unusable framing to a single connection (no keep-alive desync).
+        assert (
+            resp['headers'].get('Connection') == 'close'
+        ), f'inconsistent response must close the connection: {resp}'
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/test/test_proxy_chunked_edge.py
+++ b/test/test_proxy_chunked_edge.py
@@ -1,0 +1,125 @@
+"""Proxy chunked-response relay edge cases: chunk-extensions and trailers.
+
+The upstream sends a chunked response whose chunk-size lines carry a
+chunk-extension (`<size>;ext=val`), or which appends a trailer field after the
+terminal `0` chunk. FreeUnit must relay the body transparently and intact in
+both cases -- extensions are not part of the payload, and a trailer must not
+corrupt or truncate the relayed body.
+
+Driven by the `chunked-ext` / `chunked-trailer` modes of the Rust mock upstream
+(test/fake_upstream/), each sending the same 40-byte deterministic body split
+into two chunks. Language-module-free (gated only on built-in proxy support).
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from unit.applications.proto import ApplicationProto
+from unit.utils import waitforsocket
+
+client = ApplicationProto()
+
+# Deterministic body: byte at global offset i is PATTERN[i % 16] — mirrors the
+# fake_upstream PATTERN. Must match CHUNKED_EDGE_LEN in main.rs.
+PATTERN = '0123456789abcdef'
+EDGE_LEN = 40
+EXPECTED_BODY = (PATTERN * (EDGE_LEN // len(PATTERN) + 1))[:EDGE_LEN]
+
+# Reserved fake_upstream ports (see test/fake_upstream/README.md).
+UPSTREAM_CHUNKED_TRAILER_PORT = 7986
+UPSTREAM_CHUNKED_EXT_PORT = 7985
+
+FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
+
+_skipif_no_fake_upstream = pytest.mark.skipif(
+    not os.path.exists(FAKE_UPSTREAM_BIN),
+    reason=f'{FAKE_UPSTREAM_BIN} not installed (build via test/fake_upstream)',
+)
+
+
+def _run(port, mode):
+    proc = subprocess.Popen(
+        [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', mode],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        waitforsocket(port)
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
+    return proc
+
+
+def _dechunk(body):
+    """Minimal chunked decoder: strips chunk-extensions and stops at the
+    terminal 0-chunk (ignoring any trailer), so it is robust to both edge
+    cases regardless of how the harness would parse them."""
+    out = []
+    i = 0
+    while i < len(body):
+        j = body.find('\r\n', i)
+        if j < 0:
+            break
+        size = int(body[i:j].split(';', 1)[0], 16)
+        i = j + 2
+        if size == 0:
+            break
+        out.append(body[i : i + size])
+        i += size + 2  # chunk data + trailing CRLF
+    return ''.join(out)
+
+
+def _relayed_body(port):
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [{"action": {"proxy": f'http://127.0.0.1:{port}'}}],
+        }
+    ), 'chunked-edge proxy configuration'
+
+    raw = client.get(port=8080, raw_resp=True)
+    head, _, body = raw.partition('\r\n\r\n')
+
+    assert head.split('\r\n', 1)[0].startswith('HTTP/1.1 200'), f'status: {raw!r}'
+
+    if 'transfer-encoding: chunked' in head.lower():
+        body = _dechunk(body)
+
+    return body, raw
+
+
+@_skipif_no_fake_upstream
+def test_proxy_chunked_ext():
+    proc = _run(UPSTREAM_CHUNKED_EXT_PORT, 'chunked-ext')
+    try:
+        body, raw = _relayed_body(UPSTREAM_CHUNKED_EXT_PORT)
+        assert body == EXPECTED_BODY, f'chunk-extension body mismatch: {raw!r}'
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+@pytest.mark.xfail(
+    reason=(
+        'Suspected bug: FreeUnit aborts the relay of a chunked upstream '
+        'response that carries a trailer section after the terminal 0-chunk. '
+        'The client gets a truncated body (observed racy on CI: 0 or 1 of the '
+        '2 chunks delivered before the connection closes), whereas chunked-ext '
+        '(same body, no trailer) relays intact. Trailers are legal HTTP/1.1 '
+        '(RFC 7230 4.1.2). See freeunitorg/freeunit#106.'
+    ),
+    strict=False,
+)
+def test_proxy_chunked_trailer():
+    proc = _run(UPSTREAM_CHUNKED_TRAILER_PORT, 'chunked-trailer')
+    try:
+        body, raw = _relayed_body(UPSTREAM_CHUNKED_TRAILER_PORT)
+        assert body == EXPECTED_BODY, f'trailer body mismatch: {raw!r}'
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/test/test_proxy_overrun_cl.py
+++ b/test/test_proxy_overrun_cl.py
@@ -20,6 +20,7 @@ it runs on the minimal test build.
 """
 
 import os
+import socket
 import subprocess
 
 import pytest
@@ -37,8 +38,9 @@ PATTERN = '0123456789abcdef'
 DECLARED = 100
 EXCESS = 50
 
-# Reserved fake_upstream port for this case (see test/fake_upstream/README.md).
+# Reserved fake_upstream ports for these cases (see test/fake_upstream/README.md).
 UPSTREAM_OVERRUN_PORT = 7989
+UPSTREAM_OVERRUN_KA_PORT = 7987
 
 FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
 
@@ -48,9 +50,9 @@ _skipif_no_fake_upstream = pytest.mark.skipif(
 )
 
 
-def _run_overrun_cl(port=UPSTREAM_OVERRUN_PORT):
+def _run(port, mode):
     proc = subprocess.Popen(
-        [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', 'overrun-cl'],
+        [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', mode],
         stdout=subprocess.DEVNULL,
         # DEVNULL, not PIPE: nothing reads this stream, and an unread PIPE can
         # deadlock the child if it ever fills the OS pipe buffer.
@@ -65,6 +67,10 @@ def _run_overrun_cl(port=UPSTREAM_OVERRUN_PORT):
         proc.wait()
         raise
     return proc
+
+
+def _run_overrun_cl(port=UPSTREAM_OVERRUN_PORT):
+    return _run(port, 'overrun-cl')
 
 
 @_skipif_no_fake_upstream
@@ -103,6 +109,61 @@ def test_proxy_overrun_cl(skip_alert):
             f'got {len(resp["body"])} bytes'
         )
         assert resp['body'] == expected, 'relayed body mismatch'
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_overrun_cl_keepalive(skip_alert):
+    # Same overrun, but the upstream response is keep-alive-able (no
+    # `Connection: close`). This isolates the *inconsistent* flag: the only
+    # thing that can close the downstream connection here is FreeUnit deciding
+    # the response is inconsistent -- not a relayed upstream close. A regression
+    # that dropped the inconsistent flag would leave the connection open (the
+    # recv below would then time out rather than see EOF).
+    skip_alert(r'upstream sent .* body bytes past Content-Length')
+
+    proc = _run(UPSTREAM_OVERRUN_KA_PORT, 'overrun-cl-ka')
+    try:
+        assert 'success' in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "routes"}},
+                "routes": [
+                    {
+                        "action": {
+                            "proxy": f'http://127.0.0.1:{UPSTREAM_OVERRUN_KA_PORT}'
+                        }
+                    }
+                ],
+            }
+        ), 'overrun-cl-ka proxy configuration'
+
+        # Keep-alive request (no Connection: close), read the raw response
+        # ourselves so we can observe whether the server closes the socket.
+        sock = client.get(port=8080, no_recv=True)
+        sock.settimeout(10)
+
+        data = b''
+        closed = False
+        try:
+            while True:
+                part = sock.recv(4096)
+                if not part:
+                    closed = True
+                    break
+                data += part
+        except socket.timeout:
+            closed = False
+        finally:
+            sock.close()
+
+        body = data.split(b'\r\n\r\n', 1)[1] if b'\r\n\r\n' in data else b''
+        expected = ((PATTERN * (DECLARED // len(PATTERN) + 1))[:DECLARED]).encode()
+
+        assert data[:12] == b'HTTP/1.1 200', f'status line: {data[:40]!r}'
+        assert body == expected, f'relayed body mismatch: {body!r}'
+        assert closed, 'inconsistent response must close the downstream connection'
     finally:
         proc.terminate()
         proc.wait()


### PR DESCRIPTION
## Summary

Test-coverage push for FreeUnit: pins security-relevant and behavioral
guarantees with tests that **actually run in CI**, so a regression fails loudly
instead of silently reopening a vector. Also fixes the long-standing gap where
the C unit suite was compiled but never executed.

## pytest — proxy / OTel / Java

- **Proxy Content-Length** (`test_proxy_bad_cl.py`, `test_proxy_overrun_cl.py`):
  invalid upstream `Content-Length` is relayed verbatim and the connection is
  forced closed (no keep-alive desync); overrun bodies are truncated to the
  declared length.
- **Proxy chunked** (`test_proxy_chunked_edge.py`): chunk-extensions stripped,
  body intact.
- **OTel** (`test_otel.py`): 5xx responses are traced with `status_code=503`;
  malformed inbound `traceparent` handling.
- **Java SAPI** (`test_java_application.py`, `input_readline_bounds/app.java`):
  `ServletInputStream.readLine(off, len)` rejects out-of-bounds args instead of
  writing past the buffer; worker survives.

New `fake_upstream` modes to drive these: `bad-cl`, `overrun-cl-ka`,
`chunked-ext`, `chunked-trailer` (README + port registry updated).

## C unit tests (`src/test/` → `build/tests`)

Three pure-function suites, registered in `nxt_tests.c` / `nxt_tests.h` /
`auto/sources`:

- `nxt_string_test.c` — `nxt_rmemstrn` bounds + `nxt_is_complex_uri_encoded`
  off-by-one.
- `nxt_http_chunk_parse_test.c` — chunk-size overflow / non-hex.
- `nxt_conf_parse_test.c` — JSON depth cap (boundary 100/101) + address /
  port-range / CIDR parser.

## CI

- The C suite was **compiled but never run**. Now executed on every PR: a
  dedicated `c-tests` job in `build-test.yml` and a `Run C tests` step in
  `analysis-clang-ast.yml` (both under root/sudo for privilege-sensitive cases).
- Bump `actions/cache` v5 → v6.

## Bugs surfaced (filed, xfailed)

- **#106** — chunked response relay truncates the body when the upstream appends
  a trailer after the terminal `0`-chunk (`test_proxy_chunked_trailer`).
- **#109** — malformed inbound `traceparent` → HTTP 500 instead of being ignored
  (W3C 3.2.2.3 violation, client-triggerable on OTel listeners)
  (`test_otel_traceparent_malformed`).

Both fixes are maintainer-domain; remove the `xfail` markers once fixed.
