### PR TITLE
fix: post-merge review cleanups (proxy keepalive, cgroup dir leak)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,12 @@ Changes with FreeUnit 1.36.0                                     16 Jul 2026
        body is read to EOF instead of trusting either length, preventing a
        response-smuggling desynchronization.
 
+    *) Bugfix: keep downstream keepalive disabled after a duplicate or invalid
+       upstream "Content-Length"; a clean upstream close no longer re-enables
+       it, so an HTTP/1.1 client cannot reuse the connection past the re-framed
+       response. The complete body still ends with its terminal chunk — body
+       truncation is now tracked separately from the inconsistent flag.
+
     *) Bugfix: bound the request-header fields region against the shared
        memory message size in libunit, validate every field name/value
        serialized pointer and the cached header-field indexes before use,
@@ -194,6 +200,12 @@ Changes with FreeUnit 1.36.0                                     16 Jul 2026
        cgroup directory path could overflow the check. The append now
        preserves the original length and fails with ENAMETOOLONG when
        "/cgroup.procs" plus the trailing NUL cannot fit.
+
+    *) Bugfix: fail cgroup setup when the per-process pool allocation that
+       caches the created directory for cleanup fails; the directory is now
+       removed and setup errors out, rather than moving the process into a
+       cgroup that could never be cleaned up — a cgroup directory leak under
+       memory pressure.
 
     *) Bugfix: reject a "rootfs" that lexically resolves to "/" (such as
        "/.", "/..", or "/foo/.."); chroot("/") is a no-op and would silently

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -97,6 +97,25 @@ with ENAMETOOLONG when "/cgroup.procs" plus the trailing NUL cannot fit.
 </para>
 </change>
 
+<change type="bugfix">
+<para>
+fail cgroup setup when the per-process pool allocation that caches the
+created directory for cleanup fails; the directory is removed and setup
+errors out instead of moving the process into a cgroup that could never be
+cleaned up -- a cgroup directory leak under memory pressure.
+</para>
+</change>
+
+<change type="bugfix">
+<para>
+keep downstream keepalive disabled after a duplicate or invalid upstream
+"Content-Length"; a clean upstream close no longer re-enables it, so an
+HTTP/1.1 client cannot reuse the connection past the re-framed response. The
+complete body still ends with its terminal chunk -- body truncation is now
+tracked separately from the inconsistent flag.
+</para>
+</change>
+
 <change type="change">
 <para>
 upgrade contrib njs to 1.0.0.

--- a/src/nxt_cgroup.c
+++ b/src/nxt_cgroup.c
@@ -34,12 +34,64 @@ nxt_cgroup_make_procs_path(char *cgprocs, size_t len)
 }
 
 
+/*
+ * Remove the leaf cgroup directory at cgpath and its now-empty ancestors,
+ * walking up until cgroot (the parent process's own cgroup) is reached.
+ * rmdir() fails harmlessly on any directory that is non-empty or was not
+ * created here.  cgpath is truncated in place.
+ */
+static void
+nxt_cgroup_rmdir_up(char *cgpath, const char *cgroot)
+{
+    char    *ptr;
+    size_t  root_len, cgpath_len;
+
+    /*
+     * nxt_mk_cgpath(task, "", ...) builds cgroot with a trailing slash
+     * (".../<main process cgroup>/") because it appends "/%s" with an empty
+     * relative dir, whereas cgpath has none.  Compare against the
+     * slash-trimmed root length so the walk stops at the parent's own cgroup
+     * rather than running up to the cgroup mount root -- previously the
+     * trailing-slash mismatch let strcmp() never match, and only rmdir()
+     * failing on the non-empty ancestors kept it from removing them.
+     */
+    root_len = strlen(cgroot);
+    while (root_len > 0 && cgroot[root_len - 1] == '/') {
+        root_len--;
+    }
+
+    /*
+     * Stop at the parent's own cgroup -- an exact, length-checked match so a
+     * sibling prefix ("<cgroot>-x") cannot match -- and never walk at or above
+     * NXT_CGROUP_ROOT: an absolute isolation "path" resolves under
+     * NXT_CGROUP_ROOT rather than under cgroot, so cgroot is never reached and
+     * without this floor the walk would climb toward the cgroup mount root.
+     */
+    cgpath_len = strlen(cgpath);
+
+    while (cgpath_len > sizeof(NXT_CGROUP_ROOT) - 1
+           && !(cgpath_len == root_len
+                && strncmp(cgpath, cgroot, root_len) == 0))
+    {
+        rmdir(cgpath);
+
+        ptr = strrchr(cgpath, '/');
+        if (ptr == NULL) {
+            break;
+        }
+
+        *ptr = '\0';
+        cgpath_len = ptr - cgpath;  /* truncated in place; new length is O(1) */
+    }
+}
+
+
 nxt_int_t
 nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process)
 {
     int        len;
     size_t     old_len;
-    char       cgprocs[NXT_MAX_PATH_LEN];
+    char       cgprocs[NXT_MAX_PATH_LEN], cgroot[NXT_MAX_PATH_LEN];
     FILE       *fp;
     nxt_int_t  ret;
 
@@ -78,10 +130,32 @@ nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process)
      */
     process->isolation.cgroup.resolved_path = nxt_mp_alloc(process->mem_pool,
                                                            old_len + 1);
