### PR TITLE
fix(otel): restart trace on malformed inbound traceparent instead of 500

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,19 @@
 
 Changes with FreeUnit 1.35.6                                     07 Jul 2026
 
+    *) Bugfix: ignore a malformed incoming "traceparent" header and restart
+       the trace per W3C Trace Context instead of rejecting the request
+       with HTTP 500; the malformed header is dropped instead of being
+       forwarded alongside the restarted one, and context accepted from a
+       valid duplicate is preserved. Values are now validated in full
+       (segment lengths, lowercase hex, no all-zero ids, no "ff" version),
+       so content-invalid values restart the trace instead of being
+       re-emitted verbatim. An inbound "tracestate" is dropped together
+       with the rejected context (kept when the traceparent is inherited).
+       The injected "traceparent" fields are now zero-initialized; garbage
+       flag bits could get the header randomly dropped from proxied
+       requests and responses.
+
     *) Bugfix: reject empty values and embedded NUL bytes in configuration
        strings that are later used as NUL-terminated C strings ("user",
        "group", "working_directory", "stdout", "stderr", "executable", and

--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -139,7 +139,11 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
 
         nxt_otel_rs_copy_traceparent(traceval, r->otel->trace);
 
-        f = nxt_list_add(r->fields);
+        /*
+         * nxt_list_add() hands out non-zeroed memory: garbage skip/hopbyhop
+         * bits make the peer/app serializers randomly drop the field.
+         */
+        f = nxt_list_zero_add(r->fields);
         if (nxt_slow_path(f == NULL)) {
             return;
         }
@@ -162,7 +166,7 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
                                        &traceparent_name, &traceparent);
     }
 
