### PR TITLE
Add target branch for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "pre-1.35.6"
     schedule:
       interval: weekly


### PR DESCRIPTION
### Proposed changes

This pull request introduces a configuration update to Dependabot for GitHub Actions, specifying a target branch for updates.

Dependabot configuration:

* Added the `target-branch: "pre-1.35.6"` setting to the GitHub Actions update configuration in `.github/dependabot.yml`, so that dependency updates are proposed against the `pre-1.35.6` branch instead of the default branch.

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] If applicable, I have added tests
- [ ] If applicable, I have updated documentation