### PR TITLE
fix(conf): reject rootfs paths that lexically resolve to "/"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -100,6 +100,10 @@ Changes with FreeUnit 1.35.6                                     07 Jul 2026
        isolation options, and validate "rootfs" as an absolute path other
        than "/" at configuration time.
 
+    *) Bugfix: reject a "rootfs" that lexically resolves to "/" (such as
+       "/.", "/..", or "/foo/.."); chroot("/") is a no-op and would silently
+       defeat rootfs isolation.
+
     *) Bugfix: cap JSON parser depth and element counts in the controller,
        scrub PHP TrueAsync exception state before the prototype fork, and bind
        the Ruby rack.input / rack.errors handles to their originating request.

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -3488,6 +3488,48 @@ nxt_conf_vldt_cgroup_path(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 
 #if (NXT_HAVE_ISOLATION_ROOTFS)
 
+/*
+ * Return TRUE if the absolute, NUL-free path normalizes to "/" once "." and
+ * ".." components are collapsed (".." is clamped at root, matching what the
+ * kernel does at chroot/pivot_root time).  Such a path silently defeats rootfs
+ * isolation -- chroot("/") is a no-op -- so the validators reject it.  Caller
+ * ensures the path begins with '/' and contains no embedded NUL.
+ */
+static nxt_bool_t
+nxt_rootfs_resolves_to_root(const u_char *path, size_t length)
+{
+    size_t  i, comp_len, depth;
+
+    depth = 0;
+
+    for (i = 1; i < length; ) {           /* skip the leading '/' */
+
+        comp_len = 0;
+        while (i < length && path[i] != '/') {
+            comp_len++;
+            i++;
+        }
+
+        if (comp_len == 2 && path[i - 2] == '.' && path[i - 1] == '.') {
+            if (depth > 0) {
+                depth--;
+            }
+
+        } else if (comp_len != 0
+                   && !(comp_len == 1 && path[i - 1] == '.'))
+        {
+            depth++;
+        }
+
+        if (i < length) {
+            i++;                         /* skip the separator */
+        }
+    }
+
+    return depth == 0;
+}
+
+
 static nxt_int_t
 nxt_conf_vldt_rootfs_path(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     void *data)
@@ -3515,6 +3557,13 @@ nxt_conf_vldt_rootfs_path(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
                                    "The \"rootfs\" path \"%V\" is invalid; "
                                    "an absolute path other than \"/\" "
                                    "is required.",
+                                   &rootfs);
+    }
+
+    if (nxt_rootfs_resolves_to_root(rootfs.start, trimmed_len)) {
+        return nxt_conf_vldt_error(vldt,
+                                   "The \"rootfs\" path \"%V\" is invalid; "
+                                   "it resolves to \"/\".",
                                    &rootfs);
     }
 

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -489,6 +489,48 @@ nxt_isolation_clone_flags(nxt_task_t *task, nxt_conf_value_t *namespaces,
 
 #if (NXT_HAVE_ISOLATION_ROOTFS)
 
+/*
+ * Return TRUE if the absolute, NUL-free path normalizes to "/" once "." and
+ * ".." components are collapsed (".." clamped at root, like the kernel at
+ * chroot/pivot_root).  Mirrors nxt_conf_validation.c; duplicated rather than
+ * shared so the validator stays the only cross-TU entry point for rootfs
+ * syntax.  Defense in depth: config validation already rejects these.
+ */
+static nxt_bool_t
+nxt_rootfs_resolves_to_root(const u_char *path, size_t length)
+{
+    size_t  i, comp_len, depth;
+
+    depth = 0;
+
+    for (i = 1; i < length; ) {
+
+        comp_len = 0;
+        while (i < length && path[i] != '/') {
+            comp_len++;
+            i++;
+        }
+
+        if (comp_len == 2 && path[i - 2] == '.' && path[i - 1] == '.') {
+            if (depth > 0) {
+                depth--;
+            }
+
+        } else if (comp_len != 0
+                   && !(comp_len == 1 && path[i - 1] == '.'))
+        {
+            depth++;
+        }
+
+        if (i < length) {
+            i++;
+        }
+    }
+
+    return depth == 0;
+}
+
+
 static nxt_int_t
 nxt_isolation_set_rootfs(nxt_task_t *task, nxt_conf_value_t *isolation,
     nxt_process_t *process)
@@ -509,6 +551,20 @@ nxt_isolation_set_rootfs(nxt_task_t *task, nxt_conf_value_t *isolation,
         if (nxt_slow_path(str.length <= 1 || str.start[0] != '/')) {
             nxt_log(task, NXT_LOG_ERR, "rootfs requires an absolute path other "
                     "than \"/\" but given \"%V\"", &str);
+
+            return NXT_ERROR;
+        }
+
+        if (nxt_slow_path(memchr(str.start, '\0', str.length) != NULL)) {
+            nxt_log(task, NXT_LOG_ERR, "rootfs contains an embedded NUL but "
+                    "given \"%V\"", &str);
+
+            return NXT_ERROR;
+        }
+
+        if (nxt_slow_path(nxt_rootfs_resolves_to_root(str.start, str.length))) {
+            nxt_log(task, NXT_LOG_ERR, "rootfs resolves to \"/\" but given "
+                    "\"%V\"", &str);
 
             return NXT_ERROR;
         }

--- a/test/test_python_isolation.py
+++ b/test/test_python_isolation.py
@@ -249,9 +249,68 @@ def test_python_isolation_rootfs_invalid():
             }
         )
 
