### PR TITLE
fix(h1proto): complete the buf chain tail detached by the Content-Length trim

### DIFF
--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -2949,19 +2949,27 @@ nxt_h1p_peer_body_process(nxt_task_t *task, nxt_http_peer_t *peer,
         if (nxt_slow_path((nxt_off_t) length < 0
                           || (nxt_off_t) length > h1p->remainder))
         {
-            nxt_buf_t  *b;
-            size_t     trimmed;
+            nxt_buf_t         *b, *tail, *next;
+            size_t            trimmed;
+            nxt_work_queue_t  *wq;
 
             /*
              * Upstream sent more body bytes than its Content-Length
              * declared.  Truncate the buf chain to remainder bytes so
              * we never forward the excess past the Content-Length we
              * already advertised downstream, then flag inconsistent
-             * and close.
+             * and close.  The tail detached by the truncation is not
+             * silently dropped: each detached buffer's completion
+             * handler is posted to the work queue below, so the
+             * request-pool retains those proxy read buffers hold are
+             * released promptly instead of lingering until request
+             * teardown.
              */
             nxt_log(task, NXT_LOG_WARN,
                     "upstream sent %uz body bytes past Content-Length "
                     "(remainder %O)", length, h1p->remainder);
+
+            tail = NULL;
 
             trimmed = 0;
             for (b = out; b != NULL; b = b->next) {
@@ -2975,11 +2983,27 @@ nxt_h1p_peer_body_process(nxt_task_t *task, nxt_http_peer_t *peer,
                     trimmed += bsz;
                     continue;
                 }
-                /* Trim this buf to fit, drop everything after it. */
+                /* Trim this buf to fit, detach the tail after it. */
                 b->mem.free = b->mem.pos
                               + (size_t) h1p->remainder - trimmed;
+                tail = b->next;
                 b->next = NULL;
                 break;
+            }
+
+            /* Complete the detached tail to release its retains now. */
+            wq = &task->thread->engine->fast_work_queue;
+
+            for (b = tail; b != NULL; b = next) {
+                next = b->next;
+                b->next = NULL;
+
+                if (nxt_buf_is_sync(b)) {
+                    continue;
+                }
+
+                nxt_work_queue_add(wq, b->completion_handler, task, b,
+                                   b->parent);
             }
 
             peer->request->inconsistent = 1;


### PR DESCRIPTION
## Summary

When an upstream sends more body bytes than its declared Content-Length, the peer body-read path (#85) trims the overflowing buffer and sets `b->next = NULL`, dropping everything after it. Those detached buffers are proxy read buffers from `nxt_http_proxy_buf_mem_alloc()` whose request-pool retains are normally released by their completion handlers — so on this malformed-upstream path the retains lingered until full request teardown (they were never truly leaked; the pool reclaims them with the request).

This captures the tail before truncating and completes each detached buffer by posting its completion handler to the engine fast work queue, skipping sync buffers — the same idiom as `nxt_port_error_handler()`. Retention on the bad-Content-Length path is now bounded; the forwarded (trimmed) head, the `inconsistent` flag, and close behavior are unchanged.

This is the robustness follow-up promised in the two open #85 review threads at `nxt_h1proto.c:2981-2982` (resolves them).

## No new test / no CHANGES entry

Exercising the path needs a misbehaving upstream whose overflow spans multiple buffers — the bad-Content-Length `fake_upstream` infra is still in flight (#100); CI's `test_proxy.py` is the eventual coverage vehicle. No CHANGES entry: internal robustness, no user-visible behavior change (same call as #128).

## Verification

On top of `pre-1.35.6`: `./configure --tests && make -j$(nproc)` — clean, zero warnings. `pytest test/test_static.py test/test_idle_close_wait.py` — 20 passed, 1 skipped, 1 environment-only failure (`/proc/<pid>/fd` permission in the test helper, unrelated). `test_proxy.py` needs the python module → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYcuURscruaF1yNVHJHW3C