### PR TITLE
http: inline_fields[16] embedded header array (zero-alloc header storage)

### DIFF
--- a/fuzzing/nxt_http_controller_fuzz.c
+++ b/fuzzing/nxt_http_controller_fuzz.c
@@ -87,8 +87,8 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto failed;
     }
 
-    nxt_http_fields_process(rp.fields, &nxt_controller_fields_hash,
-                            req);
+    nxt_http_fields_process(rp.inline_fields, rp.num_inline_fields, rp.fields,
+                            &nxt_controller_fields_hash, req);
 
 failed:
 

--- a/fuzzing/nxt_http_h1p_fuzz.c
+++ b/fuzzing/nxt_http_h1p_fuzz.c
@@ -96,7 +96,8 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto failed;
     }
 
-    nxt_http_fields_process(rp.fields, &nxt_h1p_fields_hash, req);
+    nxt_http_fields_process(rp.inline_fields, rp.num_inline_fields, rp.fields,
+                            &nxt_h1p_fields_hash, req);
 
 failed:
 

--- a/fuzzing/nxt_http_h1p_peer_fuzz.c
+++ b/fuzzing/nxt_http_h1p_peer_fuzz.c
@@ -89,7 +89,8 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto failed;
     }
 
-    nxt_http_fields_process(rp.fields, &nxt_h1p_peer_fields_hash, req);
+    nxt_http_fields_process(rp.inline_fields, rp.num_inline_fields, rp.fields,
+                            &nxt_h1p_peer_fields_hash, req);
 
 failed:
 

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -895,8 +895,10 @@ nxt_controller_conn_read(nxt_task_t *task, void *obj, void *data)
         return;
     }
 
