### PR TITLE
test(conf): cover embedded-NUL/empty rejection for per-language C-string sinks

### DIFF
--- a/test/test_java_application.py
+++ b/test/test_java_application.py
@@ -1055,3 +1055,29 @@ def test_java_input_readline_bounds():
         )['status']
         == 200
     ), 'worker survived'
+
+
+def test_java_cstring_nul():
+    # "webapp" (required) and "unit_jars" are consumed as NUL-terminated C
+    # strings; an embedded NUL (survives JSON parsing) or an empty value must
+    # be rejected at validation.  "spare": 0 exercises validation without
+    # spawning (so a non-existent webapp path is not realpath-checked here).
+    def conf_app(extra):
+        base = {
+            "type": client.get_application_type(),
+            "processes": {"spare": 0},
+            "webapp": f'{option.temp_dir}/java',
+        }
+        return client.conf({"app": {**base, **extra}}, 'applications')
+
+    resp = conf_app({"webapp": "/x\0y"})
+    assert 'null character' in resp.get('detail', ''), 'webapp nul'
+
+    resp = conf_app({"webapp": ""})
+    assert 'must not be empty' in resp.get('detail', ''), 'webapp empty'
+
+    resp = conf_app({"unit_jars": "/x\0y"})
+    assert 'null character' in resp.get('detail', ''), 'unit_jars nul'
+
+    resp = conf_app({"unit_jars": ""})
+    assert 'must not be empty' in resp.get('detail', ''), 'unit_jars empty'

--- a/test/test_njs_modules.py
+++ b/test/test_njs_modules.py
@@ -102,3 +102,26 @@ def test_njs_modules_invalid(skip_alert):
     skip_alert(r'.*JS compile module.*failed.*')
 
     njs_script_load('invalid', expect='error')
+
+
+def test_njs_settings_js_module_nul():
+    # A "settings.js_module" reference is used as a NUL-terminated C-string
+    # store name; an embedded NUL (which survives JSON parsing in a
+    # length-tracked nxt_str_t) or an empty value must be rejected by the
+    # c-string validator, before the module-store lookup.
+    #
+    # The module-store lookup is length-aware and would also reject these
+    # values (as "not found"), so assert the validator's own diagnostic to
+    # prove the c-string guard ran rather than the lookup merely failing.
+    njs_script_load('next')
+
+    assert 'success' in client.conf({"js_module": "next"}, 'settings'), 'valid'
+
+    resp = client.conf({"js_module": "next\0x"}, 'settings')
+    assert 'null character' in resp.get('detail', ''), 'nul'
+
+    resp = client.conf({"js_module": ""}, 'settings')
+    assert 'must not be empty' in resp.get('detail', ''), 'empty'
+
+    resp = client.conf({"js_module": ["next\0x"]}, 'settings')
+    assert 'null character' in resp.get('detail', ''), 'array nul'

--- a/test/test_perl_application.py
+++ b/test/test_perl_application.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from unit.applications.lang.perl import ApplicationPerl
+from unit.option import option
 
 prerequisites = {'modules': {'perl': 'all'}}
 
@@ -317,3 +318,30 @@ def test_perl_application_threads():
         sock.close()
 
     assert len(socks) == len(threads), 'threads differs'
+
+
+def test_perl_script_cstring_nul():
+    # perl "script" is consumed as a NUL-terminated C-string path; an
+    # embedded NUL (survives JSON parsing) or an empty value must be
+    # rejected at validation.  "spare": 0 exercises validation without
+    # spawning a process.
+    def conf_script(value):
+        return client.conf(
+            {
+                "app": {
+                    "type": client.get_application_type(),
+                    "processes": {"spare": 0},
+                    "script": value,
+                }
+            },
+            'applications',
+        )
+
+    resp = conf_script("/x\0y.pl")
+    assert 'null character' in resp.get('detail', ''), 'script nul'
+
+    resp = conf_script("")
+    assert 'must not be empty' in resp.get('detail', ''), 'script empty'
+    assert 'success' in conf_script(
+        f'{option.test_dir}/perl/variables/psgi.pl'
+    ), 'script valid'

--- a/test/test_php_application.py
+++ b/test/test_php_application.py
@@ -896,3 +896,29 @@ def test_php_application_opcache_preload_ffr():
 
     assert client.get()['headers']['X-Cached'] == '0', 'not cached'
     assert client.get()['headers']['X-Cached'] == '1', 'cached'
+
+
+def test_php_options_file_cstring_nul():
+    # php "options.file" (the php.ini path) is later opened as a
+    # NUL-terminated C string; an embedded NUL (survives JSON parsing) or an
+    # empty value must be rejected at validation.  "spare": 0 exercises
+    # validation without spawning a process.
+    def conf_file(value):
+        return client.conf(
+            {
+                "app": {
+                    "type": client.get_application_type(),
+                    "processes": {"spare": 0},
+                    "root": "/app",
+                    "options": {"file": value},
+                }
+            },
+            'applications',
+        )
+
+    resp = conf_file("/x\0y")
+    assert 'null character' in resp.get('detail', ''), 'file nul'
+
+    resp = conf_file("")
+    assert 'must not be empty' in resp.get('detail', ''), 'file empty'
+    assert 'success' in conf_file("/tmp/php.ini"), 'file valid'

