### PR TITLE
Add target branch for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "pre-1.35.6"
     schedule:
       interval: weekly


### PR DESCRIPTION
### Proposed changes


This pull request makes a configuration change to Dependabot to specify a target branch for GitHub Actions updates.

- Dependabot configuration: Added `target-branch: "pre-1.35.6"` to the GitHub Actions update settings in `.github/dependabot.yml`, ensuring that automated dependency updates are created against the `pre-1.35.6` branch instead of the default branch.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
