### PR TITLE
fix(isolation): mount onto the openat2-validated fd, not the re-resolved path

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 
 Changes with FreeUnit 1.35.6                                     07 Jul 2026
 
+    *) Bugfix: mount rootfs automount destinations onto the openat2
+       validated descriptor via "/proc/self/fd" instead of re-resolving the
+       path, closing a check-to-use window in which a destination component
+       could be swapped for a symlink escaping the rootfs.
+
     *) Bugfix: treat duplicate upstream "Content-Length" headers in a
        proxied response as inconsistent — both headers are dropped and the
        body is read to EOF instead of trusting either length, preventing a

--- a/src/nxt_fs_mount.c
+++ b/src/nxt_fs_mount.c
@@ -13,10 +13,13 @@
 #if (NXT_HAVE_LINUX_MOUNT)
 
 nxt_int_t
-nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt)
+nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt, int dst_fd)
 {
     int            rc;
+    u_char         *p;
     const char     *fsname;
+    const char     *target;
+    u_char         fdpath[sizeof("/proc/self/fd/") + NXT_INT_T_LEN];
     unsigned long  flags;
 
     flags = 0;
@@ -62,12 +65,36 @@ nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt)
         }
     }
 
-    rc = mount((const char *) mnt->src, (const char *) mnt->dst, fsname, flags,
-               mnt->data);
+    if (dst_fd >= 0) {
+        /*
+         * Mount onto the exact inode the caller validated with
+         * openat2(RESOLVE_BENEATH) by targeting its fd via
+         * /proc/self/fd/<dst_fd>, instead of re-resolving mnt->dst as a
+         * path.  This closes the check-then-use window in which a
+         * component of the destination could be swapped for a symlink
+         * escaping the rootfs between the check and the mount.
+         *
+         * This requires /proc to be mounted and visible in the current
+         * mount namespace, which holds here (the rootfs mounts run before
+         * pivot_root, with the host /proc still in view); if it were not,
+         * mount(2) fails closed with ENOENT on the target.  Pass
+         * "end - 1" to nxt_sprintf so the trailing '\0' is always written
+         * within fdpath even if the formatted value filled the buffer.
+         */
+        p = nxt_sprintf(fdpath, fdpath + sizeof(fdpath) - 1,
+                        "/proc/self/fd/%d", dst_fd);
+        *p = '\0';
+        target = (const char *) fdpath;
+
+    } else {
+        target = (const char *) mnt->dst;
+    }
+
+    rc = mount((const char *) mnt->src, target, fsname, flags, mnt->data);
 
     if (nxt_slow_path(rc < 0)) {
         nxt_alert(task, "mount(\"%s\", \"%s\", \"%s\", %ul, \"%s\") %E",
-                  mnt->src, mnt->dst, fsname, flags, mnt->data, nxt_errno);
+                  mnt->src, target, fsname, flags, mnt->data, nxt_errno);
 
         return NXT_ERROR;
     }
@@ -78,7 +105,7 @@ nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt)
 #elif (NXT_HAVE_FREEBSD_NMOUNT)
 
 nxt_int_t
-nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt)
+nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt, int dst_fd)
 {
     int           flags;
     u_char        *data, *p, *end;

--- a/src/nxt_fs_mount.h
+++ b/src/nxt_fs_mount.h
@@ -41,7 +41,7 @@ struct nxt_fs_mount_s {
 };
 
 
-nxt_int_t nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt);
+nxt_int_t nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt, int dst_fd);
 void nxt_fs_unmount(const u_char *path);
 
 

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -919,6 +919,8 @@ nxt_isolation_prepare_rootfs(nxt_task_t *task, nxt_process_t *process)
 #endif
 
     for (i = 0; i < n; i++) {
+        int  mnt_dst_fd = -1;
+
         dst = mnt[i].dst;
 
         if (mnt[i].deps && !automount->language_deps) {
@@ -997,12 +999,26 @@ nxt_isolation_prepare_rootfs(nxt_task_t *task, nxt_process_t *process)
                 }
 
             } else {
-                close(fd);
+                /*
+                 * Keep the validated fd open and mount onto it directly
+                 * (via /proc/self/fd/<fd> in nxt_fs_mount) so the mount
+                 * targets the exact inode openat2 resolved, rather than
+                 * re-resolving dst as a path and reopening the check-then-
+                 * use window.  Closed after the mount below.
+                 */
+                mnt_dst_fd = fd;
             }
         }
 #endif
 
-        ret = nxt_fs_mount(task, &mnt[i]);
+        ret = nxt_fs_mount(task, &mnt[i], mnt_dst_fd);
+
+#if (NXT_HAVE_OPENAT2)
+        if (mnt_dst_fd != -1) {
+            close(mnt_dst_fd);
+        }
+#endif
+
         if (nxt_slow_path(ret != NXT_OK)) {
             goto undo;
         }


### PR DESCRIPTION
## What

#85 added `openat2(RESOLVE_BENEATH)` validation of each rootfs mount destination, but then closed the validated fd and called `nxt_fs_mount()` with `mnt->dst` as a path — `mount(2)` re-resolved the destination, leaving a check-then-use window in which a component could be swapped for a symlink escaping the rootfs between the check and the mount (item 8 of the wave-3 plan).

Threads the validated destination fd through to the mount:

- `nxt_fs_mount()` takes an `int dst_fd`. On Linux, when `dst_fd >= 0` it mounts onto `/proc/self/fd/<dst_fd>`, targeting the exact inode `openat2` resolved instead of re-resolving the path. `dst_fd < 0` keeps the previous mount-by-path behavior (openat2 unsupported / ENOSYS fallback, and non-Linux).
- `nxt_isolation_prepare_rootfs()` keeps the openat2 fd open, passes it to `nxt_fs_mount()`, and closes it after the mount (before the error check, so no leak on failure). The ENOSYS warn-once fallback and all early-continue / goto-undo paths pass `dst_fd = -1`.
- The FreeBSD `nmount()` definition takes the parameter and ignores it (openat2 is Linux-only, so `dst_fd` is always -1 there).

## Testing

- Compiles clean under `-Werror` with `NXT_HAVE_OPENAT2=1` and `NXT_HAVE_LINUX_MOUNT=1`; full `unitd` link verified (signature change consistent across the header, both definitions, and the sole caller).
- Exercising the live mount path requires `CAP_SYS_ADMIN` (`CLONE_NEWNS` + `mount`), so the runtime symlink-swap race test is deferred to a privileged CI runner.

## Impact

Unlocks the GHSA-14 mount-destination vector, previously excluded because the openat2-validated fd was not what got mounted onto.
