### PR TITLE
fix(libunit,java): bound InputStream.read off/len and request fields region

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 
 Changes with FreeUnit 1.35.6                                     07 Jul 2026
 
+    *) Bugfix: bound the request-header fields region against the shared
+       memory message size in libunit, validate every field name/value
+       serialized pointer and the cached header-field indexes before use,
+       and range-check off/len in the Java InputStream read() binding,
+       preventing out-of-bounds access on a malformed request.
+
     *) Feature: SIGQUIT now performs a graceful stop — application workers
        drain in-flight requests before exiting; SIGTERM remains the fast
        exit that drops them.

--- a/src/java/nxt_jni_InputStream.c
+++ b/src/java/nxt_jni_InputStream.c
@@ -163,11 +163,32 @@ static jint JNICALL
 nxt_java_InputStream_read(JNIEnv *env, jclass cls, jlong req_info_ptr,
     jarray b, jint off, jint len)
 {
+    jsize                    array_len;
     uint8_t                  *data;
     ssize_t                  res;
     nxt_unit_request_info_t  *req;
 
     req = nxt_jlong2ptr(req_info_ptr);
+
+    /*
+     * Validate (off, len) against the array bounds before handing
+     * GetPrimitiveArrayCritical's pointer + an attacker-controlled
+     * offset to nxt_unit_request_read().  Without this, a malicious
+     * caller can drive an OOB write of up to len bytes past the
+     * array's heap allocation.
+     */
+    if (b == NULL) {
+        nxt_java_throw_IllegalStateException(env,
+            "InputStream.read: input array is null");
+        return -1;
+    }
+
+    array_len = (*env)->GetArrayLength(env, b);
+    if (off < 0 || len < 0 || off > array_len || len > array_len - off) {
+        nxt_java_throw_IllegalStateException(env,
+            "InputStream.read: off/len out of bounds");
+        return -1;
+    }
 
     data = (*env)->GetPrimitiveArrayCritical(env, b, NULL);
 

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -1403,8 +1403,28 @@ nxt_unit_process_req_headers(nxt_unit_ctx_t *ctx, nxt_unit_recv_msg_t *recv_msg,
      * co-located with arrival makes the trust boundary explicit.
      */
     {
+        uint32_t            i;
         nxt_unit_request_t  *vr = recv_msg->start;
         uint32_t            vsize = recv_msg->size;
+
+        /*
+         * The fields[] array trails the fixed request struct; its region
+         * (fields_count * sizeof(nxt_unit_field_t)) must lie within the
+         * received buffer before the per-field sptr loop below -- and
+         * before nxt_unit_request_group_dup_fields() and the language
+         * modules -- dereference fields[i].  64-bit math keeps the
+         * multiplication from overflowing a 32-bit fields_count.
+         */
+        if (nxt_slow_path(sizeof(nxt_unit_request_t)
+                          + (uint64_t) vr->fields_count
+                            * sizeof(nxt_unit_field_t)
+                          > vsize))
+        {
+            nxt_unit_warn(ctx, "#%"PRIu32": malformed request: fields_count "
+                          "%"PRIu32" exceeds buffer", recv_msg->stream,
+                          vr->fields_count);
+            return NXT_UNIT_ERROR;
+        }
 
         if (nxt_slow_path(
                !nxt_unit_sptr_in_buf(&vr->method, vr->method_length,
@@ -1430,6 +1450,44 @@ nxt_unit_process_req_headers(nxt_unit_ctx_t *ctx, nxt_unit_recv_msg_t *recv_msg,
         {
             nxt_unit_warn(ctx, "#%"PRIu32": malformed request: "
                           "sptr out of buffer", recv_msg->stream);
+            return NXT_UNIT_ERROR;
+        }
+
+        for (i = 0; i < vr->fields_count; i++) {
+            if (nxt_slow_path(
+                   !nxt_unit_sptr_in_buf(&vr->fields[i].name,
+                                         vr->fields[i].name_length,
+                                         recv_msg->start, vsize)
+                || !nxt_unit_sptr_in_buf(&vr->fields[i].value,
+                                         vr->fields[i].value_length,
+                                         recv_msg->start, vsize)))
+            {
+                nxt_unit_warn(ctx, "#%"PRIu32": malformed request: field "
+                              "%"PRIu32" sptr out of buffer",
+                              recv_msg->stream, i);
+                return NXT_UNIT_ERROR;
+            }
+        }
+
+        /*
+         * The cached header indexes also arrive from the peer.  Consumers
+         * (language modules) dereference fields[<index>] after only
+         * checking against NXT_UNIT_NONE_FIELD, so an in-range fields_count
+         * paired with an out-of-range cached index still drives an OOB
+         * read.  Reject any that is neither "unset" nor a valid index.
+         */
+        if (nxt_slow_path(
+               (vr->content_length_field != NXT_UNIT_NONE_FIELD
+                && vr->content_length_field >= vr->fields_count)
+            || (vr->content_type_field != NXT_UNIT_NONE_FIELD
+                && vr->content_type_field >= vr->fields_count)
+            || (vr->cookie_field != NXT_UNIT_NONE_FIELD
+                && vr->cookie_field >= vr->fields_count)
+            || (vr->authorization_field != NXT_UNIT_NONE_FIELD
+                && vr->authorization_field >= vr->fields_count)))
+        {
+            nxt_unit_warn(ctx, "#%"PRIu32": malformed request: cached field "
+                          "index out of range", recv_msg->stream);
             return NXT_UNIT_ERROR;
         }
     }


### PR DESCRIPTION
## What

Two request-input OOB hardening fixes, completing gaps left after #85 (wave-3 follow-up per the residual-hardening plan).

**Java `InputStream.read` (item 10).** `nxt_java_InputStream_read()` passed the JNI array pointer plus an unchecked `(off, len)` straight to `nxt_unit_request_read()`, allowing an OOB write of up to `len` bytes past the array. Ports the exact `(off, len)` bounds guard already used by the sibling `nxt_java_InputStream_readLine()`, before `GetPrimitiveArrayCritical`. Defense-in-depth: the Java-side `InputStream.read()` wrapper also range-checks, but the native method is now consistent with `readLine` and safe if reached directly. `readByte()` reads a single stack byte and needs no guard.

**libunit `fields_count` / per-field sptr (item 9).** `nxt_unit_process_req_headers()` validated every fixed sptr in the request struct but neither bounded the trailing `fields[]` array region nor validated the per-field name/value sptrs. A malformed `fields_count` or field offset drove an OOB read in `nxt_unit_request_group_dup_fields()` and the language modules. Rejects when `sizeof(nxt_unit_request_t) + fields_count * sizeof(nxt_unit_field_t)` exceeds `recv_msg->size` (64-bit math to avoid overflow), then validates each field's name/value sptr with the existing `nxt_unit_sptr_in_buf` helper, co-located with the existing arrival-time validation.

## Testing

- Built `unitd`; both files compile clean under `-Werror` (java file syntax-checked against JNI headers, `nxt_unit.o` built).
- Ran `unitd` end-to-end with a libunit app: multi-header GET, POST-with-body, and repeated requests all return 200, the worker stays alive, and no `malformed`/`out of buffer` warnings — the new `fields_count` bound and per-field sptr loop do not regress valid traffic.
- The java native guard is defense-in-depth (the Java wrapper guards the public path), so no integration test exercises it directly.

## Notes

Reachability of item 9 is limited to a compromised router/peer already inside the trust boundary; this keeps the arrival-time validation complete and explicit.
