### PR TITLE
test: stabilize flaky test_tls_session_timeout

### DIFF
--- a/test/test_tls_session.py
+++ b/test/test_tls_session.py
@@ -119,7 +119,11 @@ def test_tls_session():
     reason='session reuse is not supported',
 )
 def test_tls_session_timeout():
-    assert 'success' in add_session(cache_size=5, timeout=1)
+    # OpenSSL evaluates session expiry in whole seconds (time_t), so a 1s
+    # timeout leaves barely over one second of real slack for the resume
+    # below and evicts the session early under CI load, making the "no
+    # timeout" assertion flaky.  Use a comfortable window and sleep past it.
+    assert 'success' in add_session(cache_size=5, timeout=4)
 
     _, sess, ctx, reused = connect()
     assert not reused, 'new connection'
@@ -127,7 +131,7 @@ def test_tls_session_timeout():
     _, _, _, reused = connect(ctx, sess)
     assert reused, 'no timeout'
 
-    time.sleep(3)
+    time.sleep(6)
 
     _, _, _, reused = connect(ctx, sess)
     assert not reused, 'timeout'


### PR DESCRIPTION
## Problem

`test_tls_session.py::test_tls_session_timeout` fails intermittently on loaded CI runners:

```
>       assert reused, 'no timeout'
E       AssertionError: no timeout
test/test_tls_session.py:128: AssertionError
```

## Root cause — a 1-second TTL racing integer-second expiry math

The test configures the server session cache with `timeout: 1`, caches a session with one handshake, then immediately reconnects and asserts the session is **resumed**.

OpenSSL stores a session's creation time and evaluates cache expiry in **whole seconds** (`time_t`): a cached session is evicted once

```
floor(now) - floor(created) > timeout
```

With `timeout = 1`, the two floored timestamps can already differ by **2** after only **~1.01 s** of real time (created at wall-clock `100.99` → floor `100`; checked at `102.00` → floor `102`; `102 - 100 = 2 > 1` → expired).

Between caching the session and the resume attempt the test does real work — `get_session()`, socket shutdown, a fresh `create_connection`, and a **full TLS handshake**. On an idle box that's milliseconds; on a busy CI runner (the whole matrix runs concurrently, OpenSSL 3.6 built from source) it can cross the integer-second boundary, so the session is already gone → `reused == 0` → flake.

## Fix

- Widen the cache TTL to **4 s** — ample headroom for the immediate resume even under load.
- Raise the post-expiry `sleep` to **6 s** so it still exceeds the TTL and exercises the eviction path (`assert not reused`).

A single session config is kept on purpose: re-applying the `tls/session` config rebuilds the TLS context and clears the cache, which would make the expiry assertion pass for the *wrong* reason (cache cleared, not TTL expired).

Pure test-timing change — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)