### PR TITLE
var: inline 8-element scratchpad in nxt_var_cache_t (zero-alloc routing vars)

### DIFF
--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -219,9 +219,15 @@ nxt_var_cache_value(nxt_task_t *task, nxt_tstr_state_t *state,
     value = cache->spare;
 
     if (value == NULL) {
-        value = nxt_mp_zget(cache->pool, sizeof(nxt_str_t));
-        if (nxt_slow_path(value == NULL)) {
-            return NULL;
+        if (cache->num_inline_values < nxt_nitems(cache->inline_values)) {
+            value = &cache->inline_values[cache->num_inline_values++];
+            nxt_memzero(value, sizeof(nxt_str_t));
+
+        } else {
+            value = nxt_mp_zget(cache->pool, sizeof(nxt_str_t));
+            if (nxt_slow_path(value == NULL)) {
+                return NULL;
+            }
         }
 
         cache->spare = value;

--- a/src/nxt_var.h
+++ b/src/nxt_var.h
@@ -43,6 +43,8 @@ typedef struct {
     nxt_mp_t                *pool;
     nxt_lvlhsh_t            hash;
     nxt_str_t               *spare;
+    nxt_str_t               inline_values[8];
+    uint8_t                 num_inline_values;
 } nxt_var_cache_t;
 
 


### PR DESCRIPTION
## Summary

Adds an inline 8-element scratchpad to `nxt_var_cache_t` so the common case of
routing variable resolution avoids per-value `nxt_mp_zget` calls.

Split out of the zero-alloc HTTP work (andypost#35), rebased onto current
master after freeunit#149 (inline_fields) merged. Independent of the other
split PRs — touches only `src/nxt_var.c` / `src/nxt_var.h`.

## What it does

`nxt_var_cache_value()` allocated an `nxt_str_t` from the request pool for every
distinct variable resolved during routing. This carves the first 8 values from
an `inline_values[8]` array embedded directly in `nxt_var_cache_t`, falling back
to `nxt_mp_zget` from the 9th value onward. The array lives inside the cache,
which is embedded in `nxt_http_request_t` (allocated with `nxt_mp_zget`, so it
is zero-initialized for free), and shares the request pool's lifetime — so no
pointer stored in the variable hash can outlive its backing storage.

## Verification

- Full C test suite (`./build/tests`) passes.
- Reviewed lifetimes: the scratchpad equals the `nxt_var_cache_t`/request-pool
  lifetime; the 8-slot bound is off-by-one-free (`< 8`, post-increment writes
  index 0..7); inline and heap branches produce an identically sized/zeroed
  `nxt_str_t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
