### PR TITLE
[codex] fix cgroup.procs path append bounds

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -183,6 +183,10 @@ if [ $NXT_HAVE_CLONE_NEWUSER = YES ]; then
     NXT_TEST_SRCS="$NXT_TEST_SRCS src/test/nxt_clone_test.c"
 fi
 
+if [ "$NXT_HAVE_CGROUP" = "YES" ]; then
+    NXT_TEST_SRCS="$NXT_TEST_SRCS src/test/nxt_cgroup_test.c"
+fi
+
 
 NXT_LIB_UTF8_FILE_NAME_TEST_SRCS=" \
     src/test/nxt_utf8_file_name_test.c \

--- a/src/nxt_cgroup.c
+++ b/src/nxt_cgroup.c
@@ -15,9 +15,30 @@ static nxt_int_t nxt_mk_cgpath(nxt_task_t *task, const char *dir,
 
 
 nxt_int_t
+nxt_cgroup_make_procs_path(char *cgprocs, size_t len)
+{
+    int  n;
+
+    if (nxt_slow_path(len >= NXT_MAX_PATH_LEN)) {
+        nxt_errno = ENAMETOOLONG;
+        return NXT_ERROR;
+    }
+
+    n = snprintf(cgprocs + len, NXT_MAX_PATH_LEN - len, "/cgroup.procs");
+    if (nxt_slow_path(n < 0 || (size_t) n >= NXT_MAX_PATH_LEN - len)) {
+        nxt_errno = ENAMETOOLONG;
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+nxt_int_t
 nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process)
 {
     int        len;
+    size_t     old_len;
     char       cgprocs[NXT_MAX_PATH_LEN];
     FILE       *fp;
     nxt_int_t  ret;
@@ -48,7 +69,7 @@ nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process)
         return NXT_ERROR;
     }
 
-    len = strlen(cgprocs);
+    old_len = strlen(cgprocs);
 
     /*
      * Stash the resolved directory before appending "/cgroup.procs" so
@@ -56,15 +77,14 @@ nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process)
      * which is gone once the child has exited.
      */
     process->isolation.cgroup.resolved_path = nxt_mp_alloc(process->mem_pool,
-                                                           len + 1);
+                                                           old_len + 1);
     if (nxt_fast_path(process->isolation.cgroup.resolved_path != NULL)) {
-        nxt_memcpy(process->isolation.cgroup.resolved_path, cgprocs, len);
-        process->isolation.cgroup.resolved_path[len] = '\0';
+        nxt_memcpy(process->isolation.cgroup.resolved_path, cgprocs, old_len);
+        process->isolation.cgroup.resolved_path[old_len] = '\0';
     }
 
-    len = snprintf(cgprocs + len, NXT_MAX_PATH_LEN - len, "/cgroup.procs");
-    if (nxt_slow_path(len >= NXT_MAX_PATH_LEN - len)) {
-        nxt_errno = ENAMETOOLONG;
+    ret = nxt_cgroup_make_procs_path(cgprocs, old_len);
+    if (nxt_slow_path(ret == NXT_ERROR)) {
         return NXT_ERROR;
     }
 

--- a/src/nxt_cgroup.h
+++ b/src/nxt_cgroup.h
@@ -7,6 +7,7 @@
 #define _NXT_CGROUP_H_INCLUDED_
 
 
+nxt_int_t nxt_cgroup_make_procs_path(char *cgprocs, size_t len);
 nxt_int_t nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process);
 void nxt_cgroup_cleanup(nxt_task_t *task, const nxt_process_t *process);
 

--- a/src/test/nxt_cgroup_test.c
+++ b/src/test/nxt_cgroup_test.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) FreeUnit
+ */
+
+#include <nxt_main.h>
+#include <nxt_cgroup.h>
+#include "nxt_tests.h"
+
+
+nxt_int_t
+nxt_cgroup_test(nxt_thread_t *thr)
+{
+    char    path[NXT_MAX_PATH_LEN];
+    size_t  suffix_len, len;
+
+    suffix_len = nxt_length("/cgroup.procs");
+
+    /*
+     * The final NUL also has to fit.  This is the last valid directory
+     * length before appending "/cgroup.procs".
+     */
+    len = NXT_MAX_PATH_LEN - suffix_len - 1;
+
+    memset(path, 'a', len);
+    path[len] = '\0';
+
+    if (nxt_cgroup_make_procs_path(path, len) != NXT_OK) {
+        nxt_log_alert(thr->log, "nxt_cgroup_make_procs_path() rejected "
+                      "last valid path length");
+        return NXT_ERROR;
+    }
+
+    if (strlen(path) != NXT_MAX_PATH_LEN - 1) {
+        nxt_log_alert(thr->log, "nxt_cgroup_make_procs_path() produced "
+                      "unexpected path length");
+        return NXT_ERROR;
+    }
+
+    /*
+     * One byte longer leaves room for the suffix bytes but not the trailing
+     * NUL; this used to pass because the check compared against the
+     * overwritten snprintf() return value.
+     */
+    len = NXT_MAX_PATH_LEN - suffix_len;
+
+    memset(path, 'a', len);
+    path[len] = '\0';
+    nxt_errno = 0;
+
+    if (nxt_cgroup_make_procs_path(path, len) != NXT_ERROR) {
+        nxt_log_alert(thr->log, "nxt_cgroup_make_procs_path() accepted "
+                      "overflowing path length");
+        return NXT_ERROR;
+    }
+
+    if (nxt_errno != ENAMETOOLONG) {
+        nxt_log_alert(thr->log, "nxt_cgroup_make_procs_path() set errno %E, "
+                      "expected ENAMETOOLONG", nxt_errno);
+        return NXT_ERROR;
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "nxt_cgroup test passed");
+
+    return NXT_OK;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -186,6 +186,12 @@ main(int argc, char **argv)
         return 1;
     }
 
+#if (NXT_HAVE_CGROUP)
+    if (nxt_cgroup_test(thr) != NXT_OK) {
+        return 1;
+    }
+#endif
+
 #if (NXT_HAVE_CLONE_NEWUSER)
     if (nxt_clone_creds_test(thr) != NXT_OK) {
         return 1;

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -70,6 +70,7 @@ nxt_int_t nxt_http_chunk_parse_test(nxt_thread_t *thr);
 nxt_int_t nxt_conf_json_depth_test(nxt_thread_t *thr);
 nxt_int_t nxt_http_route_addr_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
+nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);
 
 


### PR DESCRIPTION
## Summary

Fix the cgroup path append bounds check used when building the `cgroup.procs` pathname.

The previous check overwrote the original directory length with `snprintf()`'s return value, then compared that return value against `NXT_MAX_PATH_LEN - len`. That made the truncation guard ineffective for long cgroup directories.

## Changes

- Add `nxt_cgroup_make_procs_path()` to append `/cgroup.procs` with the original path length preserved.
- Return `NXT_ERROR` and set `nxt_errno = ENAMETOOLONG` when the suffix plus trailing NUL cannot fit.
- Add a C harness regression test covering the last valid path length and the first overflowing length.
- Wire the test into `auto/sources` and `src/test/nxt_tests.c` when cgroup support is compiled in.

## Validation

- `./configure --tests`
- `make build/tests`
- `build/tests`
- `git diff --check`