+    # empty / not absolute / slash-only (resolves to "/")
     check_invalid('')
+    check_invalid('app/rootfs')
     check_invalid('/')
     check_invalid('//')
     check_invalid('///')
-    check_invalid('app/rootfs')
+
+    # "." components only -> still "/"
+    check_invalid('/.')
+    check_invalid('/./')
+    check_invalid('/./.')
+    check_invalid('/././.')
+
+    # ".." that collapses back to root
+    check_invalid('/..')
+    check_invalid('/../')
+    check_invalid('/../..')
+    check_invalid('/foo/..')
+    check_invalid('/foo/bar/../..')
+    check_invalid('/./foo/..')
+    check_invalid('/foo/./..')
+    check_invalid('/foo/../bar/..')
+    check_invalid('/foo/../../bar/..')
+
+    # embedded NUL would truncate the path at config time
     check_invalid('/app/rootfs\0/injected')
+
+
+def test_python_isolation_rootfs_dotdot_valid(is_su, require, temp_dir):
+    """A rootfs that lexically contains "."/".." but resolves to a real,
+    non-root directory must be accepted (regression guard against the
+    resolves-to-root normalizer over-rejecting legitimate paths).
+    """
+    isolation = {'rootfs': f'{temp_dir}/sub/..'}
+
+    (Path(temp_dir) / 'sub').mkdir()
+
+    if not is_su:
+        require(
+            {
+                'features': {
+                    'isolation': [
+                        'unprivileged_userns_clone',
+                        'user',
+                        'mnt',
+                        'pid',
+                    ]
+                }
+            }
+        )
+
+        isolation['namespaces'] = {
+            'mount': True,
+            'credential': True,
+            'pid': True,
+        }
+
+    client.load('ns_inspect', isolation=isolation)
+
+    # The host path of temp_dir is outside the chroot (which resolves to
+    # temp_dir via ".."), so it must not be visible inside -- proves the
+    # ".." rootfs was accepted and confinement actually happened.
+    assert not (
+        client.getjson(url=f'/?path={temp_dir}')['body']['FileExists']
+    ), 'rootfs with ".." is confined'


### PR DESCRIPTION
Follow-up to #95.

## Summary

`#95` closed the embedded-NUL and `"//"`→`/` collapse cases for `rootfs`, but a path like `"/."`, `"/.."`, or `"/foo/.."` still passes the absolute-path and NUL checks and then collapses to `"/"` at `chroot`/`pivot_root` time, where `chroot("/")` is a no-op and silently defeats rootfs isolation. This is the same collapse-to-root class; this PR closes it for any path that normalizes to `"/"`.

## Change

Add `nxt_rootfs_resolves_to_root()` — a lexical normalizer that walks `'/'`-separated components, skips `""` and `"."`, decrements depth on `".."` (clamped at root, matching kernel behaviour at `chroot`/`pivot_root`), and returns true when nothing remains. Wire it into `nxt_conf_vldt_rootfs_path()` (authoritative gate) and mirror it into `nxt_isolation_set_rootfs()` for defence-in-depth, consistent with how `#95` kept the two gates in sync. The helper is duplicated `static` in each TU rather than shared, so the validator remains the only cross-TU entry point for rootfs syntax.

Only paths that **resolve to `"/"`** are rejected; `"/foo/../bar"` (→ `/bar`), `"/..foo"`, `/.foo`/, `/foo..` (real directory names) are still accepted.

## Tests

`test/test_python_isolation.py`:
- Expand `test_python_isolation_rootfs_invalid` with the dot/dotdot matrix — `"."`-only, `".."` collapsing to root (mixed and trailing-slash variants), in addition to the empty / non-absolute / slash-only / embedded-NUL cases from `#95`.
- Add `test_python_isolation_rootfs_dotdot_valid`: a `rootfs` containing `".."` that resolves to a real, non-root directory must be **accepted** and still confine the app — regression guard against the normalizer over-rejecting legitimate paths.

Verified: both TUs compile clean under `-Werror -Wall -Wextra -Wmissing-prototypes`; the normalizer was unit-checked against ~30 cases (root-resolving and valid) before wiring in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)