### PR TITLE
feat(lifecycle): plumb graceful quit mode from SIGQUIT to libunit workers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 
 Changes with FreeUnit 1.35.6                                     07 Jul 2026
 
+    *) Feature: SIGQUIT now performs a graceful stop — application workers
+       drain in-flight requests before exiting; SIGTERM remains the fast
+       exit that drops them.
+
     *) Change: upgrade the wasm-wasi-component wasmtime crates from 35.0.0
        to 36.0.12, clearing the wasmtime sandbox-escape advisories, with the
        accompanying WasiView/WasiHttpView source migration.

--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -680,7 +680,31 @@ failed:
 static void
 nxt_proto_quit_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 {
-    nxt_debug(task, "prototype quit handler");
+    uint8_t        quit_mode;
+    nxt_runtime_t  *rt;
+
+    /*
+     * The QUIT message from main carries a single nxt_port_quit_mode_t
+     * byte (see nxt_runtime_quit_buf()).  Forward it to the children
+     * unchanged so a graceful quit reaches every libunit context, not
+     * only the ports main contacts directly.  An empty body (legacy
+     * senders, or an allocation failure on the sender side) and any
+     * value other than the two defined ones normalise to
+     * NXT_PORT_QUIT_NORMAL, so a malformed sender cannot propagate a
+     * bogus byte through the whole worker pool.
+     */
+    quit_mode = NXT_PORT_QUIT_NORMAL;
+
+    if (msg->buf != NULL && nxt_buf_mem_used_size(&msg->buf->mem) >= 1
+        && msg->buf->mem.pos[0] == NXT_PORT_QUIT_GRACEFUL)
+    {
+        quit_mode = NXT_PORT_QUIT_GRACEFUL;
+    }
+
+    nxt_debug(task, "prototype quit handler (quit_mode=%d)", quit_mode);
+
+    rt = task->thread->runtime;
+    rt->quit_mode = quit_mode;
 
     nxt_proto_quit_children(task);
 
@@ -697,12 +721,14 @@ nxt_proto_quit_children(nxt_task_t *task)
 {
     nxt_port_t     *port;
     nxt_process_t  *process;
+    nxt_runtime_t  *rt;
+
+    rt = task->thread->runtime;
 
     nxt_queue_each(process, &nxt_proto_children, nxt_process_t, link) {
         port = nxt_process_port_first(process);
 
-        (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_QUIT,
-                                     -1, 0, 0, NULL);
+        nxt_runtime_port_send_quit(task, rt, port);
     }
     nxt_queue_loop;
 }
@@ -758,6 +784,14 @@ nxt_proto_sigterm_handler(nxt_task_t *task, void *obj, void *data)
 {
     nxt_trace(task, "signal signo:%d (%s) received",
               (int) (uintptr_t) obj, data);
+
+    /*
+     * A direct signal to the prototype is not the user-initiated
+     * lifecycle path (that goes main -> NXT_PORT_MSG_QUIT -> the
+     * message handler above): treat it as fast exit so children drop
+     * in-flight work rather than wait on a drain nobody requested.
+     */
+    task->thread->runtime->quit_mode = NXT_PORT_QUIT_NORMAL;
 
     nxt_proto_quit_children(task);
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -862,10 +862,19 @@ nxt_main_process_title(nxt_task_t *task)
 static void
 nxt_main_process_sigterm_handler(nxt_task_t *task, void *obj, void *data)
 {
+    nxt_runtime_t  *rt;
+
     nxt_debug(task, "sigterm handler signo:%d (%s)",
               (int) (uintptr_t) obj, data);
 
-    /* TODO: fast exit. */
+    rt = task->thread->runtime;
+
+    /*
+     * Fast exit: do not drain in-flight requests.  The QUIT byte sent
+     * to libunit workers (see nxt_runtime_stop_app_processes()) carries
+     * NXT_PORT_QUIT_NORMAL so nxt_unit_quit() returns immediately.
+     */
+    rt->quit_mode = NXT_PORT_QUIT_NORMAL;
 
     nxt_exiting = 1;
 
@@ -876,10 +885,18 @@ nxt_main_process_sigterm_handler(nxt_task_t *task, void *obj, void *data)
 static void
 nxt_main_process_sigquit_handler(nxt_task_t *task, void *obj, void *data)
 {
+    nxt_runtime_t  *rt;
+
     nxt_debug(task, "sigquit handler signo:%d (%s)",
               (int) (uintptr_t) obj, data);
 
-    /* TODO: graceful exit. */
+    rt = task->thread->runtime;
+
+    /*
+     * Graceful exit: ask libunit workers to drain in-flight requests
+     * before tearing the per-context state down (see nxt_unit_quit()).
+     */
+    rt->quit_mode = NXT_PORT_QUIT_GRACEFUL;
 
     nxt_exiting = 1;
 

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -167,6 +167,18 @@ typedef enum {
 } nxt_port_msg_type_t;
 
 
+/*
+ * Wire-format payload for NXT_PORT_MSG_QUIT.  A single byte selects
+ * between fast and graceful exit on the receiving side.  When the
+ * message arrives without a payload, the receiver defaults to
+ * NXT_PORT_QUIT_NORMAL (see src/nxt_unit.c nxt_unit_process_msg).
+ */
+typedef enum {
+    NXT_PORT_QUIT_NORMAL   = 0,
+    NXT_PORT_QUIT_GRACEFUL = 1,
+} nxt_port_quit_mode_t;
+
+
 /* Passed as a first iov chunk. */
 typedef struct {
     uint32_t             stream;

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -491,6 +491,54 @@ nxt_runtime_close_idle_connections(nxt_event_engine_t *engine)
 }
 
 
+/*
+ * Allocate a one-byte port-message body carrying rt->quit_mode (a
+ * nxt_port_quit_mode_t value, see nxt_port.h).  libunit parses this
+ * as the quit_param in nxt_unit_process_msg() and falls back to
+ * NXT_PORT_QUIT_NORMAL when the message arrives without a payload --
+ * which is also the path taken when this allocator returns NULL, so
+ * the historical payload-less wire format remains compatible.
+ */
+static nxt_buf_t *
+nxt_runtime_quit_buf(nxt_task_t *task, nxt_runtime_t *rt)
+{
+    nxt_buf_t  *b;
+
+    b = nxt_buf_mem_alloc(task->thread->engine->mem_pool, 1, 0);
+    if (nxt_slow_path(b == NULL)) {
+        return NULL;
+    }
+
+    *b->mem.free++ = rt->quit_mode;
+
+    return b;
+}
+
+
+void
+nxt_runtime_port_send_quit(nxt_task_t *task, nxt_runtime_t *rt,
+    nxt_port_t *port)
+{
+    nxt_buf_t  *b;
+    nxt_int_t  rc;
+
+    b = nxt_runtime_quit_buf(task, rt);
+
+    rc = nxt_port_socket_write(task, port, NXT_PORT_MSG_QUIT, -1, 0, 0, b);
+
+    if (nxt_slow_path(rc != NXT_OK && b != NULL)) {
+        /*
+         * Port layer did not take ownership of b; queue its completion
+         * handler so the engine mem-pool buffer is reclaimed.  The
+         * process still goes down: a failed QUIT send surfaces in
+         * port->socket.error and the port teardown path handles it.
+         */
+        nxt_work_queue_add(&task->thread->engine->fast_work_queue,
+                           b->completion_handler, task, b, b->parent);
+    }
+}
+
+
 void
 nxt_runtime_stop_app_processes(nxt_task_t *task, nxt_runtime_t *rt)
 {
@@ -508,8 +556,7 @@ nxt_runtime_stop_app_processes(nxt_task_t *task, nxt_runtime_t *rt)
 
             nxt_process_port_each(process, port) {
 
-                (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_QUIT, -1,
-                                             0, 0, NULL);
+                nxt_runtime_port_send_quit(task, rt, port);
 
             } nxt_process_port_loop;
         }
@@ -530,8 +577,7 @@ nxt_runtime_stop_all_processes(nxt_task_t *task, nxt_runtime_t *rt)
 
             nxt_debug(task, "%d sending quit to %PI", rt->type, port->pid);
 
-            (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_QUIT, -1, 0,
-                                         0, NULL);
+            nxt_runtime_port_send_quit(task, rt, port);
 
         } nxt_process_port_loop;
 

--- a/src/nxt_runtime.h
+++ b/src/nxt_runtime.h
@@ -55,6 +55,8 @@ struct nxt_runtime_s {
     uint8_t                batch;
     uint8_t                status;
     uint8_t                is_pid_isolated;
+    /* See nxt_port_quit_mode_t in nxt_port.h. */
+    uint8_t                quit_mode;
 
     const char             *engine;
     uint32_t               engine_connections;
@@ -118,6 +120,8 @@ nxt_port_t *nxt_runtime_process_port_create(nxt_task_t *task, nxt_runtime_t *rt,
 
 void nxt_runtime_port_remove(nxt_task_t *task, nxt_port_t *port);
 void nxt_runtime_stop_app_processes(nxt_task_t *task, nxt_runtime_t *rt);
+void nxt_runtime_port_send_quit(nxt_task_t *task, nxt_runtime_t *rt,
+    nxt_port_t *port);
 
 NXT_EXPORT nxt_port_t *nxt_runtime_port_find(nxt_runtime_t *rt, nxt_pid_t pid,
     nxt_port_id_t port_id);

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -24,10 +24,16 @@
 #define NXT_UNIT_LOCAL_BUF_SIZE  \
     (NXT_UNIT_MAX_PLAIN_SIZE + sizeof(nxt_port_msg_t))
 
-enum {
-    NXT_QUIT_NORMAL   = 0,
-    NXT_QUIT_GRACEFUL = 1,
-};
+/*
+ * Wire-protocol QUIT mode selector.  The canonical enum lives in
+ * src/nxt_port.h alongside NXT_PORT_MSG_QUIT itself; the aliases
+ * below preserve the original local names without risking divergence
+ * from the daemon-side usage (the preprocessor substitutes the same
+ * enum value into every reference, so a compile-time mismatch is
+ * impossible).
+ */
+#define NXT_QUIT_NORMAL    NXT_PORT_QUIT_NORMAL
+#define NXT_QUIT_GRACEFUL  NXT_PORT_QUIT_GRACEFUL
 
 typedef struct nxt_unit_impl_s                  nxt_unit_impl_t;
 typedef struct nxt_unit_mmap_s                  nxt_unit_mmap_t;

--- a/test/test_graceful_reload.py
+++ b/test/test_graceful_reload.py
@@ -1,0 +1,276 @@
+"""
+Graceful vs fast shutdown: signal-handler split.
+
+Background
+----------
+SIGTERM and SIGQUIT used to share an identical handler in
+src/nxt_main_process.c -- both routed straight to nxt_runtime_quit()
+without distinguishing fast from graceful exit.  The handlers are now
+split: SIGQUIT sets rt->quit_mode = NXT_PORT_QUIT_GRACEFUL, and the
+NXT_PORT_MSG_QUIT message dispatched by nxt_runtime_stop_app_processes()
+carries that byte.  libunit already parses this wire format and
+dispatches to nxt_unit_quit(), which lets in-flight requests drain when
+the byte is NXT_PORT_QUIT_GRACEFUL.
+
+The plumbing is what these tests exercise behaviourally:
+
+  * SIGQUIT -> in-flight request must complete with status 200.
+  * SIGTERM -> in-flight request is dropped (connection reset or truncated).
+
+A third placeholder test asserts the wire-format intent but is skipped
+because verifying the actual quit_param byte would require C-level
+instrumentation -- the behavioural pair above already covers reachability.
+"""
+
+import os
+import signal
+import socket
+import time
+
+import pytest
+
+from unit.applications.lang.python import ApplicationPython
+from unit.log import Log
+
+prerequisites = {'modules': {'python': 'all'}}
+
+client = ApplicationPython()
+
+
+@pytest.fixture(autouse=True)
+def _require_restart_flag(request):
+    """
+    Every test in this module sends SIGTERM/SIGQUIT to the unitd master.
+    The autouse `run` fixture in conftest.py only rmtrees the temp dir
+    when --restart is set; otherwise it tries to PUT /config on the now
+    dead daemon during teardown and crashes with KeyError: 'body'.
+
+    Skip with an actionable message when the flag is missing instead of
+    pretending to fail for the wrong reason.
+    """
+    if not request.config.getoption('--restart'):
+        pytest.skip(
+            'test_graceful_reload.py signals the unitd master process; '
+            'rerun with --restart so conftest.py rmtrees the temp dir '
+            'instead of trying /config PUT on a dead daemon'
+        )
+
+
+# Long enough that a non-graceful SIGTERM cannot accidentally let the
+# request finish; short enough to keep the test suite snappy.  Bumped
+# above the previous 3 s so fast machines have less chance of racing
+# the response to completion before the signal lands.
+INFLIGHT_DELAY = 5
+
+# Cap for the curl-equivalent recv loop.  Must exceed INFLIGHT_DELAY plus
+# graceful-drain overhead so a working SIGQUIT path has room to complete.
+RESPONSE_TIMEOUT = 30
+
+
+def _start_inflight_request(
+    delay: int, body: bytes = b'', parts: int = 1
+) -> socket.socket:
+    """
+    Open a TCP connection to Unit, send a request that takes *delay*
+    seconds inside the handler, and return the socket with the request
+    fully written.  Caller is responsible for receiving and closing.
+
+    With an empty *body* the delayed app sleeps once before finishing
+    the response.  With a non-empty *body* it echoes the body back in
+    *parts* chunks, sleeping *delay* seconds after each chunk -- the
+    response is demonstrably mid-stream while the handler sleeps, so a
+    truncated echo is positive proof the worker died mid-response.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(RESPONSE_TIMEOUT)
+    sock.connect(('127.0.0.1', 8080))
+
+    req = (
+        f'POST / HTTP/1.1\r\n'
+        f'Host: localhost\r\n'
+        f'X-Delay: {delay}\r\n'
+        f'X-Parts: {parts}\r\n'
+        f'Content-Length: {len(body)}\r\n'
+        f'Connection: close\r\n'
+        f'\r\n'
+    ).encode() + body
+    sock.sendall(req)
+
+    return sock
+
+
+def _recv_all(sock: socket.socket) -> bytes:
+    """
+    Drain the socket until EOF or timeout.  Returns whatever bytes
+    arrived; an empty/truncated reply is a signal that the peer reset
+    the connection mid-response, which is exactly what SIGTERM should do.
+    """
+    chunks = []
+    deadline = time.monotonic() + RESPONSE_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            data = sock.recv(4096)
+        except (ConnectionResetError, socket.timeout):
+            break
+        if not data:
+            break
+        chunks.append(data)
+    return b''.join(chunks)
+
+
+def _wait_for_socket_closed(sock: socket.socket,
+                            timeout: float = RESPONSE_TIMEOUT) -> bool:
+    """Poll the socket until the peer closes it or *timeout* elapses."""
+    sock.settimeout(timeout)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            data = sock.recv(4096)
+        except (ConnectionResetError, socket.timeout):
+            return True
+        if not data:
+            return True
+    return False
+
+
+@pytest.mark.parametrize('module', ['wsgi', 'asgi'])
+def test_sigquit_completes_inflight_request(unit_pid, skip_alert, module):
+    """
+    SIGQUIT to the unitd master must let an in-flight request complete.
+
+    Previously the SIGQUIT path was identical to SIGTERM (both called
+    nxt_runtime_quit() with no quit_param plumbing), so libunit defaulted
+    to NXT_QUIT_NORMAL and the worker exited immediately.  Now the
+    main signal handler stores rt->quit_mode = NXT_QUIT_GRACEFUL and the
+    QUIT message body now carries that byte; libunit's nxt_unit_quit()
+    drains the active request before tearing the context down.
+
+    Both application flavours matter and fail differently:
+
+      * wsgi: the worker is busy in time.sleep() and only reads the QUIT
+        message after the response -- guards against the worker being
+        torn down while it is not polling libunit.
+      * asgi: `await sleep()` yields to the asyncio loop, so libunit
+        processes the QUIT byte *while the response is mid-stream* --
+        this is the variant that actually exercises the GRACEFUL drain
+        path.  The request echoes a body in two chunks with a sleep in
+        between; a NORMAL or payload-less quit kills the worker between
+        the chunks and the full-echo assertion fails.
+    """
+    client.load('delayed', module=module)
+
+    skip_alert(r'process \d+ exited on signal')
+    skip_alert(r'sendmsg.+failed')
+    skip_alert(r'last message send failed')
+
+    if module == 'asgi':
+        payload = b'0123456789abcdef' * 8
+        # Two chunks with a 3 s pause: the signal lands inside the first
+        # pause, while half the echo is still unsent.
+        sock = _start_inflight_request(3, body=payload, parts=2)
+    else:
+        payload = b''
+        sock = _start_inflight_request(INFLIGHT_DELAY)
+
+    # Give the handler a moment to enter its sleep before the signal.
+    time.sleep(0.5)
+
+    os.kill(unit_pid, signal.SIGQUIT)
+
+    body = _recv_all(sock)
+    sock.close()
+
+    status_line = body.split(b'\r\n', 1)[0]
+    assert b'200' in status_line, (
+        f'SIGQUIT must let in-flight request complete with 200, got '
+        f'status line: {status_line!r} (full body: {body!r})'
+    )
+
+    # An incomplete header section would mean the worker was killed
+    # mid-write -- a regression we are guarding against.
+    assert b'\r\n\r\n' in body, (
+        f'graceful response must be header-complete, got: {body!r}'
+    )
+
+    if module == 'asgi':
+        received = body.split(b'\r\n\r\n', 1)[1]
+        assert received == payload, (
+            f'graceful drain must deliver the full {len(payload)}-byte '
+            f'echo; got {len(received)} bytes -- the worker was torn '
+            f'down mid-response (quit mode did not reach libunit as '
+            f'GRACEFUL)'
+        )
+
+
+def test_sigterm_drops_inflight_request(unit_pid, skip_alert):
+    """
+    SIGTERM remains the fast-exit path: in-flight requests are dropped.
+
+    On SIGTERM, rt->quit_mode = NXT_PORT_QUIT_NORMAL and the QUIT
+    message body carries 0; libunit's nxt_unit_quit() returns immediately
+    and calls close_handler() on every active request.
+
+    Why ASGI here?  In synchronous WSGI a worker that is busy in
+    time.sleep() never pumps libunit's message loop, so the QUIT byte
+    sits in the queue until the request has finished anyway.  The
+    behavioural difference between QUIT_NORMAL and QUIT_GRACEFUL is only
+    observable when libunit can actually process the QUIT message while
+    a request is still in-flight -- which is what the asyncio-driven
+    ASGI handler enables.  See test/python/delayed/asgi.py: the
+    `await sleep(delay)` yields control back to the asyncio loop,
+    letting libunit's add_reader callback run the QUIT path.
+
+    Regression evidence is the "active request on ctx quit" warning --
+    libunit emits it from the for-loop that walks
+    active_req inside nxt_unit_quit() when quit_param == NXT_QUIT_NORMAL.
+    The for-loop is unreachable on the GRACEFUL path (which returns
+    early when the active_req queue is non-empty), so the warning's
+    presence is positive proof that the NORMAL fast-exit branch ran.
+    Absence of the warning would mean SIGTERM accidentally took the
+    GRACEFUL branch -- the regression this test must catch.
+    """
+    client.load('delayed', module='asgi')
+
+    skip_alert(r'process \d+ exited on signal')
+    skip_alert(r'sendmsg.+failed')
+    skip_alert(r'last message send failed')
+    skip_alert(r'active request on ctx quit')
+
+    sock = _start_inflight_request(INFLIGHT_DELAY)
+
+    time.sleep(0.5)
+
+    os.kill(unit_pid, signal.SIGTERM)
+
+    body = _recv_all(sock)
+    sock.close()
+
+    # Positive log evidence beats body-shape inference: it is robust to
+    # the timing race where a fast machine completes the response before
+    # the signal lands.  wait_for_record polls the unit log up to ~15 s
+    # for the marker; on a real regression to the GRACEFUL branch the
+    # marker never appears and the assertion fails.
+    assert Log.wait_for_record(r'active request on ctx quit') is not None, (
+        'SIGTERM did not take the NORMAL fast-exit path: libunit drained '
+        'in-flight requests as if quit_param == NXT_PORT_QUIT_GRACEFUL. '
+        'Regression in the quit-mode plumbing -- see src/nxt_main_process.c '
+        'sigterm/sigquit handler split and src/nxt_runtime.c '
+        'nxt_runtime_quit_buf().'
+    )
+
+
+@pytest.mark.skip(
+    reason='needs C-level instrumentation; covered by test 1+2 behaviorally'
+)
+def test_quit_message_carries_quit_param():
+    """
+    Direct assertion that NXT_PORT_MSG_QUIT carries a one-byte body
+    encoding rt->quit_mode.  Verifying this from Python would require
+    intercepting the AF_UNIX port socket between unitd master and the
+    application worker, which is not straightforward without a debug
+    build that exposes the wire bytes.
+
+    Tests 1 and 2 above exercise the same plumbing behaviourally:
+      * graceful-drain on SIGQUIT  => byte == NXT_QUIT_GRACEFUL
+      * fast-exit on SIGTERM       => byte == NXT_QUIT_NORMAL
+    """


### PR DESCRIPTION
## Summary

SIGTERM and SIGQUIT shared an identical code path in `nxt_main_process.c` — both routed to `nxt_runtime_quit()` with no way to distinguish fast from graceful exit; each handler carried a TODO for its intended behavior. This PR splits them:

- **SIGQUIT** → `rt->quit_mode = NXT_PORT_QUIT_GRACEFUL`: application workers drain in-flight requests before exiting.
- **SIGTERM** → `NXT_PORT_QUIT_NORMAL`: fast exit, in-flight requests dropped (behavior unchanged).

## How it travels

The mode is a one-byte body on the existing `NXT_PORT_MSG_QUIT` message (`nxt_runtime_quit_buf()`). libunit already parses exactly this wire format in `nxt_unit_process_msg()` and falls back to `NXT_PORT_QUIT_NORMAL` when the message has no payload — so the historical payload-less format stays compatible, including on buffer-allocation failure.

The selector becomes a named enum (`nxt_port_quit_mode_t`) in `nxt_port.h` next to `NXT_PORT_MSG_QUIT`; libunit's local `NXT_QUIT_*` names alias it via `#define` so the daemon and library sides cannot diverge.

## Tests

`test/test_graceful_reload.py` (new, uses the existing `test/python/delayed` fixtures):

- SIGQUIT with an in-flight request → response completes with 200 and is header-complete.
- SIGTERM with an in-flight ASGI request → fast-exit path confirmed via libunit's `"active request on ctx quit"` log marker (positive log evidence is robust to the race where a fast machine finishes the response before the signal lands; the marker is unreachable on the graceful path).
- A skipped placeholder documents the wire-format assertion that would need C-level instrumentation.

## Verification

On top of `pre-1.35.6`:

```
./configure --tests && make -j$(nproc)     # clean
python3 -m pytest test/test_static.py test/test_idle_close_wait.py   # 21 passed, 1 skipped
```

The new suite needs the python module → runs in CI's python jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
