### PR TITLE
fix(conf): reject NUL/empty in C-string config sinks outside app options

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,12 @@ Changes with FreeUnit 1.35.6                                     07 Jul 2026
        the per-language application targets) and in pathname unix socket
        addresses, closing a silent-truncation target confusion.
 
+    *) Bugfix: reject empty values and embedded NUL bytes in the remaining
+       configuration strings used as NUL-terminated C strings outside
+       application options: the "access_log" path (string and object
+       forms), the TLS "certificate" and njs "js_module" store names, and
+       the PHP "options.file" php.ini path.
+
     *) Bugfix: mount rootfs automount destinations onto the openat2
        validated descriptor via "/proc/self/fd" instead of re-resolving the
        path, closing a check-to-use window in which a destination component

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -1073,6 +1073,8 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_php_options_members[] = {
     {
         .name       = nxt_string("file"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_c_string,
+        .u.string   = "file",
     }, {
         .name       = nxt_string("admin"),
         .type       = NXT_CONF_VLDT_OBJECT,
@@ -2842,12 +2844,24 @@ static nxt_int_t
 nxt_conf_vldt_certificate_element(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value)
 {
+    nxt_int_t         ret;
     nxt_str_t         name;
     nxt_conf_value_t  *cert;
 
     if (nxt_conf_type(value) != NXT_CONF_STRING) {
         return nxt_conf_vldt_error(vldt, "The \"certificate\" array must "
                                    "contain only string values.");
+    }
+
+    /*
+     * The certificate name is sent to the main process NUL-terminated and
+     * used there as a C-string file name in the certificates storage
+     * directory; an embedded NUL would silently truncate it to a different
+     * certificate.
+     */
+    ret = nxt_conf_vldt_c_string(vldt, value, (void *) "certificate");
+    if (ret != NXT_OK) {
+        return ret;
     }
 
     nxt_conf_get_string(value, &name);
@@ -3450,6 +3464,10 @@ nxt_conf_vldt_environment(nxt_conf_validation_t *vldt, nxt_str_t *name,
  * passes JSON validation but silently truncates at the sink, causing
  * privilege/target confusion or loading the wrong file/symbol.  The option
  * name is passed via the member's .u.string for the diagnostic.
+ *
+ * Besides application options, the helper also guards the access_log path,
+ * the php.ini "file" path, and the TLS "certificate" and njs "js_module"
+ * store names (custom validators call it directly).
  */
 static nxt_int_t
 nxt_conf_vldt_c_string(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
@@ -3912,12 +3930,23 @@ static nxt_int_t
 nxt_conf_vldt_js_module_element(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value)
 {
+    nxt_int_t         ret;
     nxt_str_t         name;
     nxt_conf_value_t  *module;
 
     if (nxt_conf_type(value) != NXT_CONF_STRING) {
         return nxt_conf_vldt_error(vldt, "The \"js_module\" array must "
                                    "contain only string values.");
+    }
+
+    /*
+     * The module name is sent to the main process NUL-terminated and used
+     * there as a C-string file name in the scripts storage directory; an
+     * embedded NUL would silently truncate it to a different module.
+     */
+    ret = nxt_conf_vldt_c_string(vldt, value, (void *) "js_module");
+    if (ret != NXT_OK) {
+        return ret;
     }
 
     nxt_conf_get_string(value, &name);
@@ -3965,7 +3994,7 @@ nxt_conf_vldt_access_log(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     static const nxt_str_t  format_str = nxt_string("format");
 
     if (nxt_conf_type(value) == NXT_CONF_STRING) {
-        return NXT_OK;
+        return nxt_conf_vldt_c_string(vldt, value, (void *) "access_log");
     }
 
     ret = nxt_conf_vldt_object(vldt, value, nxt_conf_vldt_access_log_members);
@@ -3986,6 +4015,13 @@ nxt_conf_vldt_access_log(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     if (conf.path.length == 0) {
         return nxt_conf_vldt_error(vldt,
                                    "The \"path\" string must not be empty.");
+    }
+
+    /* The log path is opened as a NUL-terminated C string. */
+
+    if (memchr(conf.path.start, '\0', conf.path.length) != NULL) {
+        return nxt_conf_vldt_error(vldt, "The \"path\" value must not "
+                                   "contain null character.");
     }
 
     if (nxt_is_tstr(&conf.format)) {

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -272,6 +272,28 @@ def test_listeners_unix_path_nul(system):
     assert 'error' in try_addr("unix:/tmp/x\0y"), 'pathname \0'
 
 
+def test_access_log_cstring_nul(temp_dir):
+    # The access log path is passed to the router and opened as a
+    # NUL-terminated C string; both the string form and the object form
+    # "path" must reject an embedded NUL (\0 survives JSON parsing) and
+    # an empty value.
+    def conf_log(value):
+        return client.conf(
+            {"listeners": {}, "applications": {}, "access_log": value}
+        )
+
+    assert 'error' in conf_log("/tmp/x\0y"), 'string nul'
+    assert 'error' in conf_log(""), 'string empty'
+    assert 'error' in conf_log({"path": "/tmp/x\0y"}), 'path nul'
+    assert 'error' in conf_log({"path": ""}), 'path empty'
+
+    # Valid values are still accepted.
+    assert 'success' in conf_log(f'{temp_dir}/access.log'), 'string valid'
+    assert 'success' in conf_log(
+        {"path": f'{temp_dir}/access.log'}
+    ), 'path valid'
+
+
 @pytest.mark.skip('not yet, unsafe')
 def test_listeners_empty():
     assert 'error' in client.conf({"*:8080": {}}, 'listeners'), 'listener empty'


### PR DESCRIPTION
PR-A of #116: extend the embedded-NUL / empty guards shipped in #114 to the config→C-string sinks that live **outside** application options. An embedded NUL (expressible in JSON via ``) survives parsing in a length-tracked `nxt_str_t` and silently truncates at the sink, so the effective value differs from the validated one.

## Sinks guarded (all in `src/nxt_conf_validation.c`)

| Config value | Sink | Change |
| --- | --- | --- |
| `access_log` (string form) | opened as a C string by the router (`nxt_router_access_log.c`) | validator returned `NXT_OK` with no checks; now routed through `nxt_conf_vldt_c_string` (empty + NUL) |
| `access_log.path` (object form) | same | empty was already rejected; added the `memchr` embedded-NUL check next to it |
| TLS `certificate` element | name sent to main NUL-terminated (`nxt_cert_store_get` appends `'\0'`) and used as a C-string file name in the certs storage dir | reject empty + NUL before the store lookup |
| njs `js_module` element | same store pattern (`nxt_script_store_get` appends `'\0'`) | reject empty + NUL before the store lookup |
| PHP `options.file` | becomes `php_ini_path_override`, a C string (`nxt_php_set_ini_path`) | wired `nxt_conf_vldt_c_string` on the member, like #114 did for `executable` |

## Explicitly out of scope

- `ruby.script` — consumed length-aware via `rb_str_new(start, length)`, truncation-safe; left alone.
- Templated `share` / `chroot` / `index` — separate change (PR-B).

## Verification

- Built clean with `--openssl` (so the TLS path compiles) under `-Werror`.
- End-to-end against a local unitd: embedded-NUL and empty values for `access_log` (both forms) and `certificate` are rejected with specific messages; a valid `access_log` still reconfigures successfully.
- New module-independent negatives + positives in `test/test_configuration.py` (`test_access_log_cstring_nul`), mirroring #114's tests, so they run in every CI leg.

Part of #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
