### PR TITLE
test(proxy): fake_upstream dup Content-Length regression (#113)

### DIFF
--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -43,6 +43,7 @@ fake_upstream --port <N> --mode <mode> [--requests <N>] [--size <MiB>] [--delay-
 | `abort-mid` | as `chunked-response`, but after `--size` bytes closes the socket **without** the terminal `0\r\n\r\n` — upstream dies mid-stream (#72 case 4) |
 | `slow-drip` | chunked, one 512-byte chunk every `--delay-ms` ms, proper terminal chunk — relay vs `proxy_read_timeout` (#72 case 5) |
 | `dup-te` | 200 with `Transfer-Encoding: chunked` header sent **twice** + valid chunked body — duplicate-TE relay (#72 case 6, nginx/unit#1088) |
+| `dup-cl` | 200 with **two conflicting** `Content-Length` headers (20, then 6) + a 20-byte body, then close — duplicate Content-Length is a response-smuggling primitive; FreeUnit must forward **neither** header, re-framing the body itself as unambiguous chunked (#113) |
 | `overrun-cl` | 200 with a fixed `Content-Length` (100) but 150 body bytes — upstream overruns its advertised length. FreeUnit must relay exactly the advertised bytes and drop the excess (no response splitting), then close the connection as inconsistent |
 | `bad-cl` | 200 with a syntactically invalid `Content-Length: notanumber` + a short body — FreeUnit must log and mark the response inconsistent instead of mis-framing the relayed body |
 | `overrun-cl-ka` | as `overrun-cl` but keep-alive-able (no `Connection: close`) — isolates the *inconsistent* flag: only FreeUnit's own decision can close the downstream connection |
@@ -75,6 +76,8 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 | Port | Token | Mode (CLI) | Rust handler | pytest |
 |------|-------|-----------|--------------|--------|
+| 7983 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_raw` (zero raw `Content-Length` occurrences on the wire, complete re-framed chunked body) |
+| 7984 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl` (duplicate upstream Content-Length → neither forwarded, body re-framed, #113) |
 | 7985 | `chunked_ext` | `chunked-ext` | `respond_chunked_edge` | `test_proxy_chunked_ext` (chunk-extensions stripped, body intact) |
 | 7986 | `chunked_trailer` | `chunked-trailer` | `respond_chunked_edge` | `test_proxy_chunked_trailer` (trailer after terminal chunk, body intact) |
 | 7987 | `overrun_cl_ka` | `overrun-cl-ka` | `respond_overrun_cl_ka` | `test_proxy_overrun_cl_keepalive` (inconsistent flag closes downstream conn) |

--- a/test/fake_upstream/src/main.rs
+++ b/test/fake_upstream/src/main.rs
@@ -28,6 +28,12 @@
 ///                    would enable response splitting) and close the
 ///                    connection as inconsistent. Mirrors pytest
 ///                    test_proxy_overrun_cl.
+///   dup-cl           200 with TWO conflicting Content-Length headers (20,
+///                    then 6) + a 20-byte body, then close. Duplicate
+///                    Content-Length is a response-smuggling primitive;
+///                    FreeUnit must forward neither header, re-framing the
+///                    body itself as unambiguous chunked (#113). Mirrors
+///                    pytest test_proxy_dup_cl.
 ///
 /// --requests N   exit after handling N connections (default: run forever)
 /// --size N       chunked-response: response body size in MiB (default: 1)
@@ -51,6 +57,7 @@ enum Mode {
     AbortMid,
     SlowDrip,
     DupTe,
+    DupCl,
     OverrunCl,
     BadCl,
     OverrunClKa,
@@ -78,6 +85,14 @@ const BAD_CL_VALUE: &str = "notanumber";
 /// the exact expected bytes.
 const OVERRUN_DECLARED: usize = 100;
 const OVERRUN_EXCESS: usize = 50;
+
+/// Conflicting Content-Length values for the `dup-cl` mode. The first header
+/// advertises the real body length, the second a shorter one — a downstream
+/// parser that honoured the second value would treat the body tail as the
+/// start of the next response (the classic smuggling desync). Kept tiny and
+/// fixed so the test regenerates the exact expected bytes.
+const DUP_CL_FIRST: usize = 20;
+const DUP_CL_SECOND: usize = 6;
 
 // ---------------------------------------------------------------------------
 
@@ -406,6 +421,33 @@ fn respond_dup_te(stream: &mut TcpStream, size: usize) {
     let _ = stream.flush();
 }
 
+/// Send TWO conflicting `Content-Length` headers (DUP_CL_FIRST, then
+/// DUP_CL_SECOND), followed by DUP_CL_FIRST deterministic body bytes, then
+/// close. Duplicate Content-Length is a classic response-smuggling
+/// primitive: the two values disagree on where the body ends, so a proxy
+/// that forwards them lets a downstream parser honouring the other value
+/// re-frame the body. FreeUnit must forward *neither* header, re-framing
+/// the body itself as unambiguous chunked (#113). Mirrors pytest
+/// `test_proxy_dup_cl`.
+fn respond_dup_cl(stream: &mut TcpStream) {
+    let mut resp = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Length: {}\r\n\
+         Content-Length: {}\r\n\
+         Connection: keep-alive\r\n\r\n",
+        DUP_CL_FIRST, DUP_CL_SECOND
+    )
+    .into_bytes();
+
+    for i in 0..DUP_CL_FIRST {
+        resp.push(PATTERN[i % PATTERN.len()]);
+    }
+
+    let _ = stream.write_all(&resp);
+    let _ = stream.flush();
+}
+
 /// Send a `Content-Length: OVERRUN_DECLARED` header but write
 /// `OVERRUN_DECLARED + OVERRUN_EXCESS` deterministic body bytes — an upstream
 /// that overruns its own advertised length. FreeUnit must relay exactly the
@@ -557,6 +599,10 @@ fn handle(mut stream: TcpStream, opts: &Opts) {
             respond_dup_te(&mut stream, opts.size);
         }
 
+        Mode::DupCl => {
+            respond_dup_cl(&mut stream);
+        }
+
         Mode::OverrunCl => {
             respond_overrun_cl(&mut stream);
         }
@@ -633,7 +679,7 @@ fn usage() -> ! {
     eprintln!(
         "Usage: fake_upstream --port <N> \
          --mode <requires-cl|no-te|strict|echo|chunked-response|\
-         abort-mid|slow-drip|dup-te|overrun-cl|bad-cl|\
+         abort-mid|slow-drip|dup-te|dup-cl|overrun-cl|bad-cl|\
          overrun-cl-ka|chunked-trailer|chunked-ext> \
          [--requests <N>] [--size <MiB>] [--delay-ms <N>]"
     );
@@ -667,6 +713,7 @@ fn main() {
                     "abort-mid" => Some(Mode::AbortMid),
                     "slow-drip" => Some(Mode::SlowDrip),
                     "dup-te" => Some(Mode::DupTe),
+                    "dup-cl" => Some(Mode::DupCl),
                     "overrun-cl" => Some(Mode::OverrunCl),
                     "bad-cl" => Some(Mode::BadCl),
                     "overrun-cl-ka" => Some(Mode::OverrunClKa),

--- a/test/test_proxy_dup_cl.py
+++ b/test/test_proxy_dup_cl.py
@@ -1,0 +1,199 @@
+"""Proxy duplicate upstream Content-Length regression test (#113).
+
+An upstream that sends a second Content-Length header is a classic
+response-smuggling primitive: the two values disagree on where the body ends,
+so a proxy that forwards them lets the client and any intermediary re-frame
+the body against each other. The hardening in nxt_http_proxy_content_length
+logs a warning, sets skip=1 on BOTH Content-Length fields so neither is
+forwarded, and resets content_length_n to -1 so the body is framed by
+read-to-EOF instead of an ambiguous advertised length.
+
+Client-observable outcome, confirmed against the running router: a 200
+response carrying NO Content-Length header at all -- FreeUnit re-frames the
+body itself as Transfer-Encoding: chunked -- with the exact upstream body
+bytes and a complete terminal chunk. The client never sees the two ambiguous
+lengths, so there is no framing disagreement to exploit.
+
+Note on the inconsistent flag: nxt_http_proxy_content_length also sets
+r->inconsistent, but once the EOF-framed body ends with a clean upstream
+close, nxt_h1p_peer_closed recomputes the flag from the (already reset)
+framing state, so a keep-alive-disabling close is not independently
+observable here. Both tests therefore drive `Connection: close` and assert
+the defense that matters on the wire: zero conflicting Content-Length headers
+reach the client and the relayed body framing is unambiguous.
+
+Driven by the `dup-cl` mode of the Rust mock upstream (test/fake_upstream/):
+it sends `Content-Length: 20` then `Content-Length: 6`, followed by a 20-byte
+deterministic body, then closes. This test was deferred from #113 to land
+with the fake_upstream harness (#100). Language-module-free (gated only on
+built-in proxy support) so it runs on the minimal test build.
+"""
+
+import os
+import socket
+import subprocess
+
+import pytest
+
+from unit.applications.proto import ApplicationProto
+from unit.utils import waitforsocket
+
+client = ApplicationProto()
+
+# Deterministic body: byte at global offset i is PATTERN[i % 16] — mirrors the
+# fake_upstream PATTERN so the test regenerates the exact upstream bytes.
+PATTERN = '0123456789abcdef'
+
+# Must match DUP_CL_FIRST / DUP_CL_SECOND in test/fake_upstream/src/main.rs:
+# the first Content-Length advertises the real body length, the second a
+# shorter, conflicting one.
+DUP_CL_FIRST = 20
+DUP_CL_SECOND = 6
+
+BODY = (PATTERN * (DUP_CL_FIRST // len(PATTERN) + 1))[:DUP_CL_FIRST]
+
+# Reserved fake_upstream ports for these cases (see test/fake_upstream/README.md).
+UPSTREAM_DUP_CL_PORT = 7984
+UPSTREAM_DUP_CL_RAW_PORT = 7983
+
+FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
+
+_skipif_no_fake_upstream = pytest.mark.skipif(
+    not os.path.exists(FAKE_UPSTREAM_BIN),
+    reason=f'{FAKE_UPSTREAM_BIN} not installed (build via test/fake_upstream)',
+)
+
+
+def _run(port, mode):
+    proc = subprocess.Popen(
+        [FAKE_UPSTREAM_BIN, '--port', str(port), '--mode', mode],
+        stdout=subprocess.DEVNULL,
+        # DEVNULL, not PIPE: nothing reads this stream, and an unread PIPE can
+        # deadlock the child if it ever fills the OS pipe buffer.
+        stderr=subprocess.DEVNULL,
+    )
+    # Tear the process down if it never binds — otherwise a waitforsocket
+    # timeout would raise before the caller's try/finally and leak it.
+    try:
+        waitforsocket(port)
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
+    return proc
+
+
+def _dechunk(raw):
+    # Minimal chunked-body decoder for the raw test; fails loudly on any
+    # malformed framing (ValueError / IndexError fail the test).
+    body = b''
+    while True:
+        line, raw = raw.split(b'\r\n', 1)
+        size = int(line.split(b';')[0], 16)
+        if size == 0:
+            break
+        body += raw[:size]
+        raw = raw[size + 2:]
+    return body
+
+
+def _conf_proxy(port):
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {"action": {"proxy": f'http://127.0.0.1:{port}'}}
+            ],
+        }
+    ), 'dup-cl proxy configuration'
+
+
+@_skipif_no_fake_upstream
+def test_proxy_dup_cl(skip_alert):
+    # The router logs a warning about the duplicate upstream Content-Length;
+    # it is [warn] not [alert], but suppress it defensively.
+    skip_alert(r'upstream sent duplicate Content-Length')
+
+    proc = _run(UPSTREAM_DUP_CL_PORT, 'dup-cl')
+    try:
+        _conf_proxy(UPSTREAM_DUP_CL_PORT)
+
+        resp = client.get(port=8080)
+
+        assert resp['status'] == 200, f'unexpected status: {resp}'
+
+        # Neither conflicting Content-Length may reach the client: both
+        # upstream fields are skipped and FreeUnit re-frames the body itself
+        # (read-to-EOF, emitted as Transfer-Encoding: chunked).
+        assert 'Content-Length' not in resp['headers'], (
+            f'conflicting upstream Content-Length must not be forwarded: {resp}'
+        )
+        assert (
+            resp['headers'].get('Transfer-Encoding') == 'chunked'
+        ), f'body must be re-framed by FreeUnit: {resp}'
+
+        # The body itself is relayed intact (the harness de-chunks it).
+        assert resp['body'] == BODY, f'body not relayed intact: {resp}'
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_dup_cl_raw(skip_alert):
+    # Same upstream, but read the raw response ourselves: the parsed-headers
+    # dict above cannot distinguish "one Content-Length" from "two", so count
+    # the occurrences on the wire and check the re-framed chunked body ends
+    # with a proper terminal chunk (unambiguous framing, no bytes left over
+    # for a smuggled response). The request carries `Connection: close`, so
+    # the exchange is bounded by EOF.
+    skip_alert(r'upstream sent duplicate Content-Length')
+
+    proc = _run(UPSTREAM_DUP_CL_RAW_PORT, 'dup-cl')
+    try:
+        _conf_proxy(UPSTREAM_DUP_CL_RAW_PORT)
+
+        sock = client.get(port=8080, no_recv=True)
+        sock.settimeout(10)
+
+        data = b''
+        closed = False
+        try:
+            while True:
+                part = sock.recv(4096)
+                if not part:
+                    closed = True
+                    break
+                data += part
+        except socket.timeout:
+            closed = False
+        finally:
+            sock.close()
+
+        assert data[:12] == b'HTTP/1.1 200', f'status line: {data[:40]!r}'
+
+        sep = data.index(b'\r\n\r\n')
+        head = data[:sep].lower()
+        body = data[sep + 4:]
+
+        # Zero Content-Length headers on the wire — not merely "not two".
+        cl_count = head.count(b'content-length')
+        assert cl_count == 0, (
+            f'client saw {cl_count} Content-Length header(s): {data[:sep]!r}'
+        )
+
+        # The re-framed chunked body is complete and unambiguous: the exact
+        # upstream bytes, a proper terminal chunk, then EOF — nothing left on
+        # the connection to smuggle.
+        assert b'transfer-encoding: chunked' in head, f'not re-framed: {head!r}'
+        assert body.endswith(b'0\r\n\r\n'), (
+            f'terminal chunk missing: {body!r}'
+        )
+        assert _dechunk(body) == BODY.encode(), (
+            f'relayed body mismatch: {body!r}'
+        )
+
+        assert closed, 'connection must be closed after the response'
+    finally:
+        proc.terminate()
+        proc.wait()


### PR DESCRIPTION
Closes out the regression test deferred from #113 ("The fake_upstream two-Content-Length regression test lands with #100") now that the #100 harness is merged.

## What

**`dup-cl` mode in `test/fake_upstream`** — sends `HTTP/1.1 200 OK` with two conflicting `Content-Length` headers (`20`, then `6`) plus a 20-byte deterministic body, then closes. Ports `7983`/`7984` reserved in the README registry, three-way name mirroring kept (`dup_cl` ↔ `--mode dup-cl` ↔ `respond_dup_cl` ↔ `test_proxy_dup_cl*`).

**`test/test_proxy_dup_cl.py`** — two language-module-free tests (built-in proxy only, run on the minimal build), mirroring `test_proxy_overrun_cl.py` structure:

- `test_proxy_dup_cl`: the proxied response carries **no `Content-Length` header at all** (the #113 hardening skips both upstream fields), the body is re-framed as `Transfer-Encoding: chunked` and relayed byte-exact.
- `test_proxy_dup_cl_raw`: raw-socket leg that counts `Content-Length` occurrences on the wire (**exactly zero**, not merely "not two") and verifies the re-framed chunked body is complete and unambiguous (proper terminal chunk, EOF-bounded exchange) — nothing is left on the connection for a downstream parser to re-frame.

## Note on the connection-close half of #113

The tests deliberately do not assert a keep-alive-disabling close. `nxt_http_proxy_content_length` does set `r->inconsistent`, but once the EOF-framed body ends with a clean upstream close, `nxt_h1p_peer_closed` recomputes the flag from the (already reset) framing state (`remainder == 0`, not chunked), so the close is not independently observable in this scenario — confirmed against a local build (a keep-alive client connection stays open after a complete re-framed response). The wire-level defense asserted here — no ambiguous `Content-Length` reaches the client and the relayed framing is self-consistent — is what forecloses the smuggling primitive. If the `inconsistent` clobber is ever tightened (e.g. `|=` in `nxt_h1p_peer_closed`), that behavior change belongs in a product PR with its own test leg.

## Verification

Built `fake_upstream` clean (`cargo build --release`), ran both tests against a local `pre-1.35.6` build: **2 passed**. Raw wire check: zero `Content-Length` headers, `Transfer-Encoding: chunked` with complete terminal chunk, exact 20-byte body, and `[warn] upstream sent duplicate Content-Length` in the router log.

Test-only change — no `CHANGES` entry, matching recent test-only commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
