### PR TITLE
chore(lib): close the stop-engines TODO as a documented decision

### DIFF
--- a/src/nxt_lib.c
+++ b/src/nxt_lib.c
@@ -146,31 +146,15 @@ nxt_lib_start(const char *app, char **argv, char ***envp)
 void
 nxt_lib_stop(void)
 {
-    /* TODO: stop engines */
-
-#if 0
-
-    for ( ;; ) {
-        nxt_thread_pool_t  *tp;
-
-        nxt_thread_spin_lock(&rt->lock);
-
-        tp = rt->thread_pools;
-        rt->thread_pools = (tp != NULL) ? tp->next : NULL;
-
-        nxt_thread_spin_unlock(&rt->lock);
-
-        if (tp == NULL) {
-            break;
-        }
-
-        nxt_thread_pool_destroy(tp);
-    }
-
-#else
+    /*
+     * There is no in-tree caller for this exported symbol, and it has no
+     * access to the runtime.  Event engines are per-thread and are torn down
+     * on the nxt_runtime_quit path by their owning threads; stopping them
+     * from here would require runtime access -- either an ABI-breaking change
+     * to this signature or a new global.  The symbol keeps its historical
+     * immediate-exit behavior for ABI compatibility.
+     */
 
     exit(0);
     nxt_unreachable();
-
-#endif
 }


### PR DESCRIPTION
## Summary

Closes the last open engine-teardown marker from the lifecycle track (roadmap P4). `nxt_lib_stop()` is an exported symbol with **no in-tree caller** and no access to the runtime; event engines are per-thread and are torn down on the `nxt_runtime_quit` path by their owning threads. A real "stop engines" here would need runtime access — an ABI-breaking signature change or a new global — which #98 already deferred to its own PR with explicit ABI review.

This drops the stale `/* TODO: stop engines */` and the dead `#if 0` thread-pool loop (it referenced an `rt` that was never in scope), records the decision in a comment, and keeps the historical immediate-exit body. Same closure style as #98's event-engine timer TODO. No behavior change.

## Verification

`./configure && make build/src/nxt_lib.o` — compiles clean; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYcuURscruaF1yNVHJHW3C