-    if (nxt_fast_path(process->isolation.cgroup.resolved_path != NULL)) {
-        nxt_memcpy(process->isolation.cgroup.resolved_path, cgprocs, old_len);
-        process->isolation.cgroup.resolved_path[old_len] = '\0';
+    if (nxt_slow_path(process->isolation.cgroup.resolved_path == NULL)) {
+        /*
+         * Without the cached path, nxt_cgroup_cleanup() cannot rmdir the
+         * directory we just created -- the child's /proc/<pid>/cgroup is gone
+         * by cleanup time.  Remove it now, together with any now-empty parents
+         * nxt_fs_mkdir_p() just created (up to the parent's own cgroup), and
+         * fail rather than moving the process into a cgroup that could never be
+         * cleaned up.
+         */
+        if (nxt_fast_path(nxt_mk_cgpath(task, "", cgroot, 0) != NXT_ERROR)) {
+            nxt_cgroup_rmdir_up(cgprocs, cgroot);
+
+        } else {
+            /*
+             * The boundary could not be resolved (e.g. /proc read failure
+             * under the same memory pressure); at least remove the leaf we
+             * created rather than leaking it.
+             */
+            (void) rmdir(cgprocs);
+        }
+
+        return NXT_ERROR;
     }
+
+    nxt_memcpy(process->isolation.cgroup.resolved_path, cgprocs, old_len);
+    process->isolation.cgroup.resolved_path[old_len] = '\0';
 
     ret = nxt_cgroup_make_procs_path(cgprocs, old_len);
     if (nxt_slow_path(ret == NXT_ERROR)) {
@@ -108,7 +182,6 @@ nxt_cgroup_proc_add(nxt_task_t *task, nxt_process_t *process)
 void
 nxt_cgroup_cleanup(nxt_task_t *task, const nxt_process_t *process)
 {
-    char       *ptr;
     char       cgroot[NXT_MAX_PATH_LEN], cgpath[NXT_MAX_PATH_LEN];
     nxt_int_t  ret;
 
@@ -142,14 +215,7 @@ nxt_cgroup_cleanup(nxt_task_t *task, const nxt_process_t *process)
         return;
     }
 
-    while (*cgpath != '\0' && strcmp(cgroot, cgpath) != 0) {
-        rmdir(cgpath);
-        ptr = strrchr(cgpath, '/');
-        if (ptr == NULL) {
-            break;
-        }
-        *ptr = '\0';
-    }
+    nxt_cgroup_rmdir_up(cgpath, cgroot);
 }
 
 

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -1642,7 +1642,7 @@ nxt_h1p_chunk_create(nxt_task_t *task, nxt_http_request_t *r, nxt_buf_t *out)
     for (b = out; b != NULL; b = b->next) {
 
         if (nxt_buf_is_last(b)) {
-            if (r->inconsistent) {
+            if (r->truncated) {
                 /*
                  * The response is truncated -- the upstream closed before the
                  * body framing completed (premature chunked EOF, or a
@@ -1651,6 +1651,11 @@ nxt_h1p_chunk_create(nxt_task_t *task, nxt_http_request_t *r, nxt_buf_t *out)
                  * so the connection closes after this buffer and the client
                  * detects the truncation via the missing terminator, rather
                  * than seeing a falsely complete response.  #72
+                 *
+                 * Keyed on "truncated" not "inconsistent": a complete body
+                 * flagged inconsistent for another reason (e.g. a duplicate
+                 * upstream Content-Length) must keep its terminal chunk while
+                 * still disabling keepalive.
                  */
                 break;
             }
@@ -3052,16 +3057,28 @@ nxt_h1p_peer_closed(nxt_task_t *task, void *obj, void *data)
          * if its framing never completed: a Content-Length response short of
          * its declared length (remainder != 0), or a chunked response that
          * never reached the terminal 0\r\n\r\n (!chunked_parse.last).  Mark it
-         * inconsistent so keepalive is disabled and the client connection is
-         * closed once the partial body has been relayed.  The missing
-         * terminator then lets the client detect the truncation instead of it
-         * being masked as a clean end of response.  Relaying the partial body
-         * and closing -- rather than calling error_handler -- avoids racing a
-         * connection reset against the already-buffered status line and body
-         * (which could otherwise leave the client with an empty response). #72
+         * "truncated" so nxt_h1p_chunk_create() drops the terminal chunk and
+         * the client detects the cut instead of it being masked as a clean end
+         * of response, and "inconsistent" so keepalive is disabled and the
+         * client connection is closed once the partial body has been relayed.
+         * Relaying the partial body and closing -- rather than calling
+         * error_handler -- avoids racing a connection reset against the
+         * already-buffered status line and body (which could otherwise leave
+         * the client with an empty response). #72
+         *
+         * Set rather than assign: an earlier stage may already have marked the
+         * response inconsistent for an unrelated reason whose body is complete
+         * (e.g. an invalid or duplicate upstream Content-Length in
+         * nxt_http_proxy_content_length()).  A clean close there must keep
+         * keepalive disabled without falsely truncating the framing, so only a
+         * genuine short body sets "truncated", and neither flag is ever cleared.
          */
-        r->inconsistent = (h1p->remainder != 0)
-                          || (h1p->chunked && !h1p->chunked_parse.last);
+        if ((h1p->remainder != 0)
+            || (h1p->chunked && !h1p->chunked_parse.last))
+        {
+            r->truncated = 1;
+            r->inconsistent = 1;
+        }
 
         r->state->ready_handler(task, r, peer);
 

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -210,6 +210,7 @@ struct nxt_http_request_s {
     uint8_t                         logged;       /* 1 bit  */
     uint8_t                         header_sent;  /* 1 bit  */
     uint8_t                         inconsistent; /* 1 bit  */
+    uint8_t                         truncated;    /* 1 bit  */
     uint8_t                         error;        /* 1 bit  */
     uint8_t                         websocket_handshake;  /* 1 bit */
     uint8_t                         chunked;  /* 1 bit */

--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -76,6 +76,7 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 | Port | Token | Mode (CLI) | Rust handler | pytest |
 |------|-------|-----------|--------------|--------|
+| 7979 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_keepalive_disabled` (duplicate upstream Content-Length disables downstream keepalive for a keep-alive client; complete body keeps its terminal chunk) — out of the 7983–7999 block below, which is exhausted; 7980–7982 are `fake_otlp`, so 7974–7979 is the free gap |
 | 7983 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_raw` (zero raw `Content-Length` occurrences on the wire, complete re-framed chunked body) |
 | 7984 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl` (duplicate upstream Content-Length → neither forwarded, body re-framed, #113) |
 | 7985 | `chunked_ext` | `chunked-ext` | `respond_chunked_edge` | `test_proxy_chunked_ext` (chunk-extensions stripped, body intact) |
@@ -92,6 +93,10 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 | 7996 | `abort_mid` | `abort-mid` | `respond_abort_mid` | `test_proxy_chunked_response_abort_mid` (#72 case 4) |
 | 7997 | `slow_drip` | `slow-drip` | `respond_slow_drip` | `test_proxy_chunked_response_slow_drip` (#72 case 5) |
 | 7998 | `dup_te` | `dup-te` | `respond_dup_te` | `test_proxy_chunked_response_dup_te` (#72 case 6, nginx/unit#1088) |
+
+> **7999 is not available here.** `test/test_proxy.py` and `test/test_proxy_chunked.py`
+> already bind `SERVER_PORT = 7999` for their own upstream, so this registry ends at
+> 7998. New `fake_upstream` slots go to the 7974–7979 gap (7980–7982 are `fake_otlp`).
 
 A test pins its port as a module constant referencing this table:
 

--- a/test/test_proxy_dup_cl.py
+++ b/test/test_proxy_dup_cl.py
@@ -14,13 +14,17 @@ body itself as Transfer-Encoding: chunked -- with the exact upstream body
 bytes and a complete terminal chunk. The client never sees the two ambiguous
 lengths, so there is no framing disagreement to exploit.
 
-Note on the inconsistent flag: nxt_http_proxy_content_length also sets
-r->inconsistent, but once the EOF-framed body ends with a clean upstream
-close, nxt_h1p_peer_closed recomputes the flag from the (already reset)
-framing state, so a keep-alive-disabling close is not independently
-observable here. Both tests therefore drive `Connection: close` and assert
-the defense that matters on the wire: zero conflicting Content-Length headers
-reach the client and the relayed body framing is unambiguous.
+Note on the inconsistent flag: nxt_http_proxy_content_length sets
+r->inconsistent so the downstream keepalive is disabled. This was previously
+clobbered -- nxt_h1p_peer_closed reassigned the flag from the (already reset)
+framing state on the clean upstream close, so the connection stayed
+keep-alive. That is fixed: peer_closed now only *sets* a separate r->truncated
+(which drives the terminal-chunk omission) and never clears r->inconsistent,
+so a complete-but-ambiguous body disables keepalive while keeping its terminal
+chunk. test_proxy_dup_cl_keepalive_disabled below asserts that directly. The
+first two tests drive `Connection: close` and assert the primary defense on
+the wire: zero conflicting Content-Length headers reach the client and the
+relayed body framing is unambiguous.
 
 Driven by the `dup-cl` mode of the Rust mock upstream (test/fake_upstream/):
 it sends `Content-Length: 20` then `Content-Length: 6`, followed by a 20-byte
@@ -55,6 +59,7 @@ BODY = (PATTERN * (DUP_CL_FIRST // len(PATTERN) + 1))[:DUP_CL_FIRST]
 # Reserved fake_upstream ports for these cases (see test/fake_upstream/README.md).
 UPSTREAM_DUP_CL_PORT = 7984
 UPSTREAM_DUP_CL_RAW_PORT = 7983
+UPSTREAM_DUP_CL_KA_PORT = 7979
 
 FAKE_UPSTREAM_BIN = '/usr/local/bin/fake_upstream'
 
@@ -194,6 +199,78 @@ def test_proxy_dup_cl_raw(skip_alert):
         )
 
         assert closed, 'connection must be closed after the response'
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_skipif_no_fake_upstream
+def test_proxy_dup_cl_keepalive_disabled(skip_alert):
+    # Regression for the inconsistent-flag clobber: a duplicate upstream
+    # Content-Length must disable downstream keepalive even for a keep-alive
+    # client, AND the re-framed body must keep its terminal chunk (a complete
+    # body is not falsely truncated).  Before the fix, nxt_h1p_peer_closed
+    # reassigned r->inconsistent to 0 on the clean upstream close, so the
+    # connection stayed keep-alive; a naive fix that reused that one flag would
+    # instead drop the terminal chunk.  Both properties are asserted here.
+    skip_alert(r'upstream sent duplicate Content-Length')
+
+    proc = _run(UPSTREAM_DUP_CL_KA_PORT, 'dup-cl')
+    try:
+        _conf_proxy(UPSTREAM_DUP_CL_KA_PORT)
+
+        # Explicit keep-alive request: the default client sends Connection:
+        # close, which would mask whether the server disables keepalive.
+        sock = client.get(
+            port=8080,
+            headers={'Host': 'localhost', 'Connection': 'keep-alive'},
+            no_recv=True,
+        )
+        sock.settimeout(10)
+
+        data = b''
+        closed = False
+        try:
+            while True:
+                part = sock.recv(4096)
+                if not part:
+                    closed = True
+                    break
+                data += part
+                # Once the full response is in, only a short grace period is
+                # needed to observe the server-initiated close; shorten the
+                # timeout so a *failing* run (keepalive left enabled) does not
+                # block for the full 10s.
+                if b'0\r\n\r\n' in data:
+                    sock.settimeout(1)
+        except socket.timeout:
+            closed = False
+        finally:
+            sock.close()
+
+        assert data[:12] == b'HTTP/1.1 200', f'status line: {data[:40]!r}'
+
+        sep = data.index(b'\r\n\r\n')
+        head = data[:sep].lower()
+        body = data[sep + 4:]
+
+        # Keepalive is disabled despite the client's keep-alive request: the
+        # server closes the connection after the response.  No explicit
+        # "Connection: close" header is emitted -- nxt_h1p_request_header_send()
+        # picks the Connection header from h1p->keepalive before
+        # nxt_h1p_request_close() applies "keepalive &= !inconsistent" -- so the
+        # socket close is the observable signal here.
+        assert closed, 'server must close the connection after a dup-CL response'
+
+        # The complete body keeps its terminal chunk: the fix decouples the
+        # keepalive-disable (r->inconsistent) from truncation (r->truncated),
+        # so framing stays unambiguous rather than being falsely cut.
+        assert head.count(b'content-length') == 0, (
+            f'conflicting Content-Length must not reach the client: {data[:sep]!r}'
+        )
+        assert b'transfer-encoding: chunked' in head, f'not re-framed: {head!r}'
+        assert body.endswith(b'0\r\n\r\n'), f'terminal chunk missing: {body!r}'
+        assert _dechunk(body) == BODY.encode(), f'relayed body mismatch: {body!r}'
     finally:
         proc.terminate()
         proc.wait()


### PR DESCRIPTION
Addresses two P2 findings from Codex on #139, verified against the code.

### 1. Proxy keepalive not disabled after a duplicate/invalid upstream Content-Length (`nxt_h1proto.c`)
[Review](https://github.com/freeunitorg/freeunit/pull/139#pullrequestreview-4718553301). `nxt_http_proxy_content_length()` sets `r->inconsistent` to disable downstream keepalive, but `nxt_h1p_peer_closed` **reassigned** the flag from the framing state on a clean upstream close, clearing it — so an HTTP/1.1 keep-alive client could reuse the connection past the re-framed response.

The flag was **overloaded**: it also drives dropping the terminal chunk in `nxt_h1p_chunk_create` (truncation detection, #72), so a naive `|=` would strip the terminal `0\r\n\r\n` from a *complete* dup-CL body. Fix decouples them:
- new `r->truncated` → terminal-chunk omission (genuine short body only);
- `r->inconsistent` → keepalive disable, now only ever **set**, never cleared.

Result: a dup-CL response disables keepalive **and** keeps its complete terminal chunk.

New `test_proxy_dup_cl_keepalive_disabled` sends a keep-alive request through the `dup-cl` mock upstream and asserts both `Connection: close`/socket close **and** the terminal chunk is present (catches the original clobber *and* a naive-fix regression). Stale docstring note refreshed.

### 2. cgroup directory leak on OOM (`nxt_cgroup.c`)
[Review](https://github.com/freeunitorg/freeunit/pull/139#pullrequestreview-4718004948). If the pool allocation that caches the created cgroup directory for cleanup failed, setup still moved the process into the cgroup and returned success, while `nxt_cgroup_cleanup()` (which needs that cache) bailed — leaking the directory under memory pressure. Now fails setup and `rmdir`s the just-created directory. Not unit-testable (needs CAP_SYS_ADMIN + `nxt_mp_alloc` fault injection), like the mount-fix runtime test.

`CHANGES` and `docs/changes.xml` updated under the 1.36.0 block. Full `unitd` build + targeted compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)