### PR TITLE
test: fix PID-collision flake in _check_processes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,7 +471,6 @@ def _check_processes():
     router_pid = _fds_info['router']['pid']
     controller_pid = _fds_info['controller']['pid']
     main_pid = unit_instance['pid']
-    main_pid_re = re.compile(r'\b' + re.escape(main_pid) + r'\b')
 
     for _ in range(600):
         out = (
@@ -481,7 +480,10 @@ def _check_processes():
             .decode()
             .splitlines()
         )
-        out = [l for l in out if main_pid_re.search(l)]
+        # match only the pid/ppid columns; a substring match against the
+        # whole line can catch unrelated processes whose arguments contain
+        # the same number (e.g. agetty's baud rates vs. pid 9600)
+        out = [l for l in out if main_pid in l.split()[:2]]
 
         if len(out) <= 3:
             break


### PR DESCRIPTION
## Summary

`_check_processes()` in `test/conftest.py` filters `ps -ax` output with a `\b<pid>\b` regex over the **whole line**, so any unrelated process whose command-line arguments contain the same number is counted as a unit process.

That's exactly what killed the go-1.26 job in [run 29420853907](https://github.com/freeunitorg/freeunit/actions/runs/29420853907/attempts/1?pr=127) on #127: unit's main process happened to get **PID 9600**, which matched agetty's baud-rate list (`--keep-baud 115200,57600,38400,9600`), so the check saw 4 lines instead of 3 and 21 tests errored with `assert 4 == 3`. The rerun passed — pure PID-assignment luck.

## Fix

Match the main PID against the `pid`/`ppid` columns only:

```python
out = [l for l in out if main_pid in l.split()[:2]]
```

This still matches the main process itself (pid column) and its controller/router children (ppid column), but can no longer match numbers inside another process's arguments.

Verified against the exact `ps` lines from the failed run: the old regex matches 4 lines (incl. agetty), the new filter matches exactly main, controller, and router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)