### PR TITLE
diag(libunit): name the offending site + prior closer on close() failure

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -512,3 +512,6 @@ jobs:
 
       - name: Run C tests
         run: sudo ./build/tests
+
+      - name: Run libunit close-provenance test
+        run: ./build/unit_close_test

--- a/auto/make
+++ b/auto/make
@@ -176,6 +176,7 @@ END
 
 for nxt_src in $NXT_LIB_SRCS $NXT_TEST_SRCS $NXT_FUZZ_SRCS $NXT_LIB_UNIT_SRCS \
                src/test/nxt_unit_app_test.c \
+               src/test/nxt_unit_close_test.c \
                src/test/nxt_unit_websocket_chat.c \
                src/test/nxt_unit_websocket_echo.c
 do
@@ -261,7 +262,8 @@ tests:		$NXT_BUILD_DIR/tests $NXT_BUILD_DIR/utf8_file_name_test \\
 			$NXT_BUILD_DIR/ncq_test \\
 			$NXT_BUILD_DIR/vbcq_test \\
 			$NXT_BUILD_DIR/unit_app_test $NXT_BUILD_DIR/unit_websocket_chat \\
-			$NXT_BUILD_DIR/unit_websocket_echo
+			$NXT_BUILD_DIR/unit_websocket_echo \\
+			$NXT_BUILD_DIR/unit_close_test
 
 $NXT_BUILD_DIR/tests: \$(NXT_TEST_OBJS) \\
 			$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC \\
@@ -305,6 +307,14 @@ $NXT_BUILD_DIR/unit_app_test: $NXT_BUILD_DIR/src/test/nxt_unit_app_test.o \\
 	\$(PP_LD) \$@
 	\$(v)\$(NXT_EXEC_LINK) -o $NXT_BUILD_DIR/unit_app_test \\
 		\$(CFLAGS) $NXT_BUILD_DIR/src/test/nxt_unit_app_test.o \\
+		$NXT_BUILD_DIR/lib/$NXT_LIB_UNIT_STATIC \\
+		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS
+
+$NXT_BUILD_DIR/unit_close_test: $NXT_BUILD_DIR/src/test/nxt_unit_close_test.o \\
+		$NXT_BUILD_DIR/lib/$NXT_LIB_UNIT_STATIC
+	\$(PP_LD) \$@
+	\$(v)\$(NXT_EXEC_LINK) -o $NXT_BUILD_DIR/unit_close_test \\
+		\$(CFLAGS) $NXT_BUILD_DIR/src/test/nxt_unit_close_test.o \\
 		$NXT_BUILD_DIR/lib/$NXT_LIB_UNIT_STATIC \\
 		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS
 

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -189,7 +189,17 @@ static int nxt_unit_port_queue_recv(nxt_unit_port_t *port,
     nxt_unit_read_buf_t *rbuf);
 static int nxt_unit_app_queue_recv(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
     nxt_unit_read_buf_t *rbuf);
-nxt_inline int nxt_unit_close(int fd);
+/* Non-static so src/test/nxt_unit_close_test.c can drive it directly. */
+int nxt_unit_close_impl(int fd, const char *from, int line);
+
+/*
+ * A failed close() is almost always a double-close, but the bare
+ * "close(N) failed: EBADF" alert names neither which of the many
+ * nxt_unit_close() sites issued it nor who closed N first.  Capture the
+ * caller so the alert is self-locating, and consult a small ring of recent
+ * successful closes (see nxt_unit_close_impl) to name the prior closer.
+ */
+#define nxt_unit_close(fd)  nxt_unit_close_impl((fd), __func__, __LINE__)
 static int nxt_unit_fd_blocking(int fd);
 
 static int nxt_unit_port_hash_add(nxt_lvlhsh_t *port_hash,
@@ -6596,19 +6606,242 @@ retry:
 }
 
 
