### PR TITLE
fix(unit): libunit port-fd double-close race in the Go module (+ callback-window hardening)

### DIFF
--- a/go/port.go
+++ b/go/port.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"syscall"
 	"unsafe"
 )
 
@@ -44,7 +45,10 @@ func find_port(key port_key) *port {
 	return res
 }
 
-func add_port(p *port) {
+// add_port registers p and reports whether it was inserted.  A duplicate key
+// (libunit re-announced an existing port) leaves p unregistered, so the caller
+// must close p to release its dup'd descriptors.
+func add_port(p *port) bool {
 
 	port_registry_.Lock()
 	if port_registry_.m == nil {
@@ -53,11 +57,15 @@ func add_port(p *port) {
 
 	old := port_registry_.m[p.key]
 
-	if old == nil {
+	inserted := old == nil
+
+	if inserted {
 		port_registry_.m[p.key] = p
 	}
 
 	port_registry_.Unlock()
+
+	return inserted
 }
 
 func (p *port) Close() {
@@ -75,7 +83,30 @@ func getUnixConn(fd int) *net.UnixConn {
 		return nil
 	}
 
-	f := os.NewFile(uintptr(fd), "sock")
+	// Duplicate the descriptor so that libunit stays the sole owner of the
+	// original fd number stored in the port struct.  net.FileConn() below
+	// dups again (close-on-exec) for its own use, and the "defer f.Close()"
+	// then closes only this dup, never the caller's fd.  Closing the original
+	// here (the old behaviour) raced with libunit's own close on port
+	// destruction, causing "close(N) failed: Bad file descriptor" alerts or,
+	// worse, closing an already reused live descriptor.
+	//
+	// The dup must be close-on-exec: plain dup(2) clears FD_CLOEXEC, so a Go
+	// app that fork/exec's while this runs could leak the Unit port socket
+	// into a child and keep the port alive.  Hold ForkLock across dup +
+	// CloseOnExec (the Go stdlib idiom for non-atomic O_CLOEXEC dups) so no
+	// concurrent forkExec observes the fd before its flag is set.
+	syscall.ForkLock.RLock()
+	newfd, err := syscall.Dup(fd)
+	if err != nil {
+		syscall.ForkLock.RUnlock()
+		nxt_go_alert("dup(%d) failed: %s", fd, err)
+		return nil
+	}
+	syscall.CloseOnExec(newfd)
+	syscall.ForkLock.RUnlock()
+
+	f := os.NewFile(uintptr(newfd), "sock")
 	defer f.Close()
 
 	c, err := net.FileConn(f)
@@ -105,10 +136,27 @@ func nxt_go_add_port(ctx *C.nxt_unit_ctx_t, p *C.nxt_unit_port_t) C.int {
 		snd: getUnixConn(int(p.out_fd)),
 	}
 
-	add_port(new_port)
+	// A present fd that failed to wrap (dup/FileConn error) would register a
+	// port with a nil rcv/snd and panic later in nxt_go_port_send/recv.  Close
+	// any partial dups and fail the callback instead; libunit still owns and
+	// closes the original descriptors.
+	if (p.in_fd >= 0 && new_port.rcv == nil) ||
+		(p.out_fd >= 0 && new_port.snd == nil) {
+		new_port.Close()
+		return C.NXT_UNIT_ERROR
+	}
 
-	p.in_fd = -1
-	p.out_fd = -1
+	if !add_port(new_port) {
+		// Duplicate key: libunit re-announced an existing port, so new_port
+		// was not registered.  Close its dups instead of leaking them to GC;
+		// libunit still owns and closes the original descriptors.
+		new_port.Close()
+	}
+
+	// Do NOT clear p.in_fd/p.out_fd here.  getUnixConn() now works on private
+	// dups, so the original descriptors remain owned by libunit, which closes
+	// them exactly once when the port is destroyed.  Go holds independent dups
+	// for its own socket I/O.
 
 	return C.NXT_UNIT_OK
 }

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -5731,6 +5731,14 @@ nxt_unit_add_port(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port, void *queue)
         pthread_mutex_unlock(&lib->mutex);
 
         if (lib->callbacks.add_port != NULL && ready) {
+            /*
+             * Hold an extra reference across the callback so a concurrent
+             * nxt_unit_port_release() cannot destroy the port and close its
+             * fds while the callback inspects port->in_fd/out_fd.  Balanced
+             * by the release below (net use_count change is zero).
+             */
+            nxt_unit_port_use(old_port);
+
             lib->callbacks.add_port(ctx, old_port);
 
             pthread_mutex_lock(&lib->mutex);
@@ -5743,6 +5751,8 @@ nxt_unit_add_port(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port, void *queue)
             }
 
             pthread_mutex_unlock(&lib->mutex);
+
+            nxt_unit_port_release(old_port);
         }
 
         nxt_unit_process_awaiting_req(ctx, &awaiting_req);
@@ -5820,6 +5830,14 @@ unlock:
     }
 
     if (lib->callbacks.add_port != NULL && new_port != NULL && ready) {
+        /*
+         * Hold an extra reference across the callback so a concurrent
+         * nxt_unit_port_release() cannot destroy the port and close its fds
+         * while the callback inspects port->in_fd/out_fd.  Balanced by the
+         * release below (net use_count change is zero).
+         */
+        nxt_unit_port_use(&new_port->port);
+
         lib->callbacks.add_port(ctx, &new_port->port);
 
         nxt_queue_init(&awaiting_req);
@@ -5836,6 +5854,8 @@ unlock:
         pthread_mutex_unlock(&lib->mutex);
 
         nxt_unit_process_awaiting_req(ctx, &awaiting_req);
+
+        nxt_unit_port_release(&new_port->port);
     }
 
     return (new_port == NULL) ? NULL : &new_port->port;

--- a/test/test_go_application.py
+++ b/test/test_go_application.py
@@ -150,6 +150,64 @@ def test_go_application_command_line_arguments():
     assert client.get()['body'] == f'{arg1},{arg2},{arg3}', 'arguments'
 
 
+def test_go_application_port_fd_churn():
+    # Regression for the libunit port-fd double-close race in the Go module.
+    #
+    # getUnixConn() used to os.NewFile(fd)+FileConn(fd) and then Close() the
+    # ORIGINAL descriptor while nxt_go_add_port() left libunit's copy of that
+    # fd number live in the port struct until just after add_port() returned.
+    # A concurrent port destruction then called nxt_unit_close() on a number Go
+    # had already closed, emitting "close(N) failed: Bad file descriptor" (or,
+    # worse, closing a reused live fd).  Now Go dups the fd for its own use and
+    # libunit stays the sole owner/closer of port->in_fd/out_fd.
+    #
+    # Churn port creation (add_port callback) and destruction by scaling the
+    # app process count up and down under load.  The teardown check_alerts()
+    # fails on any "close(...) failed" alert, and _check_fds() (run with
+    # --fds-threshold=0 in CI) guards against descriptor leaks.
+    client.load('empty')
+
+    processes = 'applications/empty/processes'
+
+    for _ in range(20):
+        assert 'success' in client.conf('4', processes), 'scale up'
+        assert client.get()['status'] == 200, 'get after scale up'
+
+        assert 'success' in client.conf('1', processes), 'scale down'
+        assert client.get()['status'] == 200, 'get after scale down'
+
+
+def test_go_application_add_port_callback_churn():
+    # Stress the libunit add_port callback window (paired with the C-side fix
+    # that holds an extra port reference across lib->callbacks.add_port so a
+    # concurrent nxt_unit_port_release()->destroy cannot close the port fds
+    # while the callback is inspecting them).
+    #
+    # Churn port creation (add_port callback) and destruction by scaling the
+    # process count while POSTing bodies -- request bodies carry spool-file
+    # descriptors on the shared port, maximizing fd-carrying traffic that
+    # overlaps the callback window.  Teardown check_alerts() fails on a
+    # double-close alert and _check_fds() (--fds-threshold=0) guards leaks.
+    #
+    # Note: nxt_unit_add_port() and its refcount helpers are static to
+    # libunit, so the C unit-test harness (src/test/nxt_tests.c) cannot call
+    # them directly; this integration test exercises the callback path via the
+    # Go module (the only add_port-registering module buildable in this env).
+    client.load('mirror')
+
+    body = '0123456789' * 500
+    processes = 'applications/mirror/processes'
+
+    for _ in range(20):
+        assert 'success' in client.conf('4', processes), 'scale up'
+        assert client.post(body=body)['body'] == body, 'mirror after scale up'
+
+        assert 'success' in client.conf('1', processes), 'scale down'
+        assert (
+            client.post(body=body)['body'] == body
+        ), 'mirror after scale down'
+
+
 def test_go_application_command_line_arguments_change():
     client.load('command_line_arguments')
 


### PR DESCRIPTION
Fixes the flaky `close(N) failed: Bad file descriptor` alert seen in `test_go_isolation_rootfs_container_priv` (rare, passes on rerun — a timing-dependent double-close). Two commits: the root-cause fix, then a defense-in-depth hardening of the `add_port` callback window. Parked for the pre-1.35.6 release track.

## Root cause
libunit's Go module took fd ownership racily. `getUnixConn()` (`go/port.go`) wrapped the raw port fd with `os.NewFile()` + `net.FileConn()` (which **dups**) and then `defer f.Close()` **closed the original fd number**, while `nxt_go_add_port()` only cleared libunit's copy (`p.in_fd/out_fd = -1`) *after* `add_port()` returned. libunit publishes the port into its hash with live fd numbers and runs the `add_port` callback **outside `lib->mutex`** (`nxt_unit_add_port`), so during that handoff window a concurrent `nxt_unit_port_release()`→destroy could `close()` a descriptor Go had already closed → EBADF, or — worse — close a reused live fd. Predates the fork (upstream `8132e1f7`, 2020); Go-module-specific.

The other modules are **watch-only**: PHP (`fcntl`), Python (`ioctl`), Node read `port->in_fd` *live* in their callback and never close it — libunit owns it and closes it once on destroy. Only Go took ownership, which is why only Go raced.

## Commit 1 — keep libunit as the sole fd owner (the fix)
`go/port.go`: `getUnixConn()` now `syscall.Dup()`s the fd for Go's own use and wraps the **dup** — `net.FileConn` dups again, and the deferred `f.Close()` closes only Go's dup, never libunit's original. Removed the `p.in_fd/out_fd = -1` clears so libunit keeps and closes the originals exactly once on destroy. Go now behaves like the watch-only modules: **libunit is the sole owner/closer**, Go holds independent dups → no thread double-closes. All early returns run the `defer`, so the dup never leaks.

*Test:* `test_go_application_port_fd_churn` — scales the Go app process count up/down under GET load to churn `add_port`/destroy; teardown `check_alerts()` fails on the `close(...) failed` alert and `_check_fds()` (`--fds-threshold=0`) guards leaks.

## Commit 2 — hold a port ref across the add_port callback window (hardening)
`src/nxt_unit.c`: in both the first-add and duplicate-add paths, bracket the out-of-mutex `callbacks.add_port()` call with `nxt_unit_port_use()` / `nxt_unit_port_release()`. Net `use_count` change is zero (no imbalance, no leak), and the port cannot be destroyed while the callback runs. This closes the **residual watch-only read race** (a concurrent destroy freeing the port / closing `in_fd` while PHP's `fcntl` or Python's `ioctl` inspects it) and future take-ownership modules. Nothing is nulled or moved before the callback, so the PHP/Python/Node contract is preserved.

*Test:* `test_go_application_add_port_callback_churn` — reconfigure-stress churn while POSTing bodies (spool-file fds on the shared port maximize fd traffic overlapping the callback). `nxt_unit_add_port` and the refcount helpers are `static` to libunit and not linked into `src/test/nxt_tests.c`, so the window is covered by this Go integration test rather than a C unit test.

## Verification
- Core + libunit + unitd build clean; `--tests` C harness builds and all existing tests pass.
- Go module (go1.26) compiles under cgo and runs end-to-end: the `test_go_application.py` subset incl. both new churn tests passes with both fixes active, no alerts, no fd leaks.
- **Relies on CI:** PHP/Python/Node module callback paths (`python3-dev` absent locally), and the namespaced go-isolation rootfs test where the original flake appeared (needs root/namespaces; the race can't be reproduced locally — the churn tests are the soak/regression backstop).

Co-authored-by the FreeUnit maintainer workflow.