-    rc = nxt_http_fields_process(r->parser.fields, &nxt_controller_fields_hash,
-                                 r);
+    rc = nxt_http_fields_process(r->parser.inline_fields,
+                                 r->parser.num_inline_fields,
+                                 r->parser.fields,
+                                 &nxt_controller_fields_hash, r);
 
     if (nxt_slow_path(rc != NXT_OK)) {
         nxt_controller_conn_close(task, c, r);

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -678,9 +678,15 @@ nxt_h1p_header_process(nxt_task_t *task, nxt_h1proto_t *h1p,
     r->path = &h1p->parser.path;
     r->args = &h1p->parser.args;
 
+    r->num_inline_fields = h1p->parser.num_inline_fields;
+    if (r->num_inline_fields > 0) {
+        nxt_memcpy(r->inline_fields, h1p->parser.inline_fields,
+                   sizeof(nxt_http_field_t) * r->num_inline_fields);
+    }
     r->fields = h1p->parser.fields;
 
-    ret = nxt_http_fields_process(r->fields, &nxt_h1p_fields_hash, r);
+    ret = nxt_http_fields_process(r->inline_fields, r->num_inline_fields,
+                                  r->fields, &nxt_h1p_fields_hash, r);
     if (nxt_slow_path(ret != NXT_OK)) {
         return ret;
     }
@@ -1443,14 +1449,16 @@ nxt_h1p_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
         size += connection[conn].length;
     }
 
-    nxt_list_each(field, r->resp.fields) {
+    nxt_http_fields_each(field, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
 
         if (!field->skip) {
             size += field->name_length + field->value_length;
             size += nxt_length(": \r\n");
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     if (nxt_slow_path(n == NXT_HTTP_UPGRADE_REQUIRED)) {
         size += nxt_length(websocket_version);
@@ -1464,7 +1472,9 @@ nxt_h1p_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
 
     p = nxt_cpymem(header->mem.free, status->start, status->length);
 
-    nxt_list_each(field, r->resp.fields) {
+    nxt_http_fields_each(field, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
 
         if (!field->skip) {
             p = nxt_cpymem(p, field->name, field->name_length);
@@ -1473,7 +1483,7 @@ nxt_h1p_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
             *p++ = '\r'; *p++ = '\n';
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     if (conn >= 0) {
         p = nxt_cpymem(p, connection[conn].start, connection[conn].length);
@@ -1753,7 +1763,7 @@ nxt_h1p_conn_request_error(nxt_task_t *task, void *obj, void *data)
         return;
     }
 
-    if (r->fields == NULL) {
+    if (r->method == NULL) {
         (void) nxt_h1p_header_process(task, h1p, r);
     }
 
@@ -1789,7 +1799,7 @@ nxt_h1p_conn_request_timeout(nxt_task_t *task, void *obj, void *data)
     h1p->keepalive = 0;
     r = h1p->request;
 
-    if (r->fields == NULL) {
+    if (r->method == NULL) {
         (void) nxt_h1p_header_process(task, h1p, r);
     }
 
@@ -2454,14 +2464,16 @@ nxt_h1p_peer_header_send(nxt_task_t *task, nxt_http_peer_t *peer)
         size += nxt_length("Content-Length: ") + NXT_OFF_T_LEN + nxt_length("\r\n");
     }
 
-    nxt_list_each(field, r->fields) {
+    nxt_http_fields_each(field, r->inline_fields, r->num_inline_fields,
+                         r->fields)
+    {
 
         if (!field->hopbyhop && !field->skip) {
             size += field->name_length + field->value_length;
             size += nxt_length(": \r\n");
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     header = nxt_http_buf_mem(task, r, size);
     if (nxt_slow_path(header == NULL)) {
@@ -2476,7 +2488,9 @@ nxt_h1p_peer_header_send(nxt_task_t *task, nxt_http_peer_t *peer)
     p = nxt_cpymem(p, " HTTP/1.1\r\n", 11);
     p = nxt_cpymem(p, "Connection: close\r\n", 19);
 
-    nxt_list_each(field, r->fields) {
+    nxt_http_fields_each(field, r->inline_fields, r->num_inline_fields,
+                         r->fields)
+    {
 
         if (!field->hopbyhop && !field->skip) {
             p = nxt_cpymem(p, field->name, field->name_length);
@@ -2485,7 +2499,7 @@ nxt_h1p_peer_header_send(nxt_task_t *task, nxt_http_peer_t *peer)
             *p++ = '\r'; *p++ = '\n';
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     if (content_length >= 0) {
         p = nxt_cpymem(p, "Content-Length: ", nxt_length("Content-Length: "));
@@ -2524,8 +2538,6 @@ nxt_h1p_peer_header_send(nxt_task_t *task, nxt_http_peer_t *peer)
         }
 
         size += nxt_buf_used_size(body);
-
-//        nxt_mp_retain(r->mem_pool);
     }
 
     if (size > 16384) {
@@ -2766,9 +2778,16 @@ nxt_h1p_peer_header_read_done(nxt_task_t *task, void *obj, void *data)
     switch (ret) {
 
     case NXT_DONE:
+        peer->num_inline_fields = peer->proto.h1->parser.num_inline_fields;
+        if (peer->num_inline_fields > 0) {
+            nxt_memcpy(peer->inline_fields,
+                       peer->proto.h1->parser.inline_fields,
+                       sizeof(nxt_http_field_t) * peer->num_inline_fields);
+        }
         peer->fields = peer->proto.h1->parser.fields;
 
-        ret = nxt_http_fields_process(peer->fields,
+        ret = nxt_http_fields_process(peer->inline_fields,
+                                      peer->num_inline_fields, peer->fields,
                                       &nxt_h1p_peer_fields_hash, r);
         if (nxt_slow_path(ret != NXT_OK)) {
             peer->status = NXT_HTTP_INTERNAL_SERVER_ERROR;

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -107,6 +107,8 @@ typedef union {
 
 
 typedef struct {
+    nxt_http_field_t                inline_fields[16];
+    uint8_t                         num_inline_fields;
     nxt_list_t                      *fields;
     nxt_http_field_t                *date;
     nxt_http_field_t                *content_type;
@@ -116,12 +118,46 @@ typedef struct {
 } nxt_http_response_t;
 
 
+nxt_inline nxt_http_field_t *
+nxt_http_resp_field_add(nxt_http_response_t *resp, nxt_mp_t *mp)
+{
+    if (resp->num_inline_fields < 16) {
+        return &resp->inline_fields[resp->num_inline_fields++];
+    }
+
+    if (resp->fields == NULL) {
+        resp->fields = nxt_list_create(mp, 8, sizeof(nxt_http_field_t));
+        if (nxt_slow_path(resp->fields == NULL)) {
+            return NULL;
+        }
+    }
+
+    return nxt_list_add(resp->fields);
+}
+
+
+nxt_inline nxt_http_field_t *
+nxt_http_resp_field_zero_add(nxt_http_response_t *resp, nxt_mp_t *mp)
+{
+    nxt_http_field_t  *field;
+
+    field = nxt_http_resp_field_add(resp, mp);
+    if (nxt_fast_path(field != NULL)) {
+        nxt_memzero(field, sizeof(nxt_http_field_t));
+    }
+
+    return field;
+}
+
+
 typedef struct nxt_upstream_server_s  nxt_upstream_server_t;
 
 typedef struct {
     nxt_http_proto_t                proto;
     nxt_http_request_t              *request;
     nxt_upstream_server_t           *server;
+    nxt_http_field_t                inline_fields[16];
+    uint8_t                         num_inline_fields;
     nxt_list_t                      *fields;
     nxt_buf_t                       *body;
 
@@ -157,6 +193,8 @@ struct nxt_http_request_s {
     nxt_str_t                       args_decoded;
     nxt_array_t                     *arguments;  /* of nxt_http_name_value_t */
     nxt_array_t                     *cookies;    /* of nxt_http_name_value_t */
+    nxt_http_field_t                inline_fields[16];
+    uint8_t                         num_inline_fields;
     nxt_list_t                      *fields;
     nxt_http_field_t                *content_type;
     nxt_http_field_t                *content_length;
@@ -215,6 +253,38 @@ struct nxt_http_request_s {
     uint8_t                         websocket_handshake;  /* 1 bit */
     uint8_t                         chunked;  /* 1 bit */
 };
+
+
+nxt_inline nxt_http_field_t *
+nxt_http_req_field_add(nxt_http_request_t *r)
+{
+    if (r->num_inline_fields < 16) {
+        return &r->inline_fields[r->num_inline_fields++];
+    }
+
+    if (r->fields == NULL) {
+        r->fields = nxt_list_create(r->mem_pool, 8, sizeof(nxt_http_field_t));
+        if (nxt_slow_path(r->fields == NULL)) {
+            return NULL;
+        }
+    }
+
+    return nxt_list_add(r->fields);
+}
+
+
+nxt_inline nxt_http_field_t *
+nxt_http_req_field_zero_add(nxt_http_request_t *r)
+{
+    nxt_http_field_t  *field;
+
+    field = nxt_http_req_field_add(r);
+    if (nxt_fast_path(field != NULL)) {
+        nxt_memzero(field, sizeof(nxt_http_field_t));
+    }
+
+    return field;
+}
 
 
 typedef struct {

--- a/src/nxt_http_compression.c
+++ b/src/nxt_http_compression.c
@@ -475,7 +475,7 @@ nxt_http_comp_set_header(nxt_http_request_t *r, nxt_uint_t comp_idx)
     static const nxt_str_t  content_encoding_str =
                                     nxt_string("Content-Encoding");
 
-    f = nxt_list_add(r->resp.fields);
+    f = nxt_http_resp_field_add(&r->resp, r->mem_pool);
     if (nxt_slow_path(f == NULL)) {
         return NXT_ERROR;
     }
@@ -499,14 +499,16 @@ nxt_http_comp_set_header(nxt_http_request_t *r, nxt_uint_t comp_idx)
          * As per RFC 2616 section 4.4 item 3, you should not send
          * Content-Length when a Transfer-Encoding header is present.
          */
-        nxt_list_each(f, r->resp.fields) {
+        nxt_http_fields_each(f, r->resp.inline_fields, r->resp.num_inline_fields,
+                             r->resp.fields)
+        {
             if (nxt_strcasecmp(f->name,
                                (const u_char *)"Content-Length") == 0)
             {
                 f->skip = true;
                 break;
             }
-        } nxt_list_loop;
+        } nxt_http_fields_loop;
     }
 
     return NXT_OK;
@@ -518,11 +520,13 @@ nxt_http_comp_is_resp_content_encoded(const nxt_http_request_t *r)
 {
     nxt_http_field_t  *f;
 
-    nxt_list_each(f, r->resp.fields) {
+    nxt_http_fields_each(f, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
         if (nxt_strcasecmp(f->name, (const u_char *)"Content-Encoding") == 0) {
             return true;
         }
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     return false;
 }

--- a/src/nxt_http_error.c
+++ b/src/nxt_http_error.c
@@ -41,12 +41,21 @@ nxt_http_request_error(nxt_task_t *task, nxt_http_request_t *r,
 
     r->status = status;
 
-    r->resp.fields = nxt_list_create(r->mem_pool, 8, sizeof(nxt_http_field_t));
-    if (nxt_slow_path(r->resp.fields == NULL)) {
-        goto fail;
-    }
+    /*
+     * Discard any response fields already collected (e.g. app-supplied
+     * headers) before building the error response.  With inline_fields the
+     * field store is not a re-created list, so reset it explicitly; otherwise
+     * nxt_http_resp_field_zero_add() below would append the error's
+     * Content-Type after stale fields, emitting a conflicting Content-Length.
+     */
+    r->resp.num_inline_fields = 0;
+    r->resp.fields = NULL;
+    r->resp.date = NULL;
+    r->resp.content_type = NULL;
+    r->resp.content_length = NULL;
+    r->resp.mime_type = NULL;
 
-    content_type = nxt_list_zero_add(r->resp.fields);
+    content_type = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
     if (nxt_slow_path(content_type == NULL)) {
         goto fail;
     }

--- a/src/nxt_http_js.c
+++ b/src/nxt_http_js.c
@@ -219,7 +219,7 @@ nxt_http_js_ext_get_header(njs_vm_t *vm, njs_object_prop_t *prop,
         return NJS_DECLINED;
     }
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
 
         if (key.length == f->name_length
             && memcmp(key.start, f->name, f->name_length) == 0)
@@ -228,7 +228,7 @@ nxt_http_js_ext_get_header(njs_vm_t *vm, njs_object_prop_t *prop,
                                               f->value_length);
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     njs_value_undefined_set(retval);
 
@@ -253,7 +253,7 @@ nxt_http_js_ext_keys_header(njs_vm_t *vm, njs_value_t *value, njs_value_t *keys)
         return NJS_OK;
     }
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
 
         value = njs_vm_array_push(vm, keys);
         if (value == NULL) {
@@ -265,7 +265,7 @@ nxt_http_js_ext_keys_header(njs_vm_t *vm, njs_value_t *value, njs_value_t *keys)
             return NJS_ERROR;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     return NJS_OK;
 }

--- a/src/nxt_http_parse.c
+++ b/src/nxt_http_parse.c
@@ -109,10 +109,8 @@ nxt_http_parse_request_init(nxt_http_request_parse_t *rp, nxt_mp_t *mp)
 {
     rp->mem_pool = mp;
 
-    rp->fields = nxt_list_create(mp, 8, sizeof(nxt_http_field_t));
-    if (nxt_slow_path(rp->fields == NULL)) {
-        return NXT_ERROR;
-    }
+    rp->num_inline_fields = 0;
+    rp->fields = NULL;
 
     rp->field_hash = NXT_HTTP_FIELD_HASH_INIT;
 
@@ -788,10 +786,22 @@ nxt_http_parse_field_end(nxt_http_request_parse_t *rp, u_char **pos,
                 rp->skip_field = 0;
 
             } else {
-                field = nxt_list_add(rp->fields);
+                if (rp->num_inline_fields < 16) {
+                    field = &rp->inline_fields[rp->num_inline_fields++];
 
-                if (nxt_slow_path(field == NULL)) {
-                    return NXT_ERROR;
+                } else {
+                    if (rp->fields == NULL) {
+                        rp->fields = nxt_list_create(rp->mem_pool, 16,
+                                                    sizeof(nxt_http_field_t));
+                        if (nxt_slow_path(rp->fields == NULL)) {
+                            return NXT_ERROR;
+                        }
+                    }
+
+                    field = nxt_list_add(rp->fields);
+                    if (nxt_slow_path(field == NULL)) {
+                        return NXT_ERROR;
+                    }
                 }
 
                 field->hash = nxt_http_field_hash_end(rp->field_hash);
@@ -1251,19 +1261,21 @@ nxt_http_fields_hash_collisions(nxt_lvlhsh_t *hash,
 
 
 nxt_int_t
-nxt_http_fields_process(nxt_list_t *fields, nxt_lvlhsh_t *hash, void *ctx)
+nxt_http_fields_process(nxt_http_field_t *inline_fields,
+    uint8_t num_inline_fields, nxt_list_t *fields, nxt_lvlhsh_t *hash,
+    void *ctx)
 {
     nxt_int_t         ret;
     nxt_http_field_t  *field;
 
-    nxt_list_each(field, fields) {
+    nxt_http_fields_each(field, inline_fields, num_inline_fields, fields) {
 
         ret = nxt_http_field_process(field, hash, ctx);
         if (nxt_slow_path(ret != NXT_OK)) {
             return ret;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     return NXT_OK;
 }

--- a/src/nxt_http_parse.h
+++ b/src/nxt_http_parse.h
@@ -20,6 +20,17 @@ typedef struct nxt_http_field_s          nxt_http_field_t;
 typedef struct nxt_http_fields_hash_s    nxt_http_fields_hash_t;
 
 
+struct nxt_http_field_s {
+    uint16_t                  hash;
+    uint8_t                   skip:1;
+    uint8_t                   hopbyhop:1;
+    uint8_t                   name_length;
+    uint32_t                  value_length;
+    u_char                    *name;
+    u_char                    *value;
+};
+
+
 typedef union {
     u_char                    str[8] NXT_NONSTRING;
     uint64_t                  ui64;
@@ -47,6 +58,9 @@ struct nxt_http_request_parse_s {
     nxt_str_t                 args;
 
     nxt_http_ver_t            version;
+
+    nxt_http_field_t          inline_fields[16];
+    uint8_t                   num_inline_fields;
 
     nxt_list_t                *fields;
     nxt_mp_t                  *mem_pool;
@@ -84,17 +98,6 @@ typedef struct {
 } nxt_http_field_proc_t;
 
 
-struct nxt_http_field_s {
-    uint16_t                  hash;
-    uint8_t                   skip:1;
-    uint8_t                   hopbyhop:1;
-    uint8_t                   name_length;
-    uint32_t                  value_length;
-    u_char                    *name;
-    u_char                    *value;
-};
-
-
 typedef struct {
     nxt_mp_t                  *mem_pool;
     uint64_t                  chunk_size;
@@ -110,6 +113,84 @@ typedef struct {
 #define nxt_http_field_hash_end(h)      (((h) >> 16) ^ (h))
 
 
+typedef struct {
+    nxt_http_field_t          *inline_fields;
+    uint8_t                   num_inline_fields;
+    uint8_t                   inline_index;
+    nxt_list_t                *fields;
+    nxt_list_part_t           *part;
+    uintptr_t                 elt;
+} nxt_http_fields_iter_t;
+
+
+nxt_inline nxt_http_field_t *
+nxt_http_fields_first(nxt_http_fields_iter_t *iter,
+    nxt_http_field_t *inline_fields, uint8_t num_inline_fields,
+    nxt_list_t *fields)
+{
+    iter->inline_fields = inline_fields;
+    iter->num_inline_fields = num_inline_fields;
+    iter->inline_index = 0;
+    iter->fields = fields;
+    iter->part = (fields != NULL) ? nxt_list_part(fields) : NULL;
+    iter->elt = 0;
+
+    if (iter->inline_index < iter->num_inline_fields) {
+        return &iter->inline_fields[iter->inline_index++];
+    }
+
+    while (iter->part != NULL) {
+        if (iter->part->nelts > 0) {
+            iter->elt = 1;
+            return (nxt_http_field_t *) nxt_list_data(iter->part);
+        }
+
+        iter->part = iter->part->next;
+    }
+
+    return NULL;
+}
+
+
+nxt_inline nxt_http_field_t *
+nxt_http_fields_next(nxt_http_fields_iter_t *iter)
+{
+    nxt_http_field_t  *f;
+
+    if (iter->inline_index < iter->num_inline_fields) {
+        return &iter->inline_fields[iter->inline_index++];
+    }
+
+    while (iter->part != NULL) {
+        if (iter->elt < iter->part->nelts) {
+            f = (nxt_http_field_t *) nxt_list_data(iter->part) + iter->elt;
+            iter->elt++;
+            return f;
+        }
+
+        iter->part = iter->part->next;
+        iter->elt = 0;
+    }
+
+    return NULL;
+}
+
+
+#define nxt_http_fields_each(field, inline_fields, num_inline_fields, fields) \
+    do {                                                                      \
+        nxt_http_fields_iter_t  _iter;                                        \
+        for (field = nxt_http_fields_first(&_iter,                            \
+                                            (nxt_http_field_t *) (inline_fields),\
+                                            num_inline_fields, fields);       \
+             field != NULL;                                                   \
+             field = nxt_http_fields_next(&_iter))                            \
+        {
+
+#define nxt_http_fields_loop                                                  \
+        }                                                                     \
+    } while (0)
+
+
 nxt_int_t nxt_http_parse_request_init(nxt_http_request_parse_t *rp,
     nxt_mp_t *mp);
 nxt_int_t nxt_http_parse_request(nxt_http_request_parse_t *rp,
@@ -121,7 +202,8 @@ nxt_int_t nxt_http_fields_hash(nxt_lvlhsh_t *hash,
     nxt_http_field_proc_t items[], nxt_uint_t count);
 nxt_uint_t nxt_http_fields_hash_collisions(nxt_lvlhsh_t *hash,
     nxt_http_field_proc_t items[], nxt_uint_t count, nxt_bool_t level);
-nxt_int_t nxt_http_fields_process(nxt_list_t *fields, nxt_lvlhsh_t *hash,
+nxt_int_t nxt_http_fields_process(nxt_http_field_t *inline_fields,
+    uint8_t num_inline_fields, nxt_list_t *fields, nxt_lvlhsh_t *hash,
     void *ctx);
 
 nxt_int_t nxt_http_parse_complex_target(nxt_http_request_parse_t *rp);

--- a/src/nxt_http_proxy.c
+++ b/src/nxt_http_proxy.c
@@ -257,14 +257,16 @@ nxt_http_proxy_header_read(nxt_task_t *task, void *obj, void *data)
 
     nxt_debug(task, "http proxy status: %d", peer->status);
 
-    nxt_list_each(field, peer->fields) {
+    nxt_http_fields_each(field, peer->inline_fields, peer->num_inline_fields,
+                         peer->fields)
+    {
 
         nxt_debug(task, "http proxy header: \"%*s: %*s\"",
                   (size_t) field->name_length, field->name,
                   (size_t) field->value_length, field->value);
 
         if (!field->skip) {
-            f = nxt_list_add(r->resp.fields);
+            f = nxt_http_resp_field_add(&r->resp, r->mem_pool);
             if (nxt_slow_path(f == NULL)) {
                 nxt_http_proxy_error(task, r, peer);
                 return;
@@ -273,7 +275,7 @@ nxt_http_proxy_header_read(nxt_task_t *task, void *obj, void *data)
             *f = *field;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     r->state = &nxt_http_proxy_read_state;
 

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -258,11 +258,6 @@ nxt_http_request_create(nxt_task_t *task)
         goto fail;
     }
 
-    r->resp.fields = nxt_list_create(mp, 8, sizeof(nxt_http_field_t));
-    if (nxt_slow_path(r->resp.fields == NULL)) {
-        goto fail;
-    }
-
     last = nxt_mp_zget(mp, NXT_BUF_SYNC_SIZE);
     if (nxt_slow_path(last == NULL)) {
         goto fail;
@@ -381,7 +376,7 @@ nxt_http_request_forward(nxt_task_t *task, nxt_http_request_t *r,
 
     protocol_field = NULL;
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
         if (client_ip_fields != NULL
             && f->hash == client_ip->header_hash
             && f->value_length > 0
@@ -407,7 +402,7 @@ nxt_http_request_forward(nxt_task_t *task, nxt_http_request_t *r,
         {
             protocol_field = f;
         }
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     if (client_ip_fields != NULL) {
         nxt_http_request_forward_client_ip(r, forward, client_ip_fields);
@@ -562,7 +557,7 @@ nxt_http_request_chunked_transform(nxt_http_request_t *r)
 
     size = r->body->file_end;
 
-    f = nxt_list_zero_add(r->fields);
+    f = nxt_http_req_field_zero_add(r);
     if (nxt_slow_path(f == NULL)) {
         return NXT_ERROR;
     }
@@ -702,7 +697,7 @@ nxt_http_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
      * to the last header filter.
      */
 
-    server = nxt_list_zero_add(r->resp.fields);
+    server = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
     if (nxt_slow_path(server == NULL)) {
         goto fail;
     }
@@ -715,7 +710,7 @@ nxt_http_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
     server->value_length = nxt_strlen(server_string);
 
     if (r->resp.date == NULL) {
-        date = nxt_list_zero_add(r->resp.fields);
+        date = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
         if (nxt_slow_path(date == NULL)) {
             goto fail;
         }
@@ -738,7 +733,7 @@ nxt_http_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
     if (r->resp.content_length_n != -1
         && (r->resp.content_length == NULL || r->resp.content_length->skip))
     {
-        content_length = nxt_list_zero_add(r->resp.fields);
+        content_length = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
         if (nxt_slow_path(content_length == NULL)) {
             goto fail;
         }
@@ -1092,7 +1087,7 @@ nxt_http_cookies_parse(nxt_http_request_t *r)
         return NULL;
     }
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
 
         if (f->hash != NXT_HTTP_COOKIE_HASH
             || f->name_length != 6
@@ -1107,7 +1102,7 @@ nxt_http_cookies_parse(nxt_http_request_t *r)
             return NULL;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     r->cookies = cookies;
 

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -189,7 +189,7 @@ nxt_http_return_send(nxt_task_t *task, nxt_http_request_t *r,
             }
         }
 
-        field = nxt_list_zero_add(r->resp.fields);
+        field = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
         if (nxt_slow_path(field == NULL)) {
             goto fail;
         }

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1966,7 +1966,7 @@ nxt_http_route_header(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
 
     ret = 0;
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
 
         if (rule->u.name.hash != f->hash
             || rule->u.name.length != f->name_length
@@ -1985,7 +1985,7 @@ nxt_http_route_header(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
             return ret;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     return ret;
 }

--- a/src/nxt_http_set_headers.c
+++ b/src/nxt_http_set_headers.c
@@ -104,7 +104,9 @@ nxt_http_resp_header_find(nxt_http_request_t *r, u_char *name, size_t length)
 {
     nxt_http_field_t  *f;
 
-    nxt_list_each(f, r->resp.fields) {
+    nxt_http_fields_each(f, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
 
         if (f->skip) {
             continue;
@@ -116,7 +118,7 @@ nxt_http_resp_header_find(nxt_http_request_t *r, u_char *name, size_t length)
             return f;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     return NULL;
 }
@@ -214,7 +216,7 @@ nxt_http_set_headers(nxt_http_request_t *r)
         if (value[i].start != NULL) {
 
             if (f == NULL) {
-                f = nxt_list_zero_add(r->resp.fields);
+                f = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
                 if (nxt_slow_path(f == NULL)) {
                     return NXT_ERROR;
                 }

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -575,7 +575,7 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
         r->status = NXT_HTTP_OK;
         r->resp.content_length_n = nxt_file_size(&fi);
 
-        field = nxt_list_zero_add(r->resp.fields);
+        field = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
         if (nxt_slow_path(field == NULL)) {
             goto fail;
         }
@@ -592,7 +592,7 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
         field->value = p;
         field->value_length = nxt_http_date(p, &tm) - p;
 
-        field = nxt_list_zero_add(r->resp.fields);
+        field = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
         if (nxt_slow_path(field == NULL)) {
             goto fail;
         }
@@ -621,7 +621,7 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
         }
 
         if (mtype->length != 0) {
-            field = nxt_list_zero_add(r->resp.fields);
+            field = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
             if (nxt_slow_path(field == NULL)) {
                 goto fail;
             }
@@ -699,7 +699,7 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
         r->status = NXT_HTTP_MOVED_PERMANENTLY;
         r->resp.content_length_n = 0;
 
-        field = nxt_list_zero_add(r->resp.fields);
+        field = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
         if (nxt_slow_path(field == NULL)) {
             goto fail;
         }

--- a/src/nxt_http_variables.c
+++ b/src/nxt_http_variables.c
@@ -657,7 +657,7 @@ nxt_http_var_header(nxt_task_t *task, nxt_str_t *str, void *ctx, void *data)
     r = ctx;
     vf = data;
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
 
         if (vf->hash == f->hash
             && vf->name.length == f->name_length
@@ -669,7 +669,7 @@ nxt_http_var_header(nxt_task_t *task, nxt_str_t *str, void *ctx, void *data)
             return NXT_OK;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     nxt_str_null(str);
 
@@ -758,7 +758,9 @@ nxt_http_var_response_header(nxt_task_t *task, nxt_str_t *str, void *ctx,
     r = ctx;
     name = data;
 
-    nxt_list_each(f, r->resp.fields) {
+    nxt_http_fields_each(f, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
 
         if (f->skip) {
             continue;
@@ -771,7 +773,7 @@ nxt_http_var_response_header(nxt_task_t *task, nxt_str_t *str, void *ctx,
             return NXT_OK;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     nxt_str_null(str);
 

--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -143,7 +143,7 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
          * nxt_list_add() hands out non-zeroed memory: garbage skip/hopbyhop
          * bits make the peer/app serializers randomly drop the field.
          */
-        f = nxt_list_zero_add(r->fields);
+        f = nxt_http_req_field_zero_add(r);
         if (nxt_slow_path(f == NULL)) {
             return;
         }
@@ -166,7 +166,7 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
                                        &traceparent_name, &traceparent);
     }
 
-    f = nxt_list_zero_add(r->resp.fields);
+    f = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
     if (nxt_slow_path(f == NULL)) {
         nxt_log(task, NXT_LOG_ERR,
                 "couldn't allocate traceparent header in response");
@@ -376,7 +376,7 @@ nxt_otel_drop_tracestate(nxt_http_request_t *r)
 
     nxt_str_null(&r->otel->trace_state);
 
-    nxt_list_each(f, r->fields) {
+    nxt_http_fields_each(f, r->inline_fields, r->num_inline_fields, r->fields) {
 
         if (f->name_length == nxt_length("tracestate")
             && nxt_memcasecmp(f->name, "tracestate",
@@ -385,11 +385,13 @@ nxt_otel_drop_tracestate(nxt_http_request_t *r)
             f->skip = 1;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     /* the echo copies nxt_otel_parse_tracestate() already appended */
 
-    nxt_list_each(f, r->resp.fields) {
+    nxt_http_fields_each(f, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
 
         if (f->name_length == nxt_length("tracestate")
             && nxt_memcasecmp(f->name, "tracestate",
@@ -398,7 +400,7 @@ nxt_otel_drop_tracestate(nxt_http_request_t *r)
             f->skip = 1;
         }
 
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 }
 
 
@@ -637,7 +639,7 @@ nxt_otel_parse_tracestate(void *ctx, nxt_http_field_t *field, uintptr_t data)
      * to the peer in the response below.
      */
 
-    f = nxt_list_add(r->resp.fields);
+    f = nxt_http_resp_field_add(&r->resp, r->mem_pool);
     if (nxt_fast_path(f != NULL)) {
         *f = *field;
     }

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4343,7 +4343,7 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
                 continue;
             }
 
-            field = nxt_list_add(r->resp.fields);
+            field = nxt_http_resp_field_add(&r->resp, r->mem_pool);
 
             if (nxt_slow_path(field == NULL)) {
                 goto fail;
@@ -4369,7 +4369,13 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
                       (size_t) field->value_length, field->value);
 
             if (field->skip) {
-                r->resp.fields->last->nelts--;
+                if (r->resp.num_inline_fields > 0
+                    && field == &r->resp.inline_fields[r->resp.num_inline_fields - 1])
+                {
+                    r->resp.num_inline_fields--;
+                } else if (r->resp.fields != NULL && r->resp.fields->last != NULL) {
+                    r->resp.fields->last->nelts--;
+                }
             }
         }
 
@@ -5546,56 +5552,7 @@ nxt_router_app_prepare_request(nxt_task_t *task,
 }
 
 
-struct nxt_fields_iter_s {
-    nxt_list_part_t   *part;
-    nxt_http_field_t  *field;
-};
 
-typedef struct nxt_fields_iter_s  nxt_fields_iter_t;
-
-
-static nxt_http_field_t *
-nxt_fields_part_first(nxt_list_part_t *part, nxt_fields_iter_t *i)
-{
-    if (part == NULL) {
-        return NULL;
-    }
-
-    while (part->nelts == 0) {
-        part = part->next;
-        if (part == NULL) {
-            return NULL;
-        }
-    }
-
-    i->part = part;
-    i->field = nxt_list_data(i->part);
-
-    return i->field;
-}
-
-
-static nxt_http_field_t *
-nxt_fields_first(nxt_list_t *fields, nxt_fields_iter_t *i)
-{
-    return nxt_fields_part_first(nxt_list_part(fields), i);
-}
-
-
-static nxt_http_field_t *
-nxt_fields_next(nxt_fields_iter_t *i)
-{
-    nxt_http_field_t  *end = nxt_list_data(i->part);
-
-    end += i->part->nelts;
-    i->field++;
-
-    if (i->field < end) {
-        return i->field;
-    }
-
-    return nxt_fields_part_first(i->part->next, i);
-}
 
 
 static nxt_buf_t *
@@ -5607,11 +5564,11 @@ nxt_router_prepare_msg(nxt_task_t *task, nxt_http_request_t *r,
     size_t              fields_count, req_size, size, free_size;
     size_t              copy_size;
     nxt_off_t           content_length;
-    nxt_buf_t           *b, *buf, *out, **tail;
-    nxt_http_field_t    *field, *dup;
-    nxt_unit_field_t    *dst_field;
-    nxt_fields_iter_t   iter, dup_iter;
-    nxt_unit_request_t  *req;
+    nxt_buf_t               *b, *buf, *out, **tail;
+    nxt_http_field_t        *field, *dup;
+    nxt_unit_field_t        *dst_field;
+    nxt_http_fields_iter_t  iter, dup_iter;
+    nxt_unit_request_t      *req;
 
     req_size = sizeof(nxt_unit_request_t)
                + r->method->length + 1
@@ -5626,12 +5583,14 @@ nxt_router_prepare_msg(nxt_task_t *task, nxt_http_request_t *r,
     content_length = r->content_length_n < 0 ? 0 : r->content_length_n;
     fields_count = 0;
 
-    nxt_list_each(field, r->fields) {
+    nxt_http_fields_each(field, r->inline_fields, r->num_inline_fields,
+                         r->fields)
+    {
         fields_count++;
 
         req_size += field->name_length + prefix->length + 1
                     + field->value_length + 1;
-    } nxt_list_loop;
+    } nxt_http_fields_loop;
 
     req_size += fields_count * sizeof(nxt_unit_field_t);
 
@@ -5728,9 +5687,10 @@ nxt_router_prepare_msg(nxt_task_t *task, nxt_http_request_t *r,
 
     dst_field = req->fields;
 
-    for (field = nxt_fields_first(r->fields, &iter);
+    for (field = nxt_http_fields_first(&iter, r->inline_fields,
+                                       r->num_inline_fields, r->fields);
          field != NULL;
-         field = nxt_fields_next(&iter))
+         field = nxt_http_fields_next(&iter))
     {
         if (field->skip) {
             continue;
@@ -5793,9 +5753,9 @@ nxt_router_prepare_msg(nxt_task_t *task, nxt_http_request_t *r,
         if (prefix->length != 0) {
             dup_iter = iter;
 
-            for (dup = nxt_fields_next(&dup_iter);
+            for (dup = nxt_http_fields_next(&dup_iter);
                  dup != NULL;
-                 dup = nxt_fields_next(&dup_iter))
+                 dup = nxt_http_fields_next(&dup_iter))
             {
                 if (dup->name_length != field->name_length
                     || dup->skip

--- a/src/test/nxt_http_parse_test.c
+++ b/src/test/nxt_http_parse_test.c
@@ -29,10 +29,23 @@ typedef struct {
 } nxt_http_parse_test_fields_t;
 
 
+typedef struct {
+    nxt_str_t  name;
+    nxt_str_t  value;
+} nxt_http_test_field_t;
+
+
+typedef struct {
+    nxt_uint_t                   count;
+    const nxt_http_test_field_t  *fields;
+} nxt_http_parse_test_headers_t;
+
+
 typedef union {
     void                                *pointer;
     nxt_http_parse_test_fields_t        fields;
     nxt_http_parse_test_request_line_t  request_line;
+    nxt_http_parse_test_headers_t       headers;
 } nxt_http_parse_test_data_t;
 
 
@@ -56,6 +69,104 @@ static nxt_int_t nxt_http_parse_test_request_line(nxt_http_request_parse_t *rp,
     nxt_str_t *request, nxt_log_t *log);
 static nxt_int_t nxt_http_parse_test_fields(nxt_http_request_parse_t *rp,
     nxt_http_parse_test_data_t *data, nxt_str_t *request, nxt_log_t *log);
+static nxt_int_t nxt_http_parse_test_headers(nxt_http_request_parse_t *rp,
+    nxt_http_parse_test_data_t *data, nxt_str_t *request, nxt_log_t *log);
+
+
+static const nxt_http_test_field_t  nxt_http_test_headers_8[] = {
+    { nxt_string("Host"), nxt_string("example.com") },
+    { nxt_string("User-Agent"), nxt_string("UnitTester/1.0") },
+    { nxt_string("Accept"), nxt_string("text/html,application/xhtml+xml") },
+    { nxt_string("Accept-Language"), nxt_string("en-US,en;q=0.9") },
+    { nxt_string("Accept-Encoding"), nxt_string("gzip, deflate") },
+    { nxt_string("Connection"), nxt_string("keep-alive") },
+    { nxt_string("X-Custom-Header-7"), nxt_string("CustomValue7") },
+    { nxt_string("X-Custom-Header-8"), nxt_string("CustomValue8") },
+};
+
+
+static const nxt_http_test_field_t  nxt_http_test_headers_16[] = {
+    { nxt_string("Host"), nxt_string("example.com") },
+    { nxt_string("User-Agent"), nxt_string("UnitTester/1.0") },
+    { nxt_string("Accept"), nxt_string("*/*") },
+    { nxt_string("Accept-Language"), nxt_string("en-US") },
+    { nxt_string("Accept-Encoding"), nxt_string("gzip") },
+    { nxt_string("Connection"), nxt_string("keep-alive") },
+    { nxt_string("Cache-Control"), nxt_string("no-cache") },
+    { nxt_string("Pragma"), nxt_string("no-cache") },
+    { nxt_string("Header-09"), nxt_string("Val-09") },
+    { nxt_string("Header-10"), nxt_string("Val-10") },
+    { nxt_string("Header-11"), nxt_string("Val-11") },
+    { nxt_string("Header-12"), nxt_string("Val-12") },
+    { nxt_string("Header-13"), nxt_string("Val-13") },
+    { nxt_string("Header-14"), nxt_string("Val-14") },
+    { nxt_string("Header-15"), nxt_string("Val-15") },
+    { nxt_string("Header-16"), nxt_string("Val-16") },
+};
+
+
+static const nxt_http_test_field_t  nxt_http_test_headers_24[] = {
+    { nxt_string("Host"), nxt_string("example.com") },
+    { nxt_string("User-Agent"), nxt_string("UnitTester/1.0") },
+    { nxt_string("Accept"), nxt_string("*/*") },
+    { nxt_string("Accept-Language"), nxt_string("en-US") },
+    { nxt_string("Accept-Encoding"), nxt_string("gzip") },
+    { nxt_string("Connection"), nxt_string("keep-alive") },
+    { nxt_string("Cache-Control"), nxt_string("no-cache") },
+    { nxt_string("Pragma"), nxt_string("no-cache") },
+    { nxt_string("Header-09"), nxt_string("Val-09") },
+    { nxt_string("Header-10"), nxt_string("Val-10") },
+    { nxt_string("Header-11"), nxt_string("Val-11") },
+    { nxt_string("Header-12"), nxt_string("Val-12") },
+    { nxt_string("Header-13"), nxt_string("Val-13") },
+    { nxt_string("Header-14"), nxt_string("Val-14") },
+    { nxt_string("Header-15"), nxt_string("Val-15") },
+    { nxt_string("Header-16"), nxt_string("Val-16") },
+    { nxt_string("X-Empty-Value"), nxt_string("") },
+    { nxt_string("X-Spaced-Value"), nxt_string("padded-value") },
+    { nxt_string("X-Special_Chars.123"), nxt_string("special#val") },
+    { nxt_string("X-Repeated-Name"), nxt_string("first") },
+    { nxt_string("X-Repeated-Name"), nxt_string("second") },
+    { nxt_string("Header-22"), nxt_string("Val-22") },
+    { nxt_string("Header-23"), nxt_string("Val-23") },
+    { nxt_string("Header-24"), nxt_string("Val-24") },
+};
+
+
+static const nxt_http_test_field_t  nxt_http_test_headers_32[] = {
+    { nxt_string("H-01"), nxt_string("v-01") },
+    { nxt_string("H-02"), nxt_string("v-02") },
+    { nxt_string("H-03"), nxt_string("v-03") },
+    { nxt_string("H-04"), nxt_string("v-04") },
+    { nxt_string("H-05"), nxt_string("v-05") },
+    { nxt_string("H-06"), nxt_string("v-06") },
+    { nxt_string("H-07"), nxt_string("v-07") },
+    { nxt_string("H-08"), nxt_string("v-08") },
+    { nxt_string("H-09"), nxt_string("v-09") },
+    { nxt_string("H-10"), nxt_string("v-10") },
+    { nxt_string("H-11"), nxt_string("v-11") },
+    { nxt_string("H-12"), nxt_string("v-12") },
+    { nxt_string("H-13"), nxt_string("v-13") },
+    { nxt_string("H-14"), nxt_string("v-14") },
+    { nxt_string("H-15"), nxt_string("v-15") },
+    { nxt_string("H-16"), nxt_string("v-16") },
+    { nxt_string("H-17"), nxt_string("v-17") },
+    { nxt_string("H-18"), nxt_string("v-18") },
+    { nxt_string("H-19"), nxt_string("v-19") },
+    { nxt_string("H-20"), nxt_string("v-20") },
+    { nxt_string("H-21"), nxt_string("v-21") },
+    { nxt_string("H-22"), nxt_string("v-22") },
+    { nxt_string("H-23"), nxt_string("v-23") },
+    { nxt_string("H-24"), nxt_string("v-24") },
+    { nxt_string("H-25"), nxt_string("v-25") },
+    { nxt_string("H-26"), nxt_string("v-26") },
+    { nxt_string("H-27"), nxt_string("v-27") },
+    { nxt_string("H-28"), nxt_string("v-28") },
+    { nxt_string("H-29"), nxt_string("v-29") },
+    { nxt_string("H-30"), nxt_string("v-30") },
+    { nxt_string("H-31"), nxt_string("v-31") },
+    { nxt_string("H-32"), nxt_string("v-32") },
+};
 
 
 static nxt_int_t nxt_http_test_header_return(void *ctx, nxt_http_field_t *field,
@@ -351,6 +462,96 @@ static nxt_http_parse_test_case_t  nxt_http_test_cases[] = {
         NXT_DONE,
         &nxt_http_parse_test_fields,
         { .fields = { NXT_ERROR, 0 } }
+    },
+    {
+        nxt_string("GET /test-0-headers HTTP/1.1\r\n\r\n"),
+        NXT_DONE,
+        &nxt_http_parse_test_headers,
+        { .headers = { 0, NULL } }
+    },
+    {
+        nxt_string("GET /test-8-headers HTTP/1.1\r\n"
+                   "Host: example.com\r\n"
+                   "User-Agent: UnitTester/1.0\r\n"
+                   "Accept: text/html,application/xhtml+xml\r\n"
+                   "Accept-Language: en-US,en;q=0.9\r\n"
+                   "Accept-Encoding: gzip, deflate\r\n"
+                   "Connection: keep-alive\r\n"
+                   "X-Custom-Header-7: CustomValue7\r\n"
+                   "X-Custom-Header-8: CustomValue8\r\n"
+                   "\r\n"),
+        NXT_DONE,
+        &nxt_http_parse_test_headers,
+        { .headers = { 8, nxt_http_test_headers_8 } }
+    },
+    {
+        nxt_string("GET /test-16-headers HTTP/1.1\r\n"
+                   "Host: example.com\r\n"
+                   "User-Agent: UnitTester/1.0\r\n"
+                   "Accept: */*\r\n"
+                   "Accept-Language: en-US\r\n"
+                   "Accept-Encoding: gzip\r\n"
+                   "Connection: keep-alive\r\n"
+                   "Cache-Control: no-cache\r\n"
+                   "Pragma: no-cache\r\n"
+                   "Header-09: Val-09\r\n"
+                   "Header-10: Val-10\r\n"
+                   "Header-11: Val-11\r\n"
+                   "Header-12: Val-12\r\n"
+                   "Header-13: Val-13\r\n"
+                   "Header-14: Val-14\r\n"
+                   "Header-15: Val-15\r\n"
+                   "Header-16: Val-16\r\n"
+                   "\r\n"),
+        NXT_DONE,
+        &nxt_http_parse_test_headers,
+        { .headers = { 16, nxt_http_test_headers_16 } }
+    },
+    {
+        nxt_string("GET /test-24-headers HTTP/1.1\r\n"
+                   "Host: example.com\r\n"
+                   "User-Agent: UnitTester/1.0\r\n"
+                   "Accept: */*\r\n"
+                   "Accept-Language: en-US\r\n"
+                   "Accept-Encoding: gzip\r\n"
+                   "Connection: keep-alive\r\n"
+                   "Cache-Control: no-cache\r\n"
+                   "Pragma: no-cache\r\n"
+                   "Header-09: Val-09\r\n"
+                   "Header-10: Val-10\r\n"
+                   "Header-11: Val-11\r\n"
+                   "Header-12: Val-12\r\n"
+                   "Header-13: Val-13\r\n"
+                   "Header-14: Val-14\r\n"
+                   "Header-15: Val-15\r\n"
+                   "Header-16: Val-16\r\n"
+                   "X-Empty-Value:\r\n"
+                   "X-Spaced-Value:   padded-value  \r\n"
+                   "X-Special_Chars.123: special#val\r\n"
+                   "X-Repeated-Name: first\r\n"
+                   "X-Repeated-Name: second\r\n"
+                   "Header-22: Val-22\r\n"
+                   "Header-23: Val-23\r\n"
+                   "Header-24: Val-24\r\n"
+                   "\r\n"),
+        NXT_DONE,
+        &nxt_http_parse_test_headers,
+        { .headers = { 24, nxt_http_test_headers_24 } }
+    },
+    {
+        nxt_string("GET /test-32-headers HTTP/1.1\r\n"
+                   "H-01: v-01\r\n" "H-02: v-02\r\n" "H-03: v-03\r\n" "H-04: v-04\r\n"
+                   "H-05: v-05\r\n" "H-06: v-06\r\n" "H-07: v-07\r\n" "H-08: v-08\r\n"
+                   "H-09: v-09\r\n" "H-10: v-10\r\n" "H-11: v-11\r\n" "H-12: v-12\r\n"
+                   "H-13: v-13\r\n" "H-14: v-14\r\n" "H-15: v-15\r\n" "H-16: v-16\r\n"
+                   "H-17: v-17\r\n" "H-18: v-18\r\n" "H-19: v-19\r\n" "H-20: v-20\r\n"
+                   "H-21: v-21\r\n" "H-22: v-22\r\n" "H-23: v-23\r\n" "H-24: v-24\r\n"
+                   "H-25: v-25\r\n" "H-26: v-26\r\n" "H-27: v-27\r\n" "H-28: v-28\r\n"
+                   "H-29: v-29\r\n" "H-30: v-30\r\n" "H-31: v-31\r\n" "H-32: v-32\r\n"
+                   "\r\n"),
+        NXT_DONE,
+        &nxt_http_parse_test_headers,
+        { .headers = { 32, nxt_http_test_headers_32 } }
     },
 };
 
@@ -690,7 +891,9 @@ nxt_http_parse_test_bench(nxt_thread_t *thr, nxt_str_t *request,
             return NXT_ERROR;
         }
 
-        if (nxt_slow_path(nxt_http_fields_process(rp.fields, hash, NULL)
+        if (nxt_slow_path(nxt_http_fields_process(rp.inline_fields,
+                                                  rp.num_inline_fields,
+                                                  rp.fields, hash, NULL)
                           != NXT_OK))
         {
             nxt_log_alert(thr->log, "http parse %s request bench failed "
@@ -798,7 +1001,8 @@ nxt_http_parse_test_fields(nxt_http_request_parse_t *rp,
 {
     nxt_int_t  rc;
 
-    rc = nxt_http_fields_process(rp->fields, &nxt_http_test_fields_hash, NULL);
+    rc = nxt_http_fields_process(rp->inline_fields, rp->num_inline_fields,
+                                 rp->fields, &nxt_http_test_fields_hash, NULL);
 
     if (rc != data->fields.result) {
         nxt_log_alert(log, "http parse test hash failed:\n"
@@ -816,4 +1020,86 @@ static nxt_int_t
 nxt_http_test_header_return(void *ctx, nxt_http_field_t *field, uintptr_t data)
 {
     return data;
+}
+
+
+static nxt_int_t
+nxt_http_parse_test_headers(nxt_http_request_parse_t *rp,
+    nxt_http_parse_test_data_t *data, nxt_str_t *request, nxt_log_t *log)
+{
+    nxt_uint_t                      i, nelts;
+    nxt_http_field_t                *field;
+    nxt_http_parse_test_headers_t  *expected;
+
+    expected = &data->headers;
+
+    /*
+     * Headers are stored inline (first 16) with any overflow spilling into
+     * the rp->fields list, so the total count is the sum of both and the
+     * only valid traversal is nxt_http_fields_each().
+     */
+    nelts = rp->num_inline_fields;
+    if (rp->fields != NULL) {
+        nelts += nxt_list_nelts(rp->fields);
+    }
+
+    if (nelts != expected->count) {
+        nxt_log_alert(log, "http parse headers test failed (count mismatch):\n"
+                           " - request:\n\"%V\"\n"
+                           " - count: %ui (expected: %ui)",
+                           request, nelts, expected->count);
+        return NXT_ERROR;
+    }
+
+    i = 0;
+    nxt_http_fields_each(field, rp->inline_fields, rp->num_inline_fields,
+                         rp->fields)
+    {
+        if (i >= expected->count) {
+            nxt_log_alert(log, "http parse headers test failed:\n"
+                               " - iterated beyond count %ui",
+                               expected->count);
+            return NXT_ERROR;
+        }
+
+        if (field->name_length != expected->fields[i].name.length
+            || memcmp(field->name, expected->fields[i].name.start,
+                      field->name_length) != 0)
+        {
+            nxt_log_alert(log, "http parse header name mismatch at [%ui]:\n"
+                               " - request:\n\"%V\"\n"
+                               " - got: \"%*s\" (expected: \"%V\")",
+                               i, request, (size_t) field->name_length,
+                               field->name, &expected->fields[i].name);
+            return NXT_ERROR;
+        }
+
+        if (field->value_length != expected->fields[i].value.length
+            || memcmp(field->value, expected->fields[i].value.start,
+                      field->value_length) != 0)
+        {
+            nxt_log_alert(log, "http parse header value mismatch at [%ui]:\n"
+                               " - request:\n\"%V\"\n"
+                               " - got: \"%*s\" (expected: \"%V\")",
+                               i, request, (size_t) field->value_length,
+                               field->value, &expected->fields[i].value);
+            return NXT_ERROR;
+        }
+
+        if (field->hash == 0 && field->name_length > 0) {
+            nxt_log_alert(log, "http parse header hash is 0 at [%ui]", i);
+            return NXT_ERROR;
+        }
+
+        i++;
+    } nxt_http_fields_loop;
+
+    if (i != expected->count) {
+        nxt_log_alert(log, "http parse headers test failed:\n"
+                           " - iteration count: %ui (expected: %ui)",
+                           i, expected->count);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
 }

--- a/test/test_http_header.py
+++ b/test/test_http_header.py
@@ -499,3 +499,53 @@ def test_http_discard_unsafe_fields():
 
     resp = check_status("Custom_Header")
     assert 'CUSTOM' not in resp['headers']['All-Headers']
+
+
+def test_http_header_fields_inline_spill():
+    # The parser stores the first 16 header fields inline and spills any
+    # further fields into a list; every field must still reach the
+    # application regardless of where it lands.  Exercise counts below, at,
+    # and well past the 16-field boundary.
+    client.load('header_fields')
+
+    for count in [1, 15, 16, 17, 32, 48]:
+        headers = {'Host': 'localhost', 'Connection': 'close'}
+        for i in range(count):
+            headers[f'X-Test-{i}'] = str(i)
+
+        resp = client.get(headers=headers)
+
+        assert resp['status'] == 200, f'{count} headers status'
+
+        got = resp['headers']['All-Headers']
+        for i in range(count):
+            assert f'HTTP_X_TEST_{i}' in got, f'field {i} of {count} present'
+
+
+def test_http_header_fields_keepalive_spill():
+    # The parser struct is reused across keep-alive requests (num_inline_fields
+    # is reset per request).  Vary the header count on the same connection --
+    # inline-only, spilled past 16, then back below the boundary -- and confirm
+    # each request's fields are all delivered, so a stale count from the
+    # previous request cannot corrupt the next one.
+    client.load('header_fields')
+
+    sock = None
+    for count in [3, 20, 5, 32]:
+        headers = {'Host': 'localhost', 'Connection': 'keep-alive'}
+        for i in range(count):
+            headers[f'X-Test-{i}'] = str(i)
+
+        kwargs = {'headers': headers, 'start': True, 'read_timeout': 1}
+        if sock is not None:
+            kwargs['sock'] = sock
+
+        resp, sock = client.get(**kwargs)
+
+        assert resp['status'] == 200, f'{count}-header keep-alive status'
+
+        got = resp['headers']['All-Headers']
+        for i in range(count):
+            assert f'HTTP_X_TEST_{i}' in got, f'keep-alive field {i} of {count}'
+
+    sock.close()

--- a/test/test_response_headers.py
+++ b/test/test_response_headers.py
@@ -234,3 +234,24 @@ def test_response_headers_var_control():
     assert resp['status'] == 200, 'request still served'
     assert 'Evil' not in resp['headers'], 'response header injection'
     assert 'X-Foo' not in resp['headers'], 'tainted value dropped'
+
+
+def test_response_headers_inline_spill(temp_dir):
+    # More than 16 response headers exercise the resp.inline_fields[16] -> list
+    # spill in the response field store; together with the static handler's own
+    # headers this is well past the 16-slot boundary, and all must reach the
+    # client.
+    headers = {f'X-Rh-{i}': str(i) for i in range(24)}
+
+    action_update(
+        {
+            'share': f'{temp_dir}/index.html',
+            'response_headers': headers,
+        }
+    )
+
+    resp = client.get()
+
+    assert resp['status'] == 200, 'spill status'
+    for i in range(24):
+        assert resp['headers'].get(f'X-Rh-{i}') == str(i), f'response header {i}'


### PR DESCRIPTION
## Summary

Splits the **inline_fields[16] header-storage refactor** out of the larger `perf/zero-alloc-h1-parser` branch ([andypost/unit#35](https://github.com/andypost/unit/pull/35)) as a self-contained change, carrying **none** of that branch's pool/buffer/connection recycling (which had several memory-safety bugs).

Each HTTP request and response now stores its first 16 header fields in an embedded `inline_fields[16]` array on `nxt_http_request_t` / `nxt_http_response_t` (and `nxt_http_peer_t`), spilling into the existing `nxt_list_t` only past 16. This eliminates the per-message `nxt_list_create()` heap allocation that every request and response previously paid for its header list — the common case (≤16 headers) needs no separate allocation.

## How it works

- The parser fills `inline_fields` first and lazily creates the list on overflow, so `r->fields` / `r->resp.fields` start `NULL`.
- New inline-aware accessors in `nxt_http.h` / `nxt_http_parse.h`:
  - `nxt_http_fields_each()` / `nxt_http_fields_first()`/`_next()` — traverse the inline array then the list.
  - `nxt_http_{req,resp}_field_add()` / `_zero_add()` — append into the inline array, spilling to the list past 16.
- Every field reader/writer is converted across the H1 protocol, router, proxy, static, otel, variables, routing, set-headers, compression, error, return, controller and js paths.

## Scope

- **Only** the header-storage refactor. No `nxt_mp_reset`, no keep-alive pool recycling, no buffer-descriptor or connection freelists, no var scratchpad — those files (`nxt_conn.*`, `nxt_var.*`, `nxt_mp.*`, `nxt_event_engine.h`) are untouched.

## Testing

Built and tested locally under AddressSanitizer + UBSan (matching the `sanitize` CI leg):

- `test/test_php_application.py`, `test/test_static.py`, `test/test_routing.py`, `test/test_http_header.py` — **65 passed, 0 sanitizer reports**, including keep-alive.
- `./build/tests` (C unit tests incl. the new parser header suite) — clean under gcc and clang.
- The added parser test exercises 0–32 headers, covering the inline→list spill boundary at 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
