### PR TITLE
data(eol): add java 25 (LTS) + java 26 runtimes with Dockerfiles

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,7 @@ on:
       - 'src/**'
       - 'test/**'
       - 'pkg/contrib/**'
+      - 'pkg/eol.json'
       - '.github/workflows/build-test.yml'
   push:
     branches: master
@@ -19,6 +20,7 @@ on:
       - 'src/**'
       - 'test/**'
       - 'pkg/contrib/**'
+      - 'pkg/eol.json'
       - '.github/workflows/build-test.yml'
 
 env:

--- a/EOL.md
+++ b/EOL.md
@@ -15,6 +15,8 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
 | Go | 1.26 | Feb 2027 | Feb 2028 |
 | Java (JSC) | 17 (LTS) | Oct 2027 | Oct 2028 |
 | Java (JSC) | 21 (LTS) | Dec 2029 | Dec 2030 |
+| Java (JSC) | 25 (LTS) | Sep 2031 | Sep 2032 |
+| Java (JSC) | 26 | Sep 2026 | Sep 2027 |
 | Node.js | 20 (LTS) (EOL) † | Apr 2026 | Apr 2027 |
 | Node.js | 22 (LTS) | Apr 2027 | Apr 2028 |
 | Node.js | 24 (LTS) | Apr 2028 | Apr 2029 |
@@ -74,7 +76,7 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
   `CHANGES`.
 - **Security-only mode:** versions within 6 months of the FreeUnit drop date receive
   security fixes only — no new features backported.
-- **LTS runtimes (Java 17/21):** follow the upstream LTS schedule strictly.
+- **LTS runtimes (Java 17/21/25):** follow the upstream LTS schedule strictly.
 - **LTS OS (Ubuntu, RHEL, Debian):** 3-year extension applies to standard EOL, not
   extended security maintenance dates.
 