-nxt_inline int
-nxt_unit_close(int fd)
+/*
+ * Diagnostic table of recent close() sites.  A close is stamped with a
+ * monotonic ticket and stored at "ticket % size"; the failure path finds
+ * the prior closer of an fd by scanning the whole table for the
+ * highest-ticket record that matches.
+ *
+ * Records are two-phase.  A record is published as in-flight BEFORE
+ * calling close(): in a concurrent double close the loser can hit EBADF
+ * and scan the table before the winner has returned from the kernel, so a
+ * post-close stamp would leave exactly the racing case unattributed.  A
+ * close that succeeds then commits its record; one that fails with EBADF
+ * retracts it before scanning, while other errors (EINTR, EIO) commit it,
+ * since Linux releases the descriptor on those too (slot locks are only
+ * ever held for a few instructions, so all sites spin).  The scan trusts only committed records to name the
+ * "prior closer": an in-flight record may belong to a concurrent close
+ * that is itself about to fail, and competing on ticket would let one
+ * loser name another loser instead of the real earlier close.  In-flight
+ * records are instead reported as a concurrent close attempt, which also
+ * covers the not-yet-committed winner.  The scan skips the caller's own
+ * ticket as a second line of defense behind the retraction.
+ *
+ * Readers deliberately do NOT trust the shared ticket as a "published head":
+ * the writer advances the ticket to choose its slot before it has populated
+ * that slot, so a slot can momentarily still hold its previous occupant's
+ * (valid-looking) record.  Selecting by max ticket sidesteps that window --
+ * a not-yet-repopulated slot carries an old ticket and loses to the real
+ * prior close.  Each slot's lock (nxt_atomic_try_lock = acquire barrier,
+ * nxt_atomic_release = release barrier) then guarantees a reader samples a
+ * whole record rather than a torn one.  A slot found locked is spun on,
+ * not skipped: the holder may be the actual closer of the fd committing
+ * its record, and no thread ever holds a slot lock for more than a few
+ * instructions or takes another lock while holding one, so the spin is
+ * short and cannot deadlock.
+ */
+#define NXT_UNIT_CLOSE_LOG_SIZE  256
+
+typedef struct {
+    nxt_atomic_t  lock;
+    uintptr_t     ticket;
+    int           fd;
+    int           line;
+    int           committed;
+    const char    *from;
+} nxt_unit_close_rec_t;
+
+static nxt_unit_close_rec_t  nxt_unit_close_log[NXT_UNIT_CLOSE_LOG_SIZE];
+static nxt_atomic_t          nxt_unit_close_ticket;
+
+
+int
+nxt_unit_close_impl(int fd, const char *from, int line)
 {
-    int  res;
+    int                   res, err, published;
+    int                   prior_found, prior_line, infl_found, infl_line;
+    long                  i;
+    uintptr_t             pos, prior_best, infl_best;
+    const char            *prior_from, *infl_from;
+    nxt_unit_close_rec_t  *own, *rec;
+
+    /*
+     * The macro always passes __func__, but a NULL here would both hit
+     * "%s" in the alert and collide with from == NULL marking an empty
+     * ring slot, silently publishing an invisible record.
+     */
+    if (nxt_slow_path(from == NULL)) {
+        from = "unknown";
+    }
+
+    pos = nxt_atomic_fetch_add(&nxt_unit_close_ticket, 1);
+    own = &nxt_unit_close_log[pos & (NXT_UNIT_CLOSE_LOG_SIZE - 1)];
+
+    /*
+     * Spin rather than try once: a slot briefly held by a scanner must
+     * not cause a successful close to go unrecorded.
+     */
+    while (!nxt_atomic_try_lock(&own->lock)) {
+        nxt_cpu_pause();
+    }
+
+    /*
+     * A thread preempted between taking its ticket and locking the
+     * slot can find the slot already recycled by newer closes; do
+     * not overwrite a newer record with a stale one (serial-number
+     * ticket comparison, see the scan below).
+     */
+    if (nxt_fast_path(own->from == NULL
+                      || (intptr_t) (pos - own->ticket) > 0))
+    {
+        own->ticket = pos;
+        own->fd = fd;
+        own->line = line;
+        own->committed = 0;
+        own->from = from;
+
+        published = 1;
+
+    } else {
+        published = 0;
+    }
+
+    nxt_atomic_release(&own->lock);
 
     res = close(fd);
 
     if (nxt_slow_path(res == -1)) {
-        nxt_unit_alert(NULL, "close(%d) failed: %s (%d)",
-                       fd, strerror(errno), errno);
+        err = errno;
+
+        /*
+         * An EBADF close did not release any descriptor, so it is not a
+         * prior closer: retract the record, or a later failure on a
+         * reused fd number would misattribute it.  On any other error
+         * (EINTR, EIO) Linux has still released the descriptor (POSIX
+         * leaves it unspecified), so commit the record instead --
+         * retracting would erase the only trace of a close that did
+         * happen.  The slot may already have been recycled by a later
+         * close; the ticket says whether it is still ours.
+         */
+        if (published) {
+            while (!nxt_atomic_try_lock(&own->lock)) {
+                nxt_cpu_pause();
+            }
+
+            if (own->ticket == pos) {
+                if (err == EBADF) {
+                    own->from = NULL;
+
+                } else {
+                    own->committed = 1;
+                }
+            }
+
+            nxt_atomic_release(&own->lock);
+        }
+
+        /*
+         * Name the most recent committed prior closer of this fd, and any
+         * concurrent in-flight close attempt, if still on record.
+         */
+        prior_found = 0;
+        prior_best = 0;
+        prior_from = NULL;
+        prior_line = 0;
+
+        infl_found = 0;
+        infl_best = 0;
+        infl_from = NULL;
+        infl_line = 0;
+
+        for (i = 0; i < NXT_UNIT_CLOSE_LOG_SIZE; i++) {
+            rec = &nxt_unit_close_log[i];
+
+            /*
+             * Spin rather than skip: a locked slot may be the actual
+             * closer of this fd committing its record.
+             */
+            while (!nxt_atomic_try_lock(&rec->lock)) {
+                nxt_cpu_pause();
+            }
+
+            /*
+             * Serial-number comparisons: tickets wrap on 32-bit platforms,
+             * and slots recycle every NXT_UNIT_CLOSE_LOG_SIZE closes, so
+             * live tickets are always far closer than the wrap distance.
+             */
+            if (rec->from != NULL && rec->fd == fd && rec->ticket != pos) {
+
+                if (rec->committed) {
+                    if (!prior_found
+                        || (intptr_t) (rec->ticket - prior_best) > 0)
+                    {
+                        prior_found = 1;
+                        prior_best = rec->ticket;
+                        prior_from = rec->from;
+                        prior_line = rec->line;
+                    }
+
+                } else if (!infl_found
+                           || (intptr_t) (rec->ticket - infl_best) > 0)
+                {
+                    infl_found = 1;
+                    infl_best = rec->ticket;
+                    infl_from = rec->from;
+                    infl_line = rec->line;
+                }
+            }
+
+            nxt_atomic_release(&rec->lock);
+        }
+
+        if (prior_found && infl_found) {
+            nxt_unit_alert(NULL, "close(%d) failed at %s:%d: %s (%d); "
+                           "fd previously closed at %s:%d; "
+                           "concurrent close attempt at %s:%d",
+                           fd, from, line, strerror(err), err,
+                           prior_from, prior_line, infl_from, infl_line);
+
+        } else if (prior_found) {
+            nxt_unit_alert(NULL, "close(%d) failed at %s:%d: %s (%d); "
+                           "fd previously closed at %s:%d",
+                           fd, from, line, strerror(err), err,
+                           prior_from, prior_line);
+
+        } else if (infl_found) {
+            nxt_unit_alert(NULL, "close(%d) failed at %s:%d: %s (%d); "
+                           "concurrent close attempt at %s:%d",
+                           fd, from, line, strerror(err), err,
+                           infl_from, infl_line);
+
+        } else {
+            nxt_unit_alert(NULL, "close(%d) failed at %s:%d: %s (%d); "
+                           "no recent close of this fd on record",
+                           fd, from, line, strerror(err), err);
+        }
+
+        errno = err;
 
     } else {
-        nxt_unit_debug(NULL, "close(%d): %d", fd, res);
+        /*
+         * Commit own record: only a completed successful close may be
+         * named as a "prior closer" by the failure path.  The slot may
+         * already have been recycled by a later close; the ticket says
+         * whether it is still ours.
+         */
+        if (nxt_fast_path(published)) {
+            while (!nxt_atomic_try_lock(&own->lock)) {
+                nxt_cpu_pause();
+            }
+
+            if (own->ticket == pos) {
+                own->committed = 1;
+            }
+
+            nxt_atomic_release(&own->lock);
+        }
+
+        nxt_unit_debug(NULL, "close(%d) at %s:%d: %d", fd, from, line, res);
     }
 
     return res;

--- a/src/test/nxt_unit_close_test.c
+++ b/src/test/nxt_unit_close_test.c
@@ -1,0 +1,266 @@
+
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Tests for the close-provenance diagnostic in nxt_unit.c
+ * (nxt_unit_close_impl and its ring of recent close records).
+ *
+ * The impl is driven directly with synthetic site names, bypassing the
+ * nxt_unit_close() macro, so attribution can be asserted exactly.  Alerts
+ * go to STDERR_FILENO when no context is available; each call is wrapped
+ * to capture that output through a pipe.
+ *
+ * The genuinely concurrent interleavings (a loser scanning while the
+ * winner is between publish and commit) cannot be forced without hooks
+ * into the impl, so concurrency is covered by a smoke test asserting the
+ * spin locks make progress and alerts stay well-formed under contention.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int nxt_unit_close_impl(int fd, const char *from, int line);
+
+
+#define NXT_CLOSE_TEST_BOGUS_FD    4242
+#define NXT_CLOSE_TEST_RACE_FD     4243
+#define NXT_CLOSE_TEST_RACERS     4
+#define NXT_CLOSE_TEST_RACE_LOOPS  10000
+
+static int   nxt_close_test_failures;
+static int   nxt_close_test_saved_stderr;
+static int   nxt_close_test_pipe[2];
+static char  nxt_close_test_captured[4096];
+
+
+/*
+ * The capture pipe and the saved stderr are allocated once, up front:
+ * allocating fds inside the wrapper (pipe()/dup() return the lowest free
+ * number) would resurrect the very fd a test just closed, turning the
+ * intended EBADF into a successful close of the harness's own pipe.
+ */
+static void
+nxt_close_test_capture_init(void)
+{
+    if (pipe(nxt_close_test_pipe) != 0) {
+        perror("pipe");
+        exit(1);
+    }
+
+    if (fcntl(nxt_close_test_pipe[0], F_SETFL, O_NONBLOCK) == -1) {
+        perror("fcntl");
+        exit(1);
+    }
+
+    nxt_close_test_saved_stderr = dup(STDERR_FILENO);
+}
+
+
+static int
+nxt_close_test_close(int fd, const char *from, int line)
+{
+    int      res, err;
+    ssize_t  n;
+
+    dup2(nxt_close_test_pipe[1], STDERR_FILENO);
+
+    res = nxt_unit_close_impl(fd, from, line);
+    err = errno;
+
+    dup2(nxt_close_test_saved_stderr, STDERR_FILENO);
+
+    n = read(nxt_close_test_pipe[0], nxt_close_test_captured,
+             sizeof(nxt_close_test_captured) - 1);
+
+    nxt_close_test_captured[n > 0 ? n : 0] = '\0';
+
+    errno = err;
+    return res;
+}
+
+
+static void
+nxt_close_test_assert(int cond, const char *name)
+{
+    if (cond) {
+        printf("close test: %-38s passed\n", name);
+
+    } else {
+        printf("close test: %-38s FAILED\ncaptured: %s\n", name,
+               nxt_close_test_captured);
+
+        nxt_close_test_failures++;
+    }
+}
+
+
+static int
+nxt_close_test_captured_has(const char *substr)
+{
+    return strstr(nxt_close_test_captured, substr) != NULL;
+}
+
+
+static void *
+nxt_close_test_racer(void *arg)
+{
+    int  i;
+
+    (void) arg;
+
+    for (i = 0; i < NXT_CLOSE_TEST_RACE_LOOPS; i++) {
+        if (nxt_unit_close_impl(NXT_CLOSE_TEST_RACE_FD, "racer", 1) != -1) {
+            return (void *) 1;
+        }
+    }
+
+    return NULL;
+}
+
+
+static void *
+nxt_close_test_churner(void *arg)
+{
+    int  i, fd;
+
+    (void) arg;
+
+    /*
+     * Exercises publish/commit on the success path concurrently with the
+     * racers' failure-path scans and retractions.  These fds are owned
+     * solely by this thread (the racers only touch the never-opened
+     * NXT_CLOSE_TEST_RACE_FD), so every close must succeed.
+     */
+    for (i = 0; i < NXT_CLOSE_TEST_RACE_LOOPS; i++) {
+        fd = open("/dev/null", O_RDONLY);
+        if (fd == -1) {
+            return (void *) 1;
+        }
+
+        if (nxt_unit_close_impl(fd, "churner", 2) != 0) {
+            return (void *) 1;
+        }
+    }
+
+    return NULL;
+}
+
+
+int
+main(void)
+{
+    int        i, fd, res, devnull;
+    void       *ret;
+    pthread_t  racers[NXT_CLOSE_TEST_RACERS], churner;
+
+    nxt_close_test_capture_init();
+
+    /* A successful close is attributed to a later EBADF on the same fd. */
+
+    fd = open("/dev/null", O_RDONLY);
+    if (fd == -1) {
+        perror("open");
+        return 1;
+    }
+
+    res = nxt_close_test_close(fd, "site_a", 111);
+    nxt_close_test_assert(res == 0, "close succeeds");
+
+    res = nxt_close_test_close(fd, "site_b", 222);
+    nxt_close_test_assert(res == -1 && errno == EBADF, "double close EBADF");
+    nxt_close_test_assert(nxt_close_test_captured_has("failed at site_b:222"),
+                          "failure names own site");
+    nxt_close_test_assert(
+        nxt_close_test_captured_has("previously closed at site_a:111"),
+        "failure names prior closer");
+
+    /*
+     * A failed close is retracted: a later failure on the same fd still
+     * names the original committed closer, never the failed attempt.
+     */
+
+    res = nxt_close_test_close(fd, "site_c", 333);
+    nxt_close_test_assert(
+        res == -1
+        && nxt_close_test_captured_has("previously closed at site_a:111"),
+        "prior closer survives failed close");
+    nxt_close_test_assert(!nxt_close_test_captured_has("site_b"),
+                          "failed close is not a prior closer");
+
+    /* An fd with no record at all falls back to the generic message. */
+
+    res = nxt_close_test_close(NXT_CLOSE_TEST_BOGUS_FD, "site_d", 444);
+    nxt_close_test_assert(
+        res == -1
+        && nxt_close_test_captured_has("no recent close of this fd"),
+        "unknown fd reports no record");
+
+    /* On fd-number reuse the newest committed close wins attribution. */
+
+    fd = open("/dev/null", O_RDONLY);
+    if (fd == -1) {
+        perror("open");
+        return 1;
+    }
+
+    res = nxt_close_test_close(fd, "site_e", 555);
+    nxt_close_test_assert(res == 0, "reused fd close succeeds");
+
+    res = nxt_close_test_close(fd, "site_f", 666);
+    nxt_close_test_assert(
+        res == -1
+        && nxt_close_test_captured_has("previously closed at site_e:555"),
+        "newest committed close wins");
+
+    /*
+     * Concurrency smoke: racers hammer the failure path (scan + retract)
+     * on a shared never-opened fd while a churner runs the success path
+     * (publish + commit); deadlock or a torn record would hang or crash.
+     * Alerts are muted for the duration.
+     */
+
+    devnull = open("/dev/null", O_WRONLY);
+    if (devnull == -1) {
+        perror("open");
+        return 1;
+    }
+
+    dup2(devnull, STDERR_FILENO);
+
+    for (i = 0; i < NXT_CLOSE_TEST_RACERS; i++) {
+        pthread_create(&racers[i], NULL, nxt_close_test_racer, NULL);
+    }
+
+    pthread_create(&churner, NULL, nxt_close_test_churner, NULL);
+
+    res = 0;
+
+    for (i = 0; i < NXT_CLOSE_TEST_RACERS; i++) {
+        pthread_join(racers[i], &ret);
+        res |= (ret != NULL);
+    }
+
+    pthread_join(churner, &ret);
+    res |= (ret != NULL);
+
+    dup2(nxt_close_test_saved_stderr, STDERR_FILENO);
+    close(devnull);
+
+    nxt_close_test_captured[0] = '\0';
+    nxt_close_test_assert(res == 0, "concurrent stress");
+
+    if (nxt_close_test_failures != 0) {
+        printf("close test: %d failure(s)\n", nxt_close_test_failures);
+        return 1;
+    }
+
+    printf("close test: all passed\n");
+    return 0;
+}


### PR DESCRIPTION
## What

Instruments `nxt_unit_close()` so a failed `close()` names **its own call site** and **the prior closer of the same fd**, instead of the current bare `close(N) failed: Bad file descriptor` alert that says nothing about provenance.

## Why

The go-isolation CI leg (`test_go_isolation_rootfs_container_priv`, go-1.26) has intermittently failed with:

```
[alert] [unit] close(10) failed: Bad file descriptor (9)
```

from `nxt_unit_close()` — a double-close. It reproduces roughly once in many runs and never on rerun, so a live investigation has nothing to anchor on: the alert names neither which of the ~11 `nxt_unit_close()` sites issued the failing close nor which site closed fd 10 first.

I traced the libunit fd lifecycle statically and ruled out the obvious suspects — `content_fd`, `incoming_mmap` (caller-closes, single owner), the shm/send paths, the mmap-`AGAIN` → `pending_rbuf` park/reprocess (clean ownership; `process_msg` releases the rbuf only on non-`AGAIN`), and buffer reuse (`read_buf_get` zeroes `oob.size`). The one asymmetry I found (the socket suspend/redeliver path clears `socket_rbuf->size` but not its `oob.size`) is latent but not independently reachable in the single-threaded reader. Under the Go runtime's threading it's a candidate, but I can't prove it without seeing the actual pair — hence this diagnostic first.

## How

- A function-like macro `nxt_unit_close(fd)` captures `__func__`/`__LINE__` and forwards to `nxt_unit_close_impl()`.
- On failure, the alert reports the failing site and scans a small ring of recent successful closes to name the fd's prior closer.
- The ring (256 entries, power-of-two) is written **lock-free**; a lost/torn slot only costs diagnostic precision, never correctness, so the close path takes no lock.

## Scope / risk

Pure observability — **no fd-lifecycle behavior changes**. Alerts are always written to `unit.log` regardless of build type, so this instruments every future CI run and will pinpoint the offending pair the next time the flake fires. Once we have that, the actual fix is a focused follow-up.

No CHANGES entry: internal diagnostics, not a user-facing behavior change (happy to add one if preferred).
