### PR TITLE
fix(proxy): reject duplicate upstream Content-Length

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 
 Changes with FreeUnit 1.35.6                                     07 Jul 2026
 
+    *) Bugfix: treat duplicate upstream "Content-Length" headers in a
+       proxied response as inconsistent — both headers are dropped and the
+       body is read to EOF instead of trusting either length, preventing a
+       response-smuggling desynchronization.
+
     *) Bugfix: bound the request-header fields region against the shared
        memory message size in libunit, validate every field name/value
        serialized pointer and the cached header-field indexes before use,

--- a/src/nxt_http_proxy.c
+++ b/src/nxt_http_proxy.c
@@ -412,6 +412,32 @@ nxt_http_proxy_content_length(void *ctx, nxt_http_field_t *field,
 
     r = ctx;
 
+    /*
+     * A second Content-Length header from the upstream is a classic
+     * response-smuggling primitive: the two values disagree on where the
+     * body ends, and silently overwriting the first with the second lets
+     * a malicious/compromised upstream desync the proxy from the client.
+     *
+     * Mark the response inconsistent (disables keepalive and closes the
+     * connection after this response, same as the parse-error path below)
+     * and do not trust either value: skip both Content-Length fields so
+     * neither is forwarded to the client, and reset content_length_n to -1
+     * so the body is framed by read-to-EOF rather than by an ambiguous
+     * advertised length.  Forwarding both headers would let a downstream
+     * parser that honours the other value re-frame the body.
+     */
+    if (r->resp.content_length != NULL) {
+        nxt_log(&r->task, NXT_LOG_WARN,
+                "upstream sent duplicate Content-Length");
+
+        r->inconsistent = 1;
+        r->resp.content_length->skip = 1;
+        field->skip = 1;
+        r->resp.content_length_n = -1;
+
+        return NXT_OK;
+    }
+
     r->resp.content_length = field;
 
     n = nxt_off_t_parse(field->value, field->value_length);


### PR DESCRIPTION
## What

`nxt_http_proxy_content_length()` overwrote `r->resp.content_length` on every `Content-Length` header, so a second header from the upstream silently replaced the first. Conflicting/duplicate `Content-Length` is a classic response-smuggling primitive: the proxy and client disagree on the body boundary, and on a kept-alive connection that desyncs the stream.

This detects the already-seen case (`r->resp.content_length != NULL`; the request is zero-allocated so it starts NULL) and marks the response inconsistent, reusing the same mechanism as the existing parse-error path (added in #85): keepalive is disabled and the connection is closed after the response, so the connection cannot be reused to smuggle a subsequent request. Single-`Content-Length` responses are unchanged.

## Testing

Verified end-to-end against a backend emitting two `Content-Length` headers:

- **duplicate CL** → proxied connection is **closed** (keepalive disabled) and `upstream sent duplicate Content-Length` is logged.
- **single CL** (control) → relayed normally with keepalive intact.

## Follow-up

The `fake_upstream` two-`Content-Length` regression test lands with #100 (test infra, WIP), per the wave-3 plan.
