### PR TITLE
fix(otel): snprintf status code; document control-socket UID gate

### DIFF
--- a/docs/man/man8/unitd.8.in
+++ b/docs/man/man8/unitd.8.in
@@ -69,6 +69,22 @@ Sets the permission of the UNIX-domain control socket.
 Sets the owner of the UNIX-domain control socket.
 .It Fl Fl control-group Ar group
 Sets the group of the UNIX-domain control socket.
+.Pp
+On a UNIX-domain control socket, and where the platform provides peer
+credentials (Linux and the BSDs), the control API additionally requires
+the connecting peer's effective user ID to be either 0 (root) or the
+user ID
+.Nm
+runs as; other local users are rejected before the request is read.
+On those builds the
+.Fl Fl control-user ,
+.Fl Fl control-group ,
+and
+.Fl Fl control-mode
+permissions act as defense-in-depth rather than the sole access control.
+Where peer credentials are unavailable, or for an IP-based control
+socket, those socket permissions (or network reachability) remain the
+boundary.
 .It Fl Fl group Ar name , Fl Fl user Ar name
 Override group name and user name used to run Unit's non-privileged processes.
 .It Fl Fl log Ar file

--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -316,8 +316,15 @@ nxt_otel_span_add_status(nxt_task_t *task, nxt_http_request_t *r)
         return;
     }
 
-    n = sprintf((char *) status_buf, "%d", (int) r->status);
-    if (n > 0) {
+    n = snprintf((char *) status_buf, sizeof(status_buf), "%d",
+                 (int) r->status);
+    /*
+     * snprintf() returns the length it *would* have written; on truncation
+     * that exceeds the buffer, so only record the attribute when the value
+     * fully fit -- a truncated status code is meaningless anyway, and using
+     * the would-have-been length as val.length would read past status_buf.
+     */
+    if (n > 0 && n < (int) sizeof(status_buf)) {
         val.start = status_buf;
         val.length = (size_t) n;
         nxt_otel_add_attr(r, NXT_OTEL_STATUS_CODE_TAG, &val);


### PR DESCRIPTION
Two small items from the 1.36.0 release review (#139), both verified against the code.

## otel status-code snprintf
`src/nxt_otel.c` formatted `r->status` into `status_buf[8]` with `sprintf("%d", ...)`. An int can format to 11 chars, so it's a latent overflow if `r->status` ever holds an out-of-range value. Switched to `snprintf(status_buf, sizeof(status_buf), ...)`. No behaviour change for normal 3-digit HTTP status codes. (Gemini flagged this; real, low severity.)

## Document the control-socket UID gate
The control-socket boundary tightening (`5f795d19`) made `nxt_controller_check_peer_cred` require the connecting peer's effective UID to be root or unitd's own UID — a deliberate design decision (filesystem perms are defense-in-depth, not the boundary). Codex correctly noted this isn't reflected in the documented `--control-user/--control-group/--control-mode` options. **Decision: keep the behaviour, document it.** Added a note to `docs/man/man8/unitd.8.in` making clear those permissions are defense-in-depth and don't delegate API access on their own.

A matching CHANGES bullet for the release goes into the changelog PR (#132), which owns CHANGES.

## Not changed (false positives, verified)
The two Gemini "security" findings on #139 are declined with evidence on that PR: the `nxt_unit.c` fields_count OOB is already guarded by a `recv_msg->size < sizeof(nxt_unit_request_t)` check ~20 lines up, and the `nxt_conf_validation.c` cgroup snprintf can't truncate because the top-of-function length check reserves more space than the buffer needs.

## Verification
`./configure --otel && make build/src/nxt_otel.o` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYcuURscruaF1yNVHJHW3C