--- a/pkg/docker/Dockerfile.java-25
+++ b/pkg/docker/Dockerfile.java-25
@@ -1,0 +1,115 @@
+FROM eclipse-temurin:25-jdk-noble
+
+LABEL org.opencontainers.image.title="FreeUnit (java-25)"
+LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
+LABEL org.opencontainers.image.url="https://freeunit.org"
+LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
+LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
+LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
+LABEL org.opencontainers.image.version="1.35.5"
+
+RUN set -ex \
+    && savedAptMark="$(apt-mark showmanual)" \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+         ca-certificates git build-essential libssl-dev openssl libpcre2-dev zlib1g-dev libzstd-dev libbrotli-dev curl wget pkg-config pkgconf libclang-dev cmake \
+    && export RUST_VERSION=1.94.1 \
+    && export RUSTUP_HOME=/usr/src/unit/rustup \
+    && export CARGO_HOME=/usr/src/unit/cargo \
+    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
+         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
+         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+       esac \
+    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
+    && curl -L -O "$url" \
+    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
+    && chmod +x rustup-init \
+    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
+    && rm rustup-init \
+    && rustup --version \
+    && cargo --version \
+    && rustc --version \
+    && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
+    && mkdir -p /usr/src/unit \
+    && cd /usr/src/unit \
+    && git clone --depth 1 -b 1.35.5 https://github.com/freeunitorg/freeunit unit \
+    && cd unit \
+    && NCPU="$(getconf _NPROCESSORS_ONLN)" \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \
+    && CC_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_CFLAGS_MAINT_APPEND="-fPIC" dpkg-buildflags --get CFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && LD_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed -pie" dpkg-buildflags --get LDFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && CONFIGURE_ARGS_MODULES="--prefix=/usr \
+                --statedir=/var/lib/unit \
+                --control=unix:/var/run/control.unit.sock \
+                --runstatedir=/var/run \
+                --pid=/var/run/unit.pid \
+                --logdir=/var/log \
+                --log=/var/log/unit.log \
+                --tmpdir=/var/tmp \
+                --user=unit \
+                --group=unit \
+                --openssl \
+                --libdir=/usr/lib/$DEB_HOST_MULTIARCH" \
+    && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
+                --njs \
+                --otel \
+                --zlib \
+                --zstd \
+                --brotli" \
+    && make -j $NCPU -C pkg/contrib .njs \
+    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
+    && make clean \
+    && /bin/true \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && ./configure java --jars=/usr/share/unit-jsc-common/ \
+    && make -j $NCPU java-shared-install java-install \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
+    && ./configure java --jars=/usr/share/unit-jsc-common/ \
+    && make -j $NCPU java-shared-install java-install \
+    && cd \
+    && rm -rf /usr/src/unit \
+    && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+       done \
+    && apt-mark showmanual | xargs apt-mark auto > /dev/null \
+    && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+    && rm -rf /root/.m2 \
+    && mkdir -p /var/lib/unit/ \
+    && mkdir -p /docker-entrypoint.d/ \
+    && groupadd --gid 999 unit \
+    && useradd \
+         --uid 999 \
+         --gid unit \
+         --no-create-home \
+         --home /nonexistent \
+         --comment "unit user" \
+         --shell /bin/false \
+         unit \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y install curl $(cat /requirements.apt) \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /requirements.apt \
+    && ln -sf /dev/stderr /var/log/unit.log
+
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY welcome.* /usr/share/unit/welcome/
+COPY seccomp-no-af-alg.json /usr/share/unit/
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+EXPOSE 80
+CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.java-26
+++ b/pkg/docker/Dockerfile.java-26
@@ -1,0 +1,115 @@
+FROM eclipse-temurin:26-jdk-noble
+
+LABEL org.opencontainers.image.title="FreeUnit (java-26)"
+LABEL org.opencontainers.image.description="Community build of FreeUnit for Docker."
+LABEL org.opencontainers.image.url="https://freeunit.org"
+LABEL org.opencontainers.image.source="https://github.com/freeunitorg/freeunit"
+LABEL org.opencontainers.image.documentation="https://github.com/freeunitorg/freeunit/blob/master/README.md"
+LABEL org.opencontainers.image.vendor="FreeUnit Community <team@freeunit.org>"
+LABEL org.opencontainers.image.version="1.35.5"
+
+RUN set -ex \
+    && savedAptMark="$(apt-mark showmanual)" \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+         ca-certificates git build-essential libssl-dev openssl libpcre2-dev zlib1g-dev libzstd-dev libbrotli-dev curl wget pkg-config pkgconf libclang-dev cmake \
+    && export RUST_VERSION=1.94.1 \
+    && export RUSTUP_HOME=/usr/src/unit/rustup \
+    && export CARGO_HOME=/usr/src/unit/cargo \
+    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
+         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
+         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+       esac \
+    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
+    && curl -L -O "$url" \
+    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
+    && chmod +x rustup-init \
+    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
+    && rm rustup-init \
+    && rustup --version \
+    && cargo --version \
+    && rustc --version \
+    && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
+    && mkdir -p /usr/src/unit \
+    && cd /usr/src/unit \
+    && git clone --depth 1 -b 1.35.5 https://github.com/freeunitorg/freeunit unit \
+    && cd unit \
+    && NCPU="$(getconf _NPROCESSORS_ONLN)" \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \
+    && CC_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_CFLAGS_MAINT_APPEND="-fPIC" dpkg-buildflags --get CFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && LD_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed -pie" dpkg-buildflags --get LDFLAGS | tr ' ' '\n' | grep -v '^-specs=' | tr '\n' ' ')" \
+    && CONFIGURE_ARGS_MODULES="--prefix=/usr \
+                --statedir=/var/lib/unit \
+                --control=unix:/var/run/control.unit.sock \
+                --runstatedir=/var/run \
+                --pid=/var/run/unit.pid \
+                --logdir=/var/log \
+                --log=/var/log/unit.log \
+                --tmpdir=/var/tmp \
+                --user=unit \
+                --group=unit \
+                --openssl \
+                --libdir=/usr/lib/$DEB_HOST_MULTIARCH" \
+    && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
+                --njs \
+                --otel \
+                --zlib \
+                --zstd \
+                --brotli" \
+    && make -j $NCPU -C pkg/contrib .njs \
+    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
+    && make clean \
+    && /bin/true \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && ./configure java --jars=/usr/share/unit-jsc-common/ \
+    && make -j $NCPU java-shared-install java-install \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
+    && ./configure java --jars=/usr/share/unit-jsc-common/ \
+    && make -j $NCPU java-shared-install java-install \
+    && cd \
+    && rm -rf /usr/src/unit \
+    && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
+        [ -f "$f" ] || continue; \
+        ldd "$f" | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $(realpath $n 2>/dev/null || echo $n) 2>/dev/null; done | grep -v '^diversion' | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+       done \
+    && apt-mark showmanual | xargs apt-mark auto > /dev/null \
+    && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+    && rm -rf /root/.m2 \
+    && mkdir -p /var/lib/unit/ \
+    && mkdir -p /docker-entrypoint.d/ \
+    && groupadd --gid 999 unit \
+    && useradd \
+         --uid 999 \
+         --gid unit \
+         --no-create-home \
+         --home /nonexistent \
+         --comment "unit user" \
+         --shell /bin/false \
+         unit \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y install curl $(cat /requirements.apt) \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /requirements.apt \
+    && ln -sf /dev/stderr /var/log/unit.log
+
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY welcome.* /usr/share/unit/welcome/
+COPY seccomp-no-af-alg.json /usr/share/unit/
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+EXPOSE 80
+CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/eol.json
+++ b/pkg/eol.json
@@ -51,7 +51,9 @@
     ],
     "java": [
       {"version": "17", "eol": "2027-10", "supported_until": "2028-10", "base": "eclipse-temurin"},
-      {"version": "21", "eol": "2029-12", "supported_until": "2030-12", "base": "eclipse-temurin"}
+      {"version": "21", "eol": "2029-12", "supported_until": "2030-12", "base": "eclipse-temurin"},
+      {"version": "25", "eol": "2031-09", "supported_until": "2032-09", "base": "eclipse-temurin", "lts": true},
+      {"version": "26", "eol": "2026-09", "supported_until": "2027-09", "base": "eclipse-temurin"}
     ],
     "node": [
       {"version": "20", "eol": "2026-04", "supported_until": "2027-04", "note": "EOL"},


### PR DESCRIPTION
## What

Adds the **java 25 (LTS)** and **java 26** runtimes to `.runtimes.java` in `pkg/eol.json`, along with their generated Dockerfiles.

### `pkg/eol.json`
| version | eol | supported_until | base | lts |
|---|---|---|---|---|
| 25 | `2031-09` | `2032-09` | eclipse-temurin | yes |
| 26 | `2026-09` | `2027-09` | eclipse-temurin | no |

`supported_until` = upstream EOL + 12-month grace (per `_grace_runtimes`). **Both dates confirmed against upstream**: `unit-eol-check --fix` reports no changes and `--new` detects nothing missing.

### Dockerfiles
`release-docker.yml` derives its build matrix from `.runtimes` and builds `pkg/docker/Dockerfile.<variant>`, so this adds the two files `make -C pkg/docker dockerfiles` emits:
- `pkg/docker/Dockerfile.java-25` -> `FROM eclipse-temurin:25-jdk-noble`
- `pkg/docker/Dockerfile.java-26` -> `FROM eclipse-temurin:26-jdk-noble`

Only the two new java files are committed. `make` also rewrites every other checked-in Dockerfile with an unrelated `1.35.5`->`1.35.6` version bump (pre-existing template drift, not part of this change) - that churn is left out, and the two new files are pinned to the `1.35.5` baseline to stay consistent with their siblings.

### `EOL.md`
Adds java 25/26 rows to the support matrix; the LTS note now lists Java 17/21/25.

## Verification
- `unit-eol-check --ci` -> **exit 0** (errors: 0). java 26's near EOL surfaces only as a non-fatal warning.
- `unit-eol-check --new` -> clean (no longer flags java 25/26).
- `unit-eol-check --fix` -> no changes (dates match upstream).
- `cargo build --release` + `cargo test --release` -> 6 passed, 0 failed.

## java-26 build-test watch item
Adding java 26 to `.runtimes` makes `build-test.yml` spin up a java-26 build/test job against brand-new JDK 26. That job's CI result is the key risk to watch on this PR - see the checks. If the java module fails to build/test against JDK 26 we should hold java 26 (java 25 LTS is the safe half); flagging rather than papering over.

## Stacking
Stacks on **#124** (the eol-gate branch, `feat/eol-ci-gate`). Base is `pre-1.35.6`; merge **after #124**. Until #124 merges, this PR's diff will include #124's commits.

Closes #126.