--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -774,3 +774,32 @@ def test_tls_multi_listener():
     assert client.get_ssl()['status'] == 200, 'listener #1'
 
     assert client.get_ssl(port=8081)['status'] == 200, 'listener #2'
+
+
+def test_tls_certificate_cstring_nul():
+    client.load('empty')
+    client.certificate()
+
+    # The "certificate" name is used as a NUL-terminated C-string store name;
+    # an embedded NUL (which survives JSON parsing in a length-tracked
+    # nxt_str_t) or an empty value must be rejected by the c-string validator,
+    # before the certificate-store lookup.
+    def conf_cert(cert):
+        return client.conf(
+            {"pass": "applications/empty", "tls": {"certificate": cert}},
+            'listeners/*:8080',
+        )
+
+    # The certificate-store lookup is length-aware and would also reject
+    # these values (as "not found"), so assert the validator's own diagnostic
+    # to prove the c-string guard ran rather than the lookup merely failing.
+    assert 'success' in conf_cert("default"), 'valid'
+
+    resp = conf_cert("default\0junk")
+    assert 'null character' in resp.get('detail', ''), 'nul'
+
+    resp = conf_cert("")
+    assert 'must not be empty' in resp.get('detail', ''), 'empty'
+
+    resp = conf_cert(["default\0junk"])
+    assert 'null character' in resp.get('detail', ''), 'array nul'

--- a/test/test_wasm-wasi-component.py
+++ b/test/test_wasm-wasi-component.py
@@ -16,3 +16,26 @@ def test_wasm_component():
 
     assert client.get()['status'] == 200
     assert req['body'] == 'Hello'
+
+
+def test_wasm_component_cstring_nul():
+    # "component" is consumed as a NUL-terminated C-string path; an embedded
+    # NUL (survives JSON parsing) or an empty value must be rejected at
+    # validation.  "spare": 0 exercises validation without spawning.
+    def conf_component(value):
+        return client.conf(
+            {
+                "app": {
+                    "type": "wasm-wasi-component",
+                    "processes": {"spare": 0},
+                    "component": value,
+                }
+            },
+            'applications',
+        )
+
+    resp = conf_component("/x\0y.wasm")
+    assert 'null character' in resp.get('detail', ''), 'nul'
+
+    resp = conf_component("")
+    assert 'must not be empty' in resp.get('detail', ''), 'empty'


### PR DESCRIPTION
## Summary

Extends the embedded-NUL / empty-value config-validation coverage to the
per-language C-string sinks that the base guards (#114 / #117) wired but that
had no tests yet. `nxt_conf_vldt_c_string()` rejects an empty value and an
embedded NUL: a JSON-encoded null survives parsing in a length-tracked
`nxt_str_t` and silently truncates at the sink, so the effective value differs
from the validated one. The merged tests only exercised the python/external app
options and `access_log`.

Each new test lives in its module's file so it runs in the matching CI leg;
`{"spare": 0}` exercises validation without spawning a process.

## Sinks now covered

| Config value | Validator / sink | Test |
| --- | --- | --- |
| php `options.file` | php.ini path opened as a C string | `test_php_application.py::test_php_options_file_cstring_nul` |
| perl `script` | script path (C string) | `test_perl_application.py::test_perl_script_cstring_nul` |
| java `webapp`, `unit_jars` | C-string paths | `test_java_application.py::test_java_cstring_nul` |
| njs `settings.js_module` | `nxt_conf_vldt_js_module_element` store name | `test_njs_modules.py::test_njs_settings_js_module_nul` |
| TLS `certificate` | `nxt_conf_vldt_certificate_element` store name | `test_tls.py::test_tls_certificate_cstring_nul` |
| wasm-component `component` | C-string path | `test_wasm-wasi-component.py::test_wasm_component_cstring_nul` |

Each asserts both the embedded-NUL and the empty-value rejection; where it needs
no language runtime, a valid positive is included too.

## Also

- Drop a duplicate `test_otel_traceparent_malformed` in `test_otel.py`: the
  obsolete `xfail` bug-stub for #109 was shadowed by the post-fix regression
  test of the same name, so Python kept only the latter and the stub never ran.
  #109 is fixed, so the stub is removed rather than renamed (renaming would
  revive a `strict=True` xfail that now xpasses -> fails).

## Out of scope

- Plain `wasm` (`module` + `*_handler` symbol names): same validator, but no
  test harness exists (`test_wasm.py` / helper absent, needs wasmtime). Left as
  a low-priority follow-up.
