### PR TITLE
chore(security): supported-versions matrix for 1.36.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ FreeUnit provides security maintenance for the following versions:
 
 | Version | Supported |
 |---------|-----------|
-| 1.35.x  | ✅ Active |
+| 1.36.x  | ✅ Active |
+| 1.35.x  | ❌ EOL — upgrade to 1.36.x |
 | 1.34.x  | ✅ LTS    |
 | < 1.34  | ❌ No     |
 


### PR DESCRIPTION
Update the Supported Versions matrix in `SECURITY.md` for the 1.36.0 release:

| Version | Supported |
|---------|-----------|
| 1.36.x  | ✅ Active |
| 1.35.x  | ❌ EOL — upgrade to 1.36.x |
| 1.34.x  | ✅ LTS    |
| < 1.34  | ❌ No     |

1.36.0 is now the Active minor line. 1.35.x is retired: the 1.36.0 security advisories ([GHSA-768w-qrh2-jjvh](https://github.com/freeunitorg/freeunit/security/advisories/GHSA-768w-qrh2-jjvh), [GHSA-g6v8-r577-76jm](https://github.com/freeunitorg/freeunit/security/advisories/GHSA-g6v8-r577-76jm)) patch 1.36.0 and backport to the 1.34.x LTS line **only** — not 1.35.x — so 1.35.x is end-of-life and users should upgrade to 1.36.x. The 1.34.x LTS entry is unchanged.