-    f = nxt_list_add(r->resp.fields);
+    f = nxt_list_zero_add(r->resp.fields);
     if (nxt_slow_path(f == NULL)) {
         nxt_log(task, NXT_LOG_ERR,
                 "couldn't allocate traceparent header in response");
@@ -359,8 +363,51 @@ nxt_otel_error(nxt_task_t *task, nxt_http_request_t *r)
 
 
 static void
+nxt_otel_drop_tracestate(nxt_http_request_t *r)
+{
+    nxt_http_field_t  *f;
+
+    nxt_str_null(&r->otel->trace_state);
+
+    nxt_list_each(f, r->fields) {
+
+        if (f->name_length == nxt_length("tracestate")
+            && nxt_memcasecmp(f->name, "tracestate",
+                              nxt_length("tracestate")) == 0)
+        {
+            f->skip = 1;
+        }
+
+    } nxt_list_loop;
+
+    /* the echo copies nxt_otel_parse_tracestate() already appended */
+
+    nxt_list_each(f, r->resp.fields) {
+
+        if (f->name_length == nxt_length("tracestate")
+            && nxt_memcasecmp(f->name, "tracestate",
+                              nxt_length("tracestate")) == 0)
+        {
+            f->skip = 1;
+        }
+
+    } nxt_list_loop;
+}
+
+
+static void
 nxt_otel_trace_and_span_init(nxt_task_t *task, nxt_http_request_t *r)
 {
+    /*
+     * Restarting the trace (no valid inbound traceparent was accepted):
+     * drop any inbound tracestate per W3C Trace Context — vendor state
+     * from a rejected or absent context must not seed the new root span,
+     * be forwarded to the peer or application, or be echoed back.
+     */
+    if (r->otel->trace_id == NULL && r->otel->trace_state.length != 0) {
+        nxt_otel_drop_tracestate(r);
+    }
+
     r->otel->trace =
         nxt_otel_rs_get_or_create_trace(r->otel->trace_id,
                                         r->otel->parent_id,
@@ -420,10 +467,42 @@ nxt_otel_request_error_path(nxt_task_t *task, nxt_http_request_t *r)
 }
 
 
+static nxt_bool_t
+nxt_otel_segment_valid(const char *s, size_t len)
+{
+    /* W3C Trace Context segments are fixed-length lowercase hex (HEXDIGLC). */
+
+    if (strlen(s) != len) {
+        return 0;
+    }
+
+    for ( ; *s != '\0'; s++) {
+        if ((*s < '0' || *s > '9') && (*s < 'a' || *s > 'f')) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+
+static nxt_bool_t
+nxt_otel_segment_all_zero(const char *s)
+{
+    for ( ; *s != '\0'; s++) {
+        if (*s != '0') {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+
 nxt_int_t
 nxt_otel_parse_traceparent(void *ctx, nxt_http_field_t *field, uintptr_t data)
 {
-    char                *copy;
+    char                *copy, *version, *trace_id, *parent_id, *trace_flags;
     nxt_http_request_t  *r;
 
     /*
@@ -455,25 +534,75 @@ nxt_otel_parse_traceparent(void *ctx, nxt_http_field_t *field, uintptr_t data)
     }
     memcpy(copy, field->value, field->value_length);
 
-    r->otel->version = (u_char *) strsep(&copy, "-");
-    r->otel->trace_id = (u_char *) strsep(&copy, "-");
-    r->otel->parent_id = (u_char *) strsep(&copy, "-");
-    r->otel->trace_flags = (u_char *) strsep(&copy, "-");
+    /*
+     * Parse into locals first and only commit to r->otel on success, so a
+     * malformed field never clobbers context already accepted from an earlier
+     * valid traceparent in the same request (fields are processed in wire
+     * order).
+     */
+    version = strsep(&copy, "-");
+    trace_id = strsep(&copy, "-");
+    parent_id = strsep(&copy, "-");
+    trace_flags = strsep(&copy, "-");
 
-    if (r->otel->version        == NULL
-        || r->otel->trace_id    == NULL
-        || r->otel->parent_id   == NULL
-        || r->otel->trace_flags == NULL)
+    if (version == NULL || trace_id == NULL
+        || parent_id == NULL || trace_flags == NULL)
     {
         goto error_state;
     }
 
+    /*
+     * Validate content, not just shape: fixed segment lengths (a misplaced
+     * hyphen shifts them, so this also rejects extra segments within the
+     * checked total length), lowercase hex per the W3C ABNF (HEXDIGLC), the
+     * forbidden "ff" version, and all-zero trace/parent ids, which the spec
+     * defines as invalid.  Anything else would be inherited and re-emitted
+     * verbatim downstream and in the response.
+     */
+    if (!nxt_otel_segment_valid(version, 2)
+        || !nxt_otel_segment_valid(trace_id, 32)
+        || !nxt_otel_segment_valid(parent_id, 16)
+        || !nxt_otel_segment_valid(trace_flags, 2))
+    {
+        goto error_state;
+    }
+
+    if (memcmp(version, "ff", 2) == 0
+        || nxt_otel_segment_all_zero(trace_id)
+        || nxt_otel_segment_all_zero(parent_id))
+    {
+        goto error_state;
+    }
+
+    r->otel->version = (u_char *) version;
+    r->otel->trace_id = (u_char *) trace_id;
+    r->otel->parent_id = (u_char *) parent_id;
+    r->otel->trace_flags = (u_char *) trace_flags;
+
     return NXT_OK;
 
 error_state:
-    nxt_otel_state_transition(r->otel, NXT_OTEL_ERROR_STATE);
+    /*
+     * A malformed inbound traceparent is ignored per W3C Trace Context
+     * (§3.2.2.3): the trace is restarted, not rejected. We do NOT fail the
+     * request (return NXT_OK, not NXT_ERROR): failing this header-parse
+     * callback aborts the request as a 500, letting any client force an outage
+     * with a bad client-supplied header. We also do NOT transition to
+     * ERROR_STATE: that would disable telemetry for the request (the next
+     * dispatch would drop to UNINIT_STATE via nxt_otel_error), losing the span
+     * and the response traceparent. Staying in INIT_STATE with a NULL trace_id
+     * makes the state machine start a fresh root span
+     * (nxt_otel_trace_and_span_init -> get_or_create_trace).
+     *
+     * We leave r->otel untouched: if an earlier valid traceparent was accepted,
+     * its context is preserved (inherit it); otherwise the fields are still
+     * NULL and the trace restarts. Either way skip this bad header on the
+     * request so it is not forwarded to a proxied peer or the application
+     * alongside the inherited/restarted one.
+     */
+    field->skip = 1;
 
-    return NXT_ERROR;
+    return NXT_OK;
 }
 
 

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -1,11 +1,13 @@
 import json
 import os
+import re
 import socket
 import subprocess
 import time
 
 import pytest
 
+from conftest import run_process
 from unit.applications.proto import ApplicationProto
 from unit.utils import waitforsocket
 
@@ -233,43 +235,6 @@ def test_otel_span_5xx_status(tmp_path, protocol):
 
 
 @_skipif_no_fake_otlp
-@pytest.mark.xfail(
-    reason=(
-        'Suspected bug: a malformed inbound traceparent returns HTTP 500 '
-        'instead of being ignored. nxt_otel_parse_traceparent() returns '
-        'NXT_ERROR on a length/format mismatch (src/nxt_otel.c ~445-476), and a '
-        'header-parse callback returning NXT_ERROR fails the request. W3C '
-        'Trace Context 3.2.2.3 requires an unparseable traceparent to be '
-        'ignored and the trace restarted, not to reject the request -- so on '
-        'an OTel-enabled listener any client can force a 500 with '
-        '"traceparent: x". Deterministic, so strict=True: once #109 is fixed '
-        'the test xpasses -> fails, forcing removal of this marker. '
-        'See freeunitorg/freeunit#109.'
-    ),
-    strict=True,
-)
-@pytest.mark.parametrize('protocol', ['http', 'grpc'])
-def test_otel_traceparent_malformed(protocol):
-    """A malformed inbound traceparent should be ignored (the trace is
-    restarted), not turned into an error response."""
-    port = _get_free_port()
-    proc = _run_fake_otlp(port, protocol=protocol)  # run forever, absorb exports
-    try:
-        _configure_or_skip(port, protocol=protocol)
-
-        resp = client.get(
-            headers={
-                'Host': 'localhost',
-                'traceparent': 'this-is-not-a-valid-traceparent',
-                'Connection': 'close',
-            }
-        )
-        assert resp['status'] == 200, f'malformed traceparent must not error: {resp}'
-    finally:
-        _kill(proc)
-
-
-@_skipif_no_fake_otlp
 @pytest.mark.parametrize('protocol', ['http', 'grpc'])
 def test_otel_traceparent_in_response(protocol):
     """FreeUnit injects a traceparent header into the response."""
@@ -341,6 +306,369 @@ def test_otel_sampling_zero_exports_nothing(protocol):
             pytest.fail('fake_otlp received a span despite sampling_ratio=0')
         except subprocess.TimeoutExpired:
             pass  # expected — no export
+    finally:
+        _kill(proc)
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_traceparent_malformed(protocol):
+    """A malformed inbound traceparent is ignored and the trace restarted.
+
+    W3C Trace Context §3.2.2.3 requires an unparseable traceparent to be
+    ignored and the trace restarted, never to reject the request. The header is
+    client-supplied, so failing the request turns a bad header into a trivial
+    availability attack (every request 500s). Regression guard for the fix in
+    nxt_otel_parse_traceparent (src/nxt_otel.c): the request must be served
+    (200) AND still traced with a fresh root span (a new traceparent is injected
+    into the response), not served with telemetry silently disabled.
+    """
+    port = _get_free_port()
+    proc = _run_fake_otlp(port, protocol=protocol)  # run forever, absorb exports
+    try:
+        _configure_or_skip(port, protocol=protocol)
+
+        # Ensure the tracer is actually live before probing, so the malformed
+        # header exercises the parse callback rather than being skipped while
+        # OTel is still initialising.
+        assert _get_until_header('traceparent')['status'] == 200
+
+        # Wrong length, wrong shape, and content-invalid values (correct
+        # 55-char shape but non-hex/uppercase segments, all-zero ids, the
+        # forbidden "ff" version, or a misplaced hyphen) all take the
+        # error_state path in the parser; each must be served 200 and get a
+        # fresh, non-inherited traceparent in the response. The probe retries
+        # via _get_until_header: OTel re-inits asynchronously on config change,
+        # so a single-shot probe can race the tracer swap and go through
+        # untraced. A regression is not masked — telemetry silently disabled
+        # never yields a traceparent, so the poll drains and `injected` stays
+        # empty.
+        for bad in [
+            'x',
+            'this-is-not-a-valid-traceparent',
+            '00-tooshort-01',
+            f'zz-{TRACE_ID}-{PARENT_ID}-01',  # non-hex version
+            f'00-{TRACE_ID.upper()}-{PARENT_ID}-01',  # uppercase: not HEXDIGLC
+            f'00-{"0" * 32}-{PARENT_ID}-01',  # all-zero trace id
+            f'00-{TRACE_ID}-{"0" * 16}-01',  # all-zero parent id
+            f'ff-{TRACE_ID}-{PARENT_ID}-01',  # forbidden version
+            f'00-{TRACE_ID[:-1]}-{PARENT_ID}-0-1',  # shifted hyphen, len 55
+        ]:
+            resp = _get_until_header(
+                'traceparent',
+                headers={
+                    'Host': 'localhost',
+                    'traceparent': bad,
+                    'Connection': 'close',
+                },
+            )
+            assert resp['status'] == 200, (
+                f'malformed traceparent {bad!r} must be served, not 500'
+            )
+            injected = _response_headers_lower(resp).get('traceparent', '')
+            assert injected, (
+                f'malformed traceparent {bad!r} must restart the trace '
+                f'(fresh traceparent injected), not disable telemetry'
+            )
+            assert not injected.startswith('00-00000000000000000000000000000000'), (
+                f'restarted traceparent must carry a real trace id: {injected!r}'
+            )
+            assert TRACE_ID not in injected, (
+                f'content-invalid traceparent {bad!r} must not be inherited'
+            )
+
+        # A well-formed traceparent is still inherited (control case): the
+        # response echoes the incoming trace id. Retried like the probes above
+        # (the async tracer swap can land at any point inside the test); an
+        # inheritance regression still fails — a restarted trace echoes a
+        # different id than TRACE_ID.
+        resp = _get_until_header(
+            'traceparent',
+            headers={
+                'Host': 'localhost',
+                'traceparent': f'00-{TRACE_ID}-{PARENT_ID}-01',
+                'Connection': 'close',
+            },
+        )
+        assert resp['status'] == 200, 'valid traceparent must be served'
+        assert TRACE_ID in _response_headers_lower(resp).get('traceparent', ''), (
+            'valid traceparent must be inherited, not restarted'
+        )
+    finally:
+        _kill(proc)
+
+
+def _run_capture_server(server_port, capture_file):
+    """A raw upstream that appends each request it receives to capture_file."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(('', server_port))
+    sock.listen(5)
+
+    resp = b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'
+
+    while True:
+        conn, _ = sock.accept()
+
+        # Read until end-of-headers: a short recv() is NOT end-of-message, and
+        # the traceparent unit injects is appended last in the field list, so
+        # a capture truncated at a segment boundary loses exactly that header.
+        # All requests here are body-less GETs, so end-of-headers ends the
+        # message.
+        data = b''
+        while b'\r\n\r\n' not in data:
+            part = conn.recv(4096)
+            if not part:
+                break
+            data += part
+
+        with open(capture_file, 'ab') as f:
+            f.write(data + b'\n===END===\n')
+
+        conn.sendall(resp)
+        conn.close()
+
+
+def _configure_proxy_or_skip(collector_port, upstream_port, protocol='http'):
+    """Apply a telemetry + proxy config, skipping cleanly on a non-otel build."""
+    conf = client.conf(
+        {
+            "settings": {
+                "telemetry": _valid_telemetry(collector_port, protocol=protocol)
+            },
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {"action": {"proxy": f"http://127.0.0.1:{upstream_port}"}}
+            ],
+            "applications": {},
+        }
+    )
+    if 'success' in conf:
+        return
+    if 'telemetry' in str(conf).lower():
+        pytest.skip('unit built without --otel')
+    pytest.fail(f'proxy + telemetry config rejected: {conf}')
+
+
+def _forwarded_headers(capture_file, marker, name):
+    """The values of header `name` in the captured proxied request with marker.
+
+    The client.get that sends the probe only returns after the upstream has
+    answered, so the forwarded request is already on disk; a short sleep guards
+    the file append that races the socket write.
+    """
+    time.sleep(0.5)
+    blocks = capture_file.read_bytes().decode(errors='replace').split('===END===')
+    probe = [b for b in blocks if marker in b.lower()]
+    assert probe, 'proxied request carrying the probe marker was not captured'
+    return re.findall(rf'(?im)^{name}:[ \t]*(.+?)[ \t\r]*$', probe[-1])
+
+
+def _forwarded_traceparents(capture_file, marker):
+    return _forwarded_headers(capture_file, marker, 'traceparent')
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_traceparent_malformed_not_forwarded(tmp_path, protocol):
+    """The bad traceparent is not forwarded alongside the restarted one.
+
+    Restarting the trace makes nxt_otel_propagate_header() append a fresh
+    traceparent to the proxied/app request. The original malformed header must
+    be dropped (field->skip), otherwise a proxied peer or the application
+    receives two traceparent headers — the bad one and the new one — and a
+    downstream reader keying on the first is misled. Regression guard for the
+    field->skip part of the fix in nxt_otel_parse_traceparent.
+    """
+    upstream_port = _get_free_port()
+    capture = tmp_path / 'forwarded.txt'
+    run_process(_run_capture_server, upstream_port, str(capture))
+    waitforsocket(upstream_port)
+
+    collector_port = _get_free_port()
+    proc = _run_fake_otlp(collector_port, protocol=protocol)
+    try:
+        _configure_proxy_or_skip(collector_port, upstream_port, protocol)
+
+        # Warm the tracer so the probe request actually restarts a trace.
+        assert _get_until_header('traceparent')['status'] == 200
+
+        # The probe goes through _get_until_header too: OTel re-inits
+        # asynchronously on every config change, so a single-shot probe can
+        # race the tracer swap and go through untraced (no injection at all).
+        # A traced probe always carries a response traceparent, so polling for
+        # it retries only raced attempts and cannot mask a regression.
+        marker = 'otel-malformed-probe'
+        resp = _get_until_header(
+            'traceparent',
+            headers={
+                'Host': 'localhost',
+                'traceparent': 'x',
+                'X-Probe': marker,
+                'Connection': 'close',
+            },
+        )
+        assert resp['status'] == 200
+
+        forwarded = _forwarded_traceparents(capture, marker)
+        assert len(forwarded) == 1, (
+            f'exactly one traceparent must be forwarded, got {forwarded}'
+        )
+        assert forwarded[0] != 'x', (
+            f'the malformed traceparent must not be forwarded: {forwarded}'
+        )
+    finally:
+        _kill(proc)
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+@pytest.mark.parametrize('order', ['valid_first', 'malformed_first'])
+def test_otel_traceparent_duplicate_valid_preserved(tmp_path, protocol, order):
+    """A valid traceparent is kept when a duplicate malformed one is present.
+
+    Header fields are parsed in wire order, so a malformed duplicate must not
+    discard context already accepted from a valid traceparent (in either
+    order). The valid trace id is inherited (echoed in the response) and exactly
+    that one traceparent is forwarded downstream — never the malformed
+    duplicate, never a second restarted header.
+    """
+    valid = f'00-{TRACE_ID}-{PARENT_ID}-01'
+    traceparent = [valid, 'x'] if order == 'valid_first' else ['x', valid]
+
+    upstream_port = _get_free_port()
+    capture = tmp_path / 'forwarded.txt'
+    run_process(_run_capture_server, upstream_port, str(capture))
+    waitforsocket(upstream_port)
+
+    collector_port = _get_free_port()
+    proc = _run_fake_otlp(collector_port, protocol=protocol)
+    try:
+        _configure_proxy_or_skip(collector_port, upstream_port, protocol)
+
+        assert _get_until_header('traceparent')['status'] == 200
+
+        # Retry the probe across the async tracer re-init (see the malformed
+        # test above); an inheritance regression still fails: the traced
+        # response would carry a restarted (wrong) trace id, not TRACE_ID.
+        marker = 'otel-dup-probe'
+        resp = _get_until_header(
+            'traceparent',
+            headers={
+                'Host': 'localhost',
+                'traceparent': traceparent,
+                'X-Probe': marker,
+                'Connection': 'close',
+            },
+        )
+        assert resp['status'] == 200
+        assert TRACE_ID in _response_headers_lower(resp).get('traceparent', ''), (
+            'the valid duplicate must be inherited, not restarted'
+        )
+
+        forwarded = _forwarded_traceparents(capture, marker)
+        assert len(forwarded) == 1, (
+            f'exactly one traceparent must be forwarded, got {forwarded}'
+        )
+        assert TRACE_ID in forwarded[0], (
+            f'the valid trace id must be the one forwarded: {forwarded}'
+        )
+    finally:
+        _kill(proc)
+
+
+TRACESTATE = 'congo=t61rcWkgMzE'
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_tracestate_dropped_on_restart(tmp_path, protocol):
+    """Inbound tracestate is dropped when the trace is restarted.
+
+    W3C Trace Context ties tracestate to the context in traceparent. With no
+    valid traceparent accepted (malformed or absent), the trace restarts and
+    the stale vendor state must not seed the new root span, be forwarded
+    downstream, or be echoed back — only the fresh traceparent survives.
+    """
+    upstream_port = _get_free_port()
+    capture = tmp_path / 'forwarded.txt'
+    run_process(_run_capture_server, upstream_port, str(capture))
+    waitforsocket(upstream_port)
+
+    collector_port = _get_free_port()
+    proc = _run_fake_otlp(collector_port, protocol=protocol)
+    try:
+        _configure_proxy_or_skip(collector_port, upstream_port, protocol)
+
+        assert _get_until_header('traceparent')['status'] == 200
+
+        scenarios = {
+            'malformed': {'traceparent': 'x', 'tracestate': TRACESTATE},
+            'absent': {'tracestate': TRACESTATE},
+        }
+        for scenario, headers in scenarios.items():
+            marker = f'otel-ts-drop-{scenario}'
+            resp = _get_until_header(
+                'traceparent',
+                headers={
+                    'Host': 'localhost',
+                    'X-Probe': marker,
+                    'Connection': 'close',
+                    **headers,
+                },
+            )
+            assert resp['status'] == 200
+            assert 'tracestate' not in _response_headers_lower(resp), (
+                f'[{scenario}] rejected tracestate must not be echoed'
+            )
+
+            assert _forwarded_headers(capture, marker, 'tracestate') == [], (
+                f'[{scenario}] rejected tracestate must not be forwarded'
+            )
+            forwarded = _forwarded_traceparents(capture, marker)
+            assert len(forwarded) == 1 and forwarded[0] != 'x', (
+                f'[{scenario}] one fresh traceparent expected: {forwarded}'
+            )
+    finally:
+        _kill(proc)
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_tracestate_preserved_on_inherit(tmp_path, protocol):
+    """Inbound tracestate rides along when the traceparent is inherited."""
+    upstream_port = _get_free_port()
+    capture = tmp_path / 'forwarded.txt'
+    run_process(_run_capture_server, upstream_port, str(capture))
+    waitforsocket(upstream_port)
+
+    collector_port = _get_free_port()
+    proc = _run_fake_otlp(collector_port, protocol=protocol)
+    try:
+        _configure_proxy_or_skip(collector_port, upstream_port, protocol)
+
+        assert _get_until_header('traceparent')['status'] == 200
+
+        marker = 'otel-ts-keep'
+        resp = _get_until_header(
+            'traceparent',
+            headers={
+                'Host': 'localhost',
+                'traceparent': f'00-{TRACE_ID}-{PARENT_ID}-01',
+                'tracestate': TRACESTATE,
+                'X-Probe': marker,
+                'Connection': 'close',
+            },
+        )
+        assert resp['status'] == 200
+        assert TRACE_ID in _response_headers_lower(resp).get('traceparent', '')
+        assert TRACESTATE in _response_headers_lower(resp).get(
+            'tracestate', ''
+        ), 'tracestate must be echoed with an inherited traceparent'
+
+        assert _forwarded_headers(capture, marker, 'tracestate') == [
+            TRACESTATE
+        ], 'tracestate must be forwarded with an inherited traceparent'
     finally:
         _kill(proc)
 


### PR DESCRIPTION
## Summary

On an OTel-enabled listener (`settings.telemetry`), a request carrying a
**malformed `traceparent` header** was answered with **HTTP 500** instead of
being served. Because the header is client-supplied, any client could force a
500 on every request by sending e.g. `traceparent: x` — a trivial availability
problem for OTel-enabled deployments. It also violates W3C Trace Context
§3.2.2.3, which requires an unparseable `traceparent` to be **ignored and the
trace restarted**, never to reject the request.

Fixes [freeunitorg/freeunit#109](https://github.com/freeunitorg/freeunit/issues/109).

## Root cause

`nxt_otel_parse_traceparent()` (`src/nxt_otel.c`) is a per-field HTTP header
parse callback (registered in `src/nxt_h1proto.c`). Its `error_state:` path —
reached on wrong length, allocation failure, or a wrong
`version-trace_id-parent_id-flags` shape — returned `NXT_ERROR`, which
propagates through `nxt_http_fields_process()` and aborts request processing,
surfacing as `500`.

## Fix — ignore and restart

- **Parse into locals, commit to `r->otel` only on success.** Fields are
  processed in wire order, so a malformed `traceparent` must not clobber
  context already accepted from a valid one earlier in the same request. (The
  shape path previously overwrote `r->otel->*` via `strsep` before the NULL
  check, so locals are required, not just moving the reset.)
- **`error_state` returns `NXT_OK` and stays in `INIT_STATE`.** Not `NXT_ERROR`
  (that 500s the request); not `NXT_OTEL_ERROR_STATE` (that disables telemetry
  for the request via `nxt_otel_error` → `UNINIT_STATE`, losing the span and
  the response `traceparent`). With no valid context accepted, `trace_id` is
  `NULL` and the state machine starts a **fresh root span**
  (`nxt_otel_trace_and_span_init` → `get_or_create_trace`); with a valid
  duplicate present, that context is **preserved and inherited**.
- **`field->skip = 1`** on the malformed header (pattern per
  `src/nxt_h1proto.c:846`/`:3201`) so it is not forwarded to a proxied peer or
  the application alongside the inherited/restarted `traceparent` that
  `nxt_otel_propagate_header()` emits.
- **Validate content, not just shape** (claude review follow-up): fixed
  segment lengths (2/32/16/2, also rejecting misplaced hyphens), lowercase hex
  per the W3C ABNF (HEXDIGLC), no `ff` version, no all-zero trace/parent ids —
  content-invalid values restart the trace instead of being inherited and
  re-emitted verbatim.
- **Drop `tracestate` on restart** (Codex review follow-up). Vendor state is
  tied to the context in `traceparent`; when no valid one was accepted
  (malformed or absent), `nxt_otel_trace_and_span_init()` — after all fields
  are parsed, so both header orders work — clears the saved
  `r->otel->trace_state` before span creation and skips the `tracestate`
  request field(s) and their response echoes. A `tracestate` arriving with a
  valid `traceparent` is untouched.

## Also fixed — randomly dropped `traceparent` (uninitialized field flags)

The new regression tests exposed a latent bug in
`nxt_otel_propagate_header()` as intermittent CI failures: the `traceparent`
fields it appends (to `r->fields` for the restarted trace and to
`r->resp.fields` for the response echo) came from `nxt_list_add()`, which
hands out **non-zeroed** memory — leaving garbage in the `skip`/`hopbyhop`
bits. Depending on allocation history, the peer serializer
(`nxt_h1p_peer_header_send`, checks `!field->hopbyhop && !field->skip`) and
the response serializer (`nxt_h1p_request_header_send`, checks `!field->skip`)
then silently dropped the injected/echoed header. Switched to
`nxt_list_zero_add()` — the pattern used everywhere else fields are appended
(`nxt_http_request.c`, `nxt_http_return.c`, `nxt_http_static.c`, ...).

The tests were also hardened for slow CI runners: probes retry across the
router's asynchronous tracer (re)initialisation via the file's existing
`_get_until_header` helper (a regression is not masked — a restarted trace
echoes the wrong id, and disabled telemetry never yields a `traceparent`), and
the capture upstream reads until end-of-headers instead of treating a short
`recv()` as end-of-message.

## Tests

Added to `test/test_otel.py` (parametrized `http`/`grpc`), following the file's
`fake_otlp` + `_get_until_header` pattern:

- `test_otel_traceparent_malformed` — malformed traceparents served `200` with
  a fresh non-zero `traceparent` injected (restarted, not disabled); valid one
  still inherited.
- `test_otel_traceparent_malformed_not_forwarded` — proxies to a raw capture
  upstream, asserts exactly one `traceparent` is forwarded and it is not the
  malformed original.
- `test_otel_traceparent_duplicate_valid_preserved` — a valid+malformed
  duplicate (either order) inherits the valid trace id and forwards exactly
  that one.
- `test_otel_tracestate_dropped_on_restart` / `..._preserved_on_inherit` —
  a `tracestate` with a malformed or absent `traceparent` is neither forwarded
  nor echoed (only the fresh `traceparent` is); with a valid `traceparent` it
  is forwarded verbatim and echoed.

Full `test_otel.py` (32 tests) passes against `fake_otlp`; the new tests skip
gracefully where `fake_otlp` is not built.

## Verification

On top of `pre-1.35.6`, built `--otel`, telemetry configured (endpoint need not
be reachable), route proxying to a raw capture upstream:

- malformed `traceparent: x` → `200`, fresh restarted id injected; upstream
  receives exactly one `traceparent` (not `x`)
- valid → `200`, incoming trace id inherited/echoed and forwarded
- valid + malformed duplicate (either order) → valid trace id inherited and the
  single forwarded `traceparent`

`make` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



