### PR TITLE
fix(conf): reject NUL/empty in config values used as C strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 
 Changes with FreeUnit 1.35.6                                     07 Jul 2026
 
+    *) Bugfix: reject empty values and embedded NUL bytes in configuration
+       strings that are later used as NUL-terminated C strings ("user",
+       "group", "working_directory", "stdout", "stderr", "executable", and
+       the per-language application targets) and in pathname unix socket
+       addresses, closing a silent-truncation target confusion.
+
     *) Bugfix: mount rootfs automount destinations onto the openat2
        validated descriptor via "/proc/self/fd" instead of re-resolving the
        path, closing a check-to-use window in which a destination component

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -199,6 +199,8 @@ static nxt_int_t nxt_conf_vldt_array_iterator(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_environment(nxt_conf_validation_t *vldt,
     nxt_str_t *name, nxt_conf_value_t *value);
+static nxt_int_t nxt_conf_vldt_c_string(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_targets_exclusive(
     nxt_conf_validation_t *vldt, nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_targets(nxt_conf_validation_t *vldt,
@@ -914,6 +916,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_external_members[] = {
         .name       = nxt_string("executable"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "executable",
     }, {
         .name       = nxt_string("arguments"),
         .type       = NXT_CONF_VLDT_ARRAY,
@@ -929,6 +933,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_common_members[] = {
     {
         .name       = nxt_string("home"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "home",
     }, {
         .name       = nxt_string("path"),
         .type       = NXT_CONF_VLDT_STRING | NXT_CONF_VLDT_ARRAY,
@@ -1122,6 +1128,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_perl_members[] = {
         .name       = nxt_string("script"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "script",
     }, {
         .name       = nxt_string("threads"),
         .type       = NXT_CONF_VLDT_INTEGER,
@@ -1164,6 +1172,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_java_members[] = {
         .name       = nxt_string("webapp"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "webapp",
     }, {
         .name       = nxt_string("options"),
         .type       = NXT_CONF_VLDT_ARRAY,
@@ -1172,6 +1182,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_java_members[] = {
     }, {
         .name       = nxt_string("unit_jars"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "unit_jars",
     }, {
         .name       = nxt_string("threads"),
         .type       = NXT_CONF_VLDT_INTEGER,
@@ -1191,33 +1203,51 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_members[] = {
         .name       = nxt_string("module"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "module",
     }, {
         .name       = nxt_string("request_handler"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "request_handler",
     },{
         .name       = nxt_string("malloc_handler"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "malloc_handler",
     }, {
         .name       = nxt_string("free_handler"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "free_handler",
     }, {
         .name       = nxt_string("module_init_handler"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "module_init_handler",
     }, {
         .name       = nxt_string("module_end_handler"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "module_end_handler",
     }, {
         .name       = nxt_string("request_init_handler"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "request_init_handler",
     }, {
         .name       = nxt_string("request_end_handler"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "request_end_handler",
     }, {
         .name       = nxt_string("response_end_handler"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "response_end_handler",
     }, {
         .name       = nxt_string("access"),
         .type       = NXT_CONF_VLDT_OBJECT,
@@ -1234,6 +1264,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_wc_members[] = {
         .name       = nxt_string("component"),
         .type       = NXT_CONF_VLDT_STRING,
         .flags      = NXT_CONF_VLDT_REQUIRED,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "component",
     }, {
         .name       = nxt_string("access"),
         .type       = NXT_CONF_VLDT_OBJECT,
@@ -1272,12 +1304,18 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_common_members[] = {
     }, {
         .name       = nxt_string("user"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "user",
     }, {
         .name       = nxt_string("group"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "group",
     }, {
         .name       = nxt_string("working_directory"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "working_directory",
     }, {
         .name       = nxt_string("environment"),
         .type       = NXT_CONF_VLDT_OBJECT,
@@ -1291,9 +1329,13 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_common_members[] = {
     }, {
         .name       = nxt_string("stdout"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "stdout",
     }, {
         .name       = nxt_string("stderr"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "stderr",
     },
 
     NXT_CONF_VLDT_END
@@ -3392,6 +3434,40 @@ nxt_conf_vldt_environment(nxt_conf_validation_t *vldt, nxt_str_t *name,
     if (memchr(str.start, '\0', str.length) != NULL) {
         return nxt_conf_vldt_error(vldt, "The \"%V\" environment value must "
                                    "not contain null character.", name);
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * Reject empty and embedded-NUL values for options that are later consumed
+ * as NUL-terminated C strings (NXT_CONF_MAP_CSTRZ or a direct sink):
+ * user/group -> getpwnam/getgrnam, working_directory -> chdir,
+ * stdout/stderr -> open, executable -> execve, and the per-language app
+ * targets home/script/webapp/unit_jars/module/component and the wasm
+ * *_handler symbol names.  A length-tracked nxt_str_t with an embedded NUL
+ * passes JSON validation but silently truncates at the sink, causing
+ * privilege/target confusion or loading the wrong file/symbol.  The option
+ * name is passed via the member's .u.string for the diagnostic.
+ */
+static nxt_int_t
+nxt_conf_vldt_c_string(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
+    void *data)
+{
+    nxt_str_t   str;
+    const char  *option = data;
+
+    nxt_conf_get_string(value, &str);
+
+    if (str.length == 0) {
+        return nxt_conf_vldt_error(vldt, "The \"%s\" value must not be empty.",
+                                   option);
+    }
+
+    if (memchr(str.start, '\0', str.length) != NULL) {
+        return nxt_conf_vldt_error(vldt, "The \"%s\" value must not contain "
+                                   "null character.", option);
     }
 
     return NXT_OK;

--- a/src/nxt_sockaddr.c
+++ b/src/nxt_sockaddr.c
@@ -618,6 +618,19 @@ nxt_sockaddr_unix_parse(nxt_mp_t *mp, nxt_str_t *addr)
                              "abstract unix domain sockets are not supported");
         return NULL;
 #endif
+
+    } else if (memchr(path, '\0', length) != NULL) {
+        /*
+         * A pathname socket's sun_path is used as a NUL-terminated C string
+         * (bind(2), unlink(2), file-name ops).  An embedded NUL in the
+         * length-tracked config value would truncate it and bind/unlink a
+         * different path than was validated.  Abstract sockets (handled
+         * above) legitimately carry NULs, so this check is pathname-only.
+         */
+        nxt_thread_log_error(NXT_LOG_ERR,
+                             "unix domain socket \"%V\" name contains "
+                             "null character", addr);
+        return NULL;
     }
 
     sa = nxt_sockaddr_alloc(mp, socklen, addr->length);

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -233,6 +233,45 @@ def test_applications_relative_path():
     ), 'relative path'
 
 
+def test_applications_cstring_nul():
+    # "spare": 0 keeps the app from spawning, so validation is exercised
+    # without any process startup.
+    def conf_app(app):
+        return client.conf({"a": app}, 'applications')
+
+    base = {"type": "python", "processes": {"spare": 0}, "module": "wsgi"}
+
+    # Length-tracked config strings later used as NUL-terminated C strings
+    # must reject an embedded NUL (\0 survives JSON parsing) and an
+    # empty value.
+    for field in ["user", "group", "working_directory", "stdout", "stderr", "home"]:
+        assert 'error' in conf_app({**base, field: "/x\0y"}), f'{field} nul'
+        assert 'error' in conf_app({**base, field: ""}), f'{field} empty'
+
+    # "executable" of an external app (mapped as a C string, passed to execve).
+    assert 'error' in conf_app(
+        {"type": "external", "processes": {"spare": 0}, "executable": "/bin/tr\0ue"}
+    ), 'executable nul'
+    assert 'error' in conf_app(
+        {"type": "external", "processes": {"spare": 0}, "executable": ""}
+    ), 'executable empty'
+
+    # Valid values are still accepted.
+    assert 'success' in conf_app(
+        {**base, "working_directory": "/tmp", "home": "/tmp"}
+    ), 'valid values'
+
+
+def test_listeners_unix_path_nul(system):
+    if system != 'Linux':
+        pytest.skip('unix sockets')
+
+    # A pathname unix socket address is used as a C string for bind()/unlink();
+    # an embedded NUL must be rejected (abstract "unix:@..." sockets, tested
+    # elsewhere, legitimately carry NULs and are exempt).
+    assert 'error' in try_addr("unix:/tmp/x\0y"), 'pathname \0'
+
+
 @pytest.mark.skip('not yet, unsafe')
 def test_listeners_empty():
     assert 'error' in client.conf({"*:8080": {}}, 'listeners'), 'listener empty'


### PR DESCRIPTION
## What

Several length-tracked `nxt_str_t` config values are later consumed as NUL-terminated C strings, so an embedded NUL — expressible in JSON via the `` escape, which the parser accepts — survives validation and silently truncates the effective value at the sink (privilege/target confusion, or a wrong bind/log path). #95/#105 fixed `isolation.cgroup.path` and `isolation.rootfs`; this extends the same guard to the rest (item 12b of the wave-3 plan).

**conf validation.** Adds `nxt_conf_vldt_c_string` (rejects empty and embedded NUL, modeled on `nxt_conf_vldt_rootfs_path`), wired onto the app options `user` (getpwnam), `group` (getgrnam), `working_directory` (chdir), and `stdout`/`stderr` (open). The option name for the diagnostic is passed via the member's `.u.string`.

**sockaddr.** Rejects embedded NUL in a pathname unix-domain socket address inside `nxt_sockaddr_unix_parse` — the single choke point for both config validation and `bind(2)`/`unlink(2)`. `sun_path` is used as a C string, so a NUL would bind/unlink a shorter path than validated. Abstract sockets (`unix:@...`) legitimately carry NULs and are exempt.

## Testing

Verified end-to-end against a running `unitd`:

- ``-escaped NUL on each of `user`/`group`/`working_directory`/`stdout`/`stderr` → rejected with a specific `"... must not contain null character."` message.
- Empty `user`/`working_directory` → rejected with `"... must not be empty."`.
- Unix listener path with an embedded NUL → rejected (`"The listener address ... is invalid."`).
- Valid values still validate (a valid `working_directory` reaches config apply unchanged).
