### PR TITLE
refactor(engine): track active connections symmetrically with idle (P4.5 / pre-P5)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,11 @@ Changes with FreeUnit 1.35.6                                     07 Jul 2026
        listener first and releases its descriptor only after pending accept
        references drain, instead of resetting them.
 
+    *) Change: the event engine now tracks in-flight connections on a
+       dedicated active connections queue, symmetric with idle tracking —
+       groundwork for graceful connection draining; connection accounting
+       in the "/status" API is exact on all close paths.
+
     *) Bugfix: authorize privileged IPC message types by the kernel-validated
        sender PID (SCM_CREDENTIALS), close any received descriptors on every
        rejected privileged message, and cap port queue item size at the slot

--- a/src/nxt_conn.h
+++ b/src/nxt_conn.h
@@ -167,7 +167,23 @@ struct nxt_conn_s {
     uint8_t                       block_read;   /* 1 bit */
     uint8_t                       block_write;  /* 1 bit */
     uint8_t                       delayed;      /* 1 bit */
-    uint8_t                       idle;         /* 1 bit */
+
+#define NXT_CONN_TRACK_NONE       0
+#define NXT_CONN_TRACK_IDLE       1
+#define NXT_CONN_TRACK_ACTIVE     2
+
+    /*
+     * Tri-state membership in the engine's idle/active connection queues.
+     * NONE (0): conn was never placed onto an engine tracking queue
+     *           (e.g. controller clients, proxy peers).  c->link is owned
+     *           by some other subsystem.
+     * IDLE (1): conn is on engine->idle_connections.
+     * ACTIVE (2): conn is on engine->active_connections.
+     *
+     * Set/cleared exclusively by nxt_conn_idle() / nxt_conn_active() and
+     * cleared by nxt_conn_close() when the conn is unlinked from its queue.
+     */
+    uint8_t                       idle;         /* NXT_CONN_TRACK_* */
 
 #define NXT_CONN_SENDFILE_OFF     0
 #define NXT_CONN_SENDFILE_ON      1
@@ -302,24 +318,101 @@ NXT_EXPORT void nxt_event_conn_job_sendfile(nxt_task_t *task,
     } while (0)
 
 
+/*
+ * Place conn onto engine->idle_connections.
+ *
+ * Prior states:
+ *   NXT_CONN_TRACK_NONE   - freshly created conn (e.g. just-accepted in
+ *                           nxt_conn_accept()).  Link is not on any queue.
+ *   NXT_CONN_TRACK_ACTIVE - keep-alive transition: conn is currently on
+ *                           engine->active_connections and is being moved
+ *                           back to idle awaiting the next request.
+ *   NXT_CONN_TRACK_IDLE   - already idle: no-op (idempotent).
+ *
+ * After this macro: conn is on idle_connections, c->idle == TRACK_IDLE.
+ * The idle guard keeps the transition idempotent so a stray second call
+ * cannot double-insert the link or double-count idle_conns_cnt.
+ */
 #define nxt_conn_idle(engine, c)                                              \
     do {                                                                      \
         nxt_event_engine_t  *e = engine;                                      \
                                                                               \
-        nxt_queue_insert_head(&e->idle_connections, &c->link);                \
+        if (c->idle != NXT_CONN_TRACK_IDLE) {                                 \
+            if (c->idle == NXT_CONN_TRACK_ACTIVE) {                           \
+                nxt_queue_remove(&c->link);                                   \
+                e->active_conns_cnt--;                                        \
+            }                                                                 \
                                                                               \
-        c->idle = 1;                                                          \
-        e->idle_conns_cnt++;                                                  \
+            nxt_queue_insert_head(&e->idle_connections, &c->link);           \
+                                                                              \
+            c->idle = NXT_CONN_TRACK_IDLE;                                    \
+            e->idle_conns_cnt++;                                              \
+        }                                                                     \
     } while (0)
 
 
+/*
+ * Move conn from engine->idle_connections onto engine->active_connections.
+ *
+ * Prior states:
+ *   NXT_CONN_TRACK_IDLE   - conn is currently on engine->idle_connections;
+ *                           a request has begun arriving, or a teardown/idle
+ *                           handler is detaching it before shutdown.
+ *   NXT_CONN_TRACK_ACTIVE / _NONE - no-op (idempotent).
+ *
+ * After this macro: conn is on active_connections, c->idle == TRACK_ACTIVE.
+ * All current callers (nxt_conn_accept marks every conn idle first) only
+ * reach this in TRACK_IDLE; the guard makes it safe should a future caller
+ * (e.g. P5 drain) invoke it on an already-active or untracked conn -- an
+ * unconditional nxt_queue_remove() on an untracked link would corrupt.
+ */
 #define nxt_conn_active(engine, c)                                            \
     do {                                                                      \
         nxt_event_engine_t  *e = engine;                                      \
                                                                               \
-        nxt_queue_remove(&c->link);                                           \
+        if (c->idle == NXT_CONN_TRACK_IDLE) {                                 \
+            nxt_queue_remove(&c->link);                                       \
+            e->idle_conns_cnt--;                                              \
                                                                               \
-        e->idle_conns_cnt -= c->idle;                               \
+            nxt_queue_insert_head(&e->active_connections, &c->link);         \
+                                                                              \
+            c->idle = NXT_CONN_TRACK_ACTIVE;                                  \
+            e->active_conns_cnt++;                                            \
+        }                                                                     \
+    } while (0)
+
+
+/*
+ * Detach conn from the engine's idle/active tracking queue on close.
+ *
+ * Prior states:
+ *   NXT_CONN_TRACK_IDLE   - conn is on engine->idle_connections.
+ *   NXT_CONN_TRACK_ACTIVE - conn is on engine->active_connections.
+ *   NXT_CONN_TRACK_NONE   - untracked (controller clients, proxy peers, or a
+ *                           conn already untracked here): no-op (idempotent).
+ *
+ * Unlinks the conn, decrements the queue's counter, increments
+ * closed_conns_cnt, and sets c->idle = TRACK_NONE.  Being idempotent, a conn
+ * untracked by nxt_runtime_close_idle_connections() before it scheduled the
+ * async close is not unlinked or counted a second time in the close handler.
+ */
+#define nxt_conn_untrack(engine, c)                                           \
+    do {                                                                      \
+        nxt_event_engine_t  *e = engine;                                      \
+                                                                              \
+        if (c->idle != NXT_CONN_TRACK_NONE) {                                 \
+            nxt_queue_remove(&c->link);                                       \
+                                                                              \
+            if (c->idle == NXT_CONN_TRACK_IDLE) {                             \
+                e->idle_conns_cnt--;                                          \
+                                                                              \
+            } else {                                                          \
+                e->active_conns_cnt--;                                        \
+            }                                                                 \
+                                                                              \
+            c->idle = NXT_CONN_TRACK_NONE;                                    \
+            e->closed_conns_cnt++;                                            \
+        }                                                                     \
     } while (0)
 
 

--- a/src/nxt_conn_close.c
+++ b/src/nxt_conn_close.c
@@ -119,9 +119,7 @@ nxt_conn_close_handler(nxt_task_t *task, void *obj, void *data)
         nxt_socket_close(task, c->socket.fd);
         c->socket.fd = -1;
 
-        if (c->idle) {
-            engine->closed_conns_cnt++;
-        }
+        nxt_conn_untrack(engine, c);
 
         if (timers_pending == 0) {
             nxt_work_queue_add(&engine->fast_work_queue,
@@ -157,9 +155,7 @@ nxt_conn_close_timer_handler(nxt_task_t *task, void *obj, void *data)
         nxt_socket_close(task, c->socket.fd);
         c->socket.fd = -1;
 
-        if (c->idle) {
-            engine->closed_conns_cnt++;
-        }
+        nxt_conn_untrack(engine, c);
     }
 
     nxt_work_queue_add(&engine->fast_work_queue, c->write_state->ready_handler,

--- a/src/nxt_event_engine.c
+++ b/src/nxt_event_engine.c
@@ -139,6 +139,7 @@ nxt_event_engine_create(nxt_task_t *task,
     nxt_queue_init(&engine->joints);
     nxt_queue_init(&engine->listen_connections);
     nxt_queue_init(&engine->idle_connections);
+    nxt_queue_init(&engine->active_connections);
 
     return engine;
 

--- a/src/nxt_event_engine.h
+++ b/src/nxt_event_engine.h
@@ -481,10 +481,12 @@ struct nxt_event_engine_s {
     nxt_queue_t                joints;
     nxt_queue_t                listen_connections;
     nxt_queue_t                idle_connections;
+    nxt_queue_t                active_connections;
     nxt_array_t                *mem_cache;
 
     nxt_atomic_uint_t          accepted_conns_cnt;
     nxt_atomic_uint_t          idle_conns_cnt;
+    nxt_atomic_uint_t          active_conns_cnt;
     nxt_atomic_uint_t          closed_conns_cnt;
     nxt_atomic_uint_t          requests_cnt;
 

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -484,7 +484,17 @@ nxt_runtime_close_idle_connections(nxt_event_engine_t *engine)
         c = nxt_queue_link_data(link, nxt_conn_t, link);
 
         if (!c->socket.read_ready) {
-            nxt_queue_remove(link);
+            /*
+             * Unlink and clear the tracking state immediately, before
+             * scheduling the async close.  nxt_runtime_quit() calls this on
+             * every shutdown continuation, so a conn left on idle_connections
+             * would be re-selected and re-closed on the next pass before its
+             * async close handler runs -- a double nxt_conn_close(), i.e. a
+             * use-after-free.  Clearing c->idle to TRACK_NONE also stops the
+             * close handler from unlinking the same conn a second time
+             * (P4.5).  Iteration stays safe: `next` was captured above.
+             */
+            nxt_conn_untrack(engine, c);
             nxt_conn_close(engine, c);
         }
     }

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -146,6 +146,45 @@ def test_status_connections():
     check_connections(3, 0, 0, 3)
 
 
+def test_status_connections_keepalive_cycle():
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [{"action": {"return": 200}}],
+        },
+    )
+
+    Status.init()
+
+    # each keep-alive request cycles the connection idle -> active -> idle;
+    # the engine tracking queues and counters must stay balanced throughout
+
+    (resp, sock) = client.get(
+        headers={'Host': 'localhost', 'Connection': 'keep-alive'},
+        start=True,
+        read_timeout=1,
+    )
+
+    assert resp['status'] == 200
+    check_connections(1, 0, 1, 0)
+
+    for _ in range(3):
+        (resp, sock) = client.get(
+            headers={'Host': 'localhost', 'Connection': 'keep-alive'},
+            start=True,
+            read_timeout=1,
+            sock=sock,
+        )
+
+        assert resp['status'] == 200
+        check_connections(1, 0, 1, 0)
+
+    # closing the connection unlinks it from the idle queue exactly once
+
+    client.get(sock=sock)
+    check_connections(1, 0, 0, 1)
+
+
 def test_status_applications():
     def check_applications(expert):
         apps = list(client.conf_get('/status/applications').keys()).sort()


### PR DESCRIPTION
## What

Prep refactor for **P5 (connection drain)**. The engine had no enumerable
list of in-flight connections: `nxt_conn_active()` removed a conn from
`engine->idle_connections` but placed it on no other queue, so while a
request was in flight the conn was on no engine tracking queue at all. P5's
graceful-drain force-close-on-timeout step needs to *enumerate* active
conns; a counter cannot substitute.

This adds the missing primitive and makes idle/active state symmetric.
**No drain logic, no timer logic** — those land in P5 on top of this.

## Changes

- `nxt_event_engine.{h,c}` — add `active_connections` queue + `active_conns_cnt`
  counter (plain `++/--`, per-engine single-thread, like the existing
  `idle_conns_cnt`).
- `nxt_conn.h` — `c->idle` becomes a tri-state `uint8_t`
  (`TRACK_NONE`/`_IDLE`/`_ACTIVE`); the old boolean coincided with
  `TRACK_IDLE == 1`, so boolean callers stay correct. `nxt_conn_idle()` /
  `nxt_conn_active()` now move conns between the two queues symmetrically.
- `nxt_conn_close.c` — both close handlers unlink from whichever tracking
  queue the conn is on and clear `c->idle`; `closed_conns_cnt` counted for
  both idle and active closes.
- `nxt_runtime.c` — `nxt_runtime_close_idle_connections()` no longer unlinks
  before `nxt_conn_close()` (the close handler now owns the unlink;
  double-remove avoided). Iteration stays safe — `next` is pre-captured and
  the async close unlinks on a later tick.

## Safety (reviewed)

- Every accepted conn is marked `TRACK_IDLE` in `nxt_conn_accept()` **before**
  any protocol handler, so it is always on `idle_connections` before any
  `nxt_conn_active()` → the unconditional `nxt_queue_remove()` there always
  operates on a linked conn.
- All five `nxt_conn_active()` sites (`nxt_h1p_conn_request_init`,
  `_conn_close`, `_conn_error`, `_idle_close`, `_idle_timeout`) act on a
  `TRACK_IDLE` conn and each reaches `nxt_conn_close()` → **no conn is left
  dangling** on the new `active_connections` queue.
- Controller clients and proxy peers stay `TRACK_NONE` and own `c->link` on
  their own queues; the close-handler tracking branches leave them untouched
  (same as the pre-P4.5 `if (c->idle)` gate).

## Verified

Core `./configure && make` clean. Plain + ASan builds over
`test_python_application.py` + `test_idle_close_wait.py` (42 passed / 6
skipped; no queue corruption / UAF under ASan). `test_routing.py`'s 4
failures are pre-existing `[::1]` IPv6-environmental (reproduce on
`master`). New
`test_status_connections_keepalive_cycle` in `test/test_status.py` drives one
connection through repeated idle -> active -> idle transitions over a
keep-alive socket and asserts the `/status` connection gauges stay balanced
after every cycle and after the final close (`/status` derives `active` as
`accepted - closed - idle`, so any counter imbalance in the new macros
surfaces there). A CHANGES bullet records the tracking change under 1.35.6.
The new `active_connections` queue itself gets its enumeration test with
P5's drain consumer, where it becomes externally observable.

Refs `roadmap/plan-graceful-shutdown.md` (P5 prerequisite). Resolves
andypost/unit#22 (close manually on merge — cross-repo auto-close does not fire).
