### PR TITLE
fix(static): reject embedded NUL in templated share/chroot paths (PR-B of #116)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,12 @@ Changes with FreeUnit 1.35.6                                     07 Jul 2026
        forms), the TLS "certificate" and njs "js_module" store names, and
        the PHP "options.file" php.ini path.
 
+    *) Bugfix: reject an embedded NUL byte in a templated static-serving
+       path ("share" and "chroot") after it is resolved from
+       request-controlled variables and before it reaches open()/openat2(),
+       preventing a silent truncation that could serve a different file
+       than the resolved path.
+
     *) Bugfix: mount rootfs automount destinations onto the openat2
        validated descriptor via "/proc/self/fd" instead of re-resolving the
        path, closing a check-to-use window in which a destination component

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -293,8 +293,63 @@ nxt_http_static_iterate(nxt_task_t *task, nxt_http_request_t *r,
             if (nxt_slow_path(ret != NXT_OK)) {
                 goto fail;
             }
+
+            /*
+             * "chroot" is resolved once (share_idx == 0) and reused for every
+             * share candidate.  This must run before the "share" NUL check
+             * below so ctx->chroot stays populated for the whole share chain
+             * even when a templated share is rejected and we advance to the
+             * next candidate; otherwise the fallback share would be opened
+             * without the configured chroot confinement.  An embedded NUL
+             * would truncate the root at openat2(), and since the same chroot
+             * applies to every share, a bad "chroot" dooms the whole action --
+             * fail the request rather than advancing to the next share (which
+             * would reuse the unchecked value).  Skip straight to the last
+             * share so nxt_http_static_next() bypasses the remaining shares
+             * (never re-resolving the bad chroot) yet still dispatches the
+             * action "fallback" when one is configured, matching how the share
+             * NUL rejection below behaves.
+             */
+            if (ctx->chroot.length > 0
+                && nxt_slow_path(memchr(ctx->chroot.start, '\0',
+                                        ctx->chroot.length) != NULL))
+            {
+                nxt_log(task, NXT_LOG_ERR, "rejected \"chroot\" path with an "
+                        "embedded zero byte");
+                ctx->share_idx = conf->nshares - 1;
+                nxt_http_static_next(task, r, ctx, NXT_HTTP_NOT_FOUND);
+                return;
+            }
         }
 #endif
+
+        /*
+         * A templated "share" may resolve to an empty string (e.g. "$arg_name"
+         * with the argument absent).  An empty path can never name a file, and
+         * nxt_http_static_send() reads shr->start[shr->length - 1] unguarded --
+         * a zero length would underflow that to shr->start[-1].  Reject the
+         * empty candidate and try the next share.
+         */
+        if (nxt_slow_path(ctx->share.length == 0)) {
+            nxt_log(task, NXT_LOG_ERR, "rejected empty \"share\" path");
+            nxt_http_static_next(task, r, ctx, NXT_HTTP_NOT_FOUND);
+            return;
+        }
+
+        /*
+         * A templated "share" is resolved from request-controlled variables
+         * (e.g. "$uri", "$arg_name") and later handed to open()/openat2() as a
+         * NUL-terminated C string.  An embedded NUL would silently truncate the
+         * path at the sink, so reject this candidate and try the next share.
+         */
+        if (nxt_slow_path(memchr(ctx->share.start, '\0', ctx->share.length)
+                          != NULL))
+        {
+            nxt_log(task, NXT_LOG_ERR, "rejected \"share\" path with an "
+                    "embedded zero byte");
+            nxt_http_static_next(task, r, ctx, NXT_HTTP_NOT_FOUND);
+            return;
+        }
     }
 
     nxt_http_static_send(task, r, ctx);

--- a/test/test_static_chroot.py
+++ b/test/test_static_chroot.py
@@ -70,6 +70,53 @@ def test_share_chroot_array(temp_dir):
     assert client.get()['status'] != 200, 'share array bad'
 
 
+def test_share_chroot_array_embedded_zero(temp_dir):
+    # Regression: a NUL byte in the first (templated) share must skip that
+    # candidate WITHOUT dropping chroot confinement for the fallback share.
+    # "chroot" is resolved once (share_idx == 0); rejecting the first share
+    # before it is resolved would leave the fallback unconfined.
+    assert 'success' in update_action(
+        f'{temp_dir}/assets/dir',
+        [f'{temp_dir}/assets/$arg_x', f'{temp_dir}/assets$uri'],
+    )
+
+    # First share resolves to a NUL-truncated path and is skipped; the fallback
+    # share must stay confined to the chroot, so a file outside it is denied.
+    assert (
+        client.get(url='/index.html?x=%00')['status'] == 403
+    ), 'chroot kept on fallback'
+
+    # A file inside the chroot is still served through the fallback share.
+    assert (
+        client.get(url='/dir/file?x=%00')['status'] == 200
+    ), 'chroot allows in-root file'
+
+
+def test_static_chroot_embedded_zero(temp_dir):
+    # A templated "chroot" with an embedded NUL would truncate the root at
+    # openat2(); since one chroot applies to every share, the request fails.
+    assert 'success' in update_action(
+        f'{temp_dir}/assets/$arg_c', f'{temp_dir}/assets$uri'
+    )
+    assert (
+        client.get(url='/dir/file?c=%00')['status'] == 404
+    ), 'chroot embedded zero byte'
+
+    # With an action "fallback" configured, a rejected chroot must still
+    # dispatch the fallback (like the share NUL rejection) rather than 404.
+    assert 'success' in client.conf(
+        {
+            'share': f'{temp_dir}/assets$uri',
+            'chroot': f'{temp_dir}/assets/$arg_c',
+            'fallback': {"return": 204},
+        },
+        'routes/0/action',
+    )
+    assert (
+        client.get(url='/dir/file?c=%00')['status'] == 204
+    ), 'chroot rejection falls through to fallback'
+
+
 def test_static_chroot_permission(require, temp_dir):
     require({'privileged_user': False})
 

--- a/test/test_static_variables.py
+++ b/test/test_static_variables.py
@@ -78,6 +78,29 @@ def test_static_variables_buildin_end():
     assert client.get(url='/index.html')['status'] == 200
 
 
+def test_static_variables_embedded_zero(temp_dir):
+    # A templated "share" is resolved from request-controlled variables and
+    # then handed to open() as a NUL-terminated C string.  A percent-encoded
+    # NUL in a query argument ("%00") decodes to an embedded zero byte that
+    # would otherwise truncate the path at the sink, serving a different file
+    # than requested.  The server must reject such a path instead.
+    assert 'success' in update_share(f'{temp_dir}/assets/$arg_x')
+
+    # Sanity: without a NUL the resolved path serves the file.
+    assert client.get(url='/?x=index.html')['status'] == 200, 'no zero byte'
+
+    # With an embedded NUL the path must not be truncated to "index.html".
+    assert (
+        client.get(url='/?x=index.html%00.txt')['status'] == 404
+    ), 'embedded zero byte'
+
+    # A "share" that is entirely a request variable resolves to an empty path
+    # when the argument is absent.  An empty path can never name a file and must
+    # be rejected safely (not underflow shr->start[-1]).
+    assert 'success' in update_share('$arg_x')
+    assert client.get(url='/')['status'] == 404, 'empty share path'
+
+
 def test_static_variables_invalid(temp_dir):
     assert 'error' in update_share(f'{temp_dir}/assets/d$r$uri')
     assert 'error' in update_share(f'{temp_dir}/assets/$$uri')


### PR DESCRIPTION
## Summary

**PR-B of #116** (follow-up to **PR-A / #117**). Same vulnerability class — a length-tracked `nxt_str_t` consumed at a C-string sink silently truncates at an embedded NUL — but for the **templated** static-serving paths that PR-A explicitly deferred.

`share`, `chroot` (and `index`) are `NXT_CONF_VLDT_TSTR` templated strings resolved **per request** from request-controlled variables (`$uri`, `$host`, `$arg_*`, …). A static config validator cannot cover them: the NUL is injected at request time. So the guard runs at **template-resolution time**, before the path reaches the file open.

## Attack path (verified)

`share` = `/data/$arg_x`, request `GET /?x=index.html%00.txt`:

- The query-argument decoder (`nxt_http_arguments_parse`, `src/nxt_http_request.c`) decodes `%00` into a real zero byte with no rejection (unlike the URI path parser, `nxt_http_parse_complex_target`, which rejects `%00` — so `$uri` itself is already safe).
- The resolved `share` becomes `/data/index.html\0.txt`.
- Handed to `open()`/`openat2()` as a C string it truncates to `/data/index.html` → the server serves `index.html` (HTTP 200) even though the request asked for a `.txt` path. Confirmed locally: without the guard the new test gets **200**; with it, **404**.

## What is guarded

In `nxt_http_static_iterate()` (`src/nxt_http_static.c`), a `memchr(str.start, '\0', str.length)` check is added right after each **non-const** template resolution, before the path reaches the open sinks in `nxt_http_static_send()`:

- **`share`** — all builds.
- **`chroot`** — inside the existing `#if (NXT_HAVE_OPENAT2)` guard where it lives.

On a hit the request is failed via `nxt_http_static_next(..., NXT_HTTP_NOT_FOUND)` — the established "bad static path" precedent (advance to the next share / fallback, ultimately 404), **not** a 500. An `[error]`-level log line is emitted, matching the existing open-failure logging.

## Explicitly out of scope / not touched

- **const `share`/`chroot`** (`share->is_const`): resolved from a config-time literal, not request-controlled. Left unchecked (a config-author literal NUL is a static-config concern, not this runtime request-path issue) to avoid dead checks.
- **`index`**: a plain (non-templated) config string (`NXT_CONF_VLDT_STRING`, no `TSTR` flag; `conf->index` is set once at config time). It is appended to an already-guarded `share`, and carries no request-controlled component — no runtime NUL can reach the sink through it, so no check is added.

## Test

`test/test_static_variables.py::test_static_variables_embedded_zero` drives `share = "$temp/assets/$arg_x"` and asserts:
- `/?x=index.html` → 200 (sanity: resolution works), and
- `/?x=index.html%00.txt` → 404 (the NUL-truncation is rejected, not served).

Verified the test **fails (200)** without the guard and **passes (404)** with it, so it genuinely guards against regression. The `[error]` log is not flagged by the harness `check_alerts` (which only matches `[alert]`).

Does not close #116 — the maintainer may consider further scope beyond PR-B.