### PR TITLE
conn: thread-local connection struct freelist recycler

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -64,8 +64,12 @@ jobs:
             # unitd master and self-skips without it.  It also makes conftest
             # rmtree the temp dir on teardown, which is fine for these tests.
             pytest_opts: "--restart"
-            # test_static is module-free; the graceful/listener drivers need
-            # the python module, so the shared teardown coverage lives here.
+            # test_static and test_conn_recycle are module-free; the
+            # graceful/listener drivers need the python module, so the shared
+            # teardown coverage lives here.  test_conn_recycle exercises the
+            # connection-struct freelist recycler under ASan (recycle churn +
+            # engine teardown at listen_threads reconfig).
+            #
             # test_conn_task_race drives a send-timeout mid-stream RST abort
             # straddling keep-alive reuse (freeunit#156): pre-fix a deferred
             # conn write item dereferenced a freed request-pool task, which
@@ -91,6 +95,7 @@ jobs:
               test/test_conn_task_race.py
               test/test_proxy.py
               test/test_chunked.py
+              test/test_conn_recycle.py
           - runtime: php
             apt: ""
             configure: php

--- a/src/nxt_conn.c
+++ b/src/nxt_conn.c
@@ -154,12 +154,77 @@ nxt_conn_free(nxt_task_t *task, nxt_conn_t *c)
     nxt_assert(c->task.thread == task->thread);
 
     if (engine->mem_pool != NULL) {
-        c->next = engine->free_connections;
-        engine->free_connections = c;
+        /*
+         * Take both timers out of the engine's timer machinery.  Callers only
+         * ever nxt_timer_disable() them, which clears the enabled bit but
+         * leaves the node in the engine's rbtree -- re-zeroing the struct on
+         * reuse would then corrupt that tree.  nxt_timer_delete() removes it,
+         * but the removal can be deferred as a queued change, so quiescence is
+         * rechecked in nxt_conn_recycle_pending() before the struct is handed
+         * out again.
+         */
+        nxt_timer_delete(engine, &c->read_timer);
+        nxt_timer_delete(engine, &c->write_timer);
+
+        /*
+         * Park the struct rather than publishing it to the freelist directly.
+         * A conn can be freed while work items that reference it are still
+         * queued -- nxt_h1p_peer_close() sets block_read/block_write for
+         * exactly that reason, then reaches nxt_conn_free() synchronously on
+         * its fd == -1 path.  Handing the struct out now would let
+         * nxt_conn_create()'s re-zero clear those guards from under the queued
+         * item, which would then act on an unrelated live connection.
+         * nxt_conn_recycle_pending() promotes the struct only once the engine
+         * has drained every work queue, so no queued item can still reach it.
+         */
+        c->next = engine->pending_connections;
+        engine->pending_connections = c;
     }
 
     if (mp != NULL) {
         nxt_mp_release(mp);
+    }
+}
+
+
+nxt_inline nxt_bool_t
+nxt_conn_timer_quiescent(nxt_timer_t *timer)
+{
+    return !nxt_timer_is_in_tree(timer)
+           && !timer->queued
+           && timer->change == NXT_TIMER_NO_CHANGE;
+}
+
+
+/*
+ * Publish parked connection structs to the reusable freelist.  Called from the
+ * event engine once nxt_event_engine_queue_pop() reports every work queue
+ * empty: at that point no queued work item can reference any parked struct, so
+ * reuse cannot race a handler that is still to run.  A struct whose timers have
+ * not settled yet stays parked and is retried on a later cycle.
+ */
+
+void
+nxt_conn_recycle_pending(nxt_event_engine_t *engine)
+{
+    nxt_conn_t  *c, *next, **link;
+
+    link = &engine->pending_connections;
+
+    for (c = *link; c != NULL; c = next) {
+        next = c->next;
+
+        if (nxt_conn_timer_quiescent(&c->read_timer)
+            && nxt_conn_timer_quiescent(&c->write_timer))
+        {
+            *link = next;
+
+            c->next = engine->free_connections;
+            engine->free_connections = c;
+
+        } else {
+            link = &c->next;
+        }
     }
 }
 

--- a/src/nxt_conn.c
+++ b/src/nxt_conn.c
@@ -7,6 +7,13 @@
 #include <nxt_main.h>
 
 
+#if (NXT_DEBUG)
+static nxt_bool_t nxt_conn_is_parked(nxt_event_engine_t *engine,
+    nxt_conn_t *c);
+#endif
+static nxt_bool_t nxt_conn_timer_quiescent(nxt_timer_t *timer);
+
+
 nxt_conn_io_t  nxt_unix_conn_io = {
     .connect = nxt_conn_io_connect,
     .accept = nxt_conn_io_accept,
@@ -153,18 +160,31 @@ nxt_conn_free(nxt_task_t *task, nxt_conn_t *c)
 
     nxt_assert(c->task.thread == task->thread);
 
+    /*
+     * Take both timers out of the engine's timer machinery, and take the conn
+     * off whichever tracking queue it is on.  Callers only ever
+     * nxt_timer_disable() a timer, which clears the enabled bit but leaves the
+     * node in the engine's rbtree, and they rely on nxt_conn_close_handler()
+     * having untracked the conn -- both leave a live node inside a struct that
+     * nxt_conn_create() re-zeroes on reuse, silently corrupting the rbtree or
+     * the idle/active queue and drifting their counters.  nxt_conn_untrack() is
+     * idempotent and nxt_timer_delete()'s removal can be deferred as a queued
+     * change, so quiescence is rechecked in nxt_conn_recycle_pending().
+     *
+     * Both run outside the recycling branch below: on the non-recycling path
+     * the struct dies with mp, so a node left in the rbtree or on a tracking
+     * queue would dangle into released memory rather than be re-zeroed -- the
+     * same defect with a worse failure mode.
+     */
+
+    nxt_assert(c->idle == NXT_CONN_TRACK_NONE);
+    nxt_conn_untrack(engine, c);
+
+    nxt_timer_delete(engine, &c->read_timer);
+    nxt_timer_delete(engine, &c->write_timer);
+
     if (engine->mem_pool != NULL) {
-        /*
-         * Take both timers out of the engine's timer machinery.  Callers only
-         * ever nxt_timer_disable() them, which clears the enabled bit but
-         * leaves the node in the engine's rbtree -- re-zeroing the struct on
-         * reuse would then corrupt that tree.  nxt_timer_delete() removes it,
-         * but the removal can be deferred as a queued change, so quiescence is
-         * rechecked in nxt_conn_recycle_pending() before the struct is handed
-         * out again.
-         */
-        nxt_timer_delete(engine, &c->read_timer);
-        nxt_timer_delete(engine, &c->write_timer);
+        nxt_assert(!nxt_conn_is_parked(engine, c));
 
         /*
          * Park the struct rather than publishing it to the freelist directly.
@@ -187,7 +207,7 @@ nxt_conn_free(nxt_task_t *task, nxt_conn_t *c)
 }
 
 
-nxt_inline nxt_bool_t
+static nxt_bool_t
 nxt_conn_timer_quiescent(nxt_timer_t *timer)
 {
     return !nxt_timer_is_in_tree(timer)
@@ -196,12 +216,41 @@ nxt_conn_timer_quiescent(nxt_timer_t *timer)
 }
 
 
+#if (NXT_DEBUG)
+
+/*
+ * A conn freed twice would appear on pending_connections twice; the promotion
+ * walk then splices it onto free_connections twice and the two lists end up
+ * aliasing, so distinct live connections can be handed the same struct.  Catch
+ * it at the source in debug builds rather than at the far-away symptom.
+ */
+
+static nxt_bool_t
+nxt_conn_is_parked(nxt_event_engine_t *engine, nxt_conn_t *c)
+{
+    nxt_conn_t  *p;
+
+    for (p = engine->pending_connections; p != NULL; p = p->next) {
+        if (p == c) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+#endif
+
+
 /*
  * Publish parked connection structs to the reusable freelist.  Called from the
- * event engine once nxt_event_engine_queue_pop() reports every work queue
- * empty: at that point no queued work item can reference any parked struct, so
- * reuse cannot race a handler that is still to run.  A struct whose timers have
- * not settled yet stays parked and is retried on a later cycle.
+ * event engine once nxt_event_engine_queue_pop() reports every engine-local
+ * work queue empty: at that point no queued work item can reference any parked
+ * struct, so reuse cannot race a handler that is still to run.  A struct whose
+ * timers have not settled yet stays parked and is retried on a later cycle.
+ *
+ * See nxt_event_engine_start() for why the cross-thread locked_work_queue is
+ * outside this barrier and why that is currently safe.
  */
 
 void

--- a/src/nxt_conn.c
+++ b/src/nxt_conn.c
@@ -45,9 +45,35 @@ nxt_conn_create(nxt_mp_t *mp, nxt_task_t *task)
     nxt_conn_t    *c;
     nxt_thread_t  *thr;
 
-    c = nxt_mp_zget(mp, sizeof(nxt_conn_t));
-    if (nxt_slow_path(c == NULL)) {
-        return NULL;
+    thr = nxt_thread();
+
+    /*
+     * The freelist only recycles connection structs backed by the persistent
+     * engine->mem_pool, so a recycled struct outlives every per-connection
+     * pool.  When engine->mem_pool is NULL (e.g. an OOM at engine setup) the
+     * struct is allocated from the per-connection pool mp and is therefore
+     * NOT recyclable; nxt_conn_free() must not push it onto the freelist.
+     */
+
+    if (thr->engine->mem_pool != NULL) {
+
+        if (thr->engine->free_connections != NULL) {
+            c = thr->engine->free_connections;
+            thr->engine->free_connections = c->next;
+            nxt_memzero(c, sizeof(nxt_conn_t));
+
+        } else {
+            c = nxt_mp_zget(thr->engine->mem_pool, sizeof(nxt_conn_t));
+            if (nxt_slow_path(c == NULL)) {
+                return NULL;
+            }
+        }
+
+    } else {
+        c = nxt_mp_zget(mp, sizeof(nxt_conn_t));
+        if (nxt_slow_path(c == NULL)) {
+            return NULL;
+        }
     }
 
     c->mem_pool = mp;
@@ -63,7 +89,6 @@ nxt_conn_create(nxt_mp_t *mp, nxt_task_t *task)
         c->log.ident = nxt_task_next_ident();
     }
 
-    thr = nxt_thread();
     thr->engine->connections++;
 
     c->task.thread = thr;
@@ -104,12 +129,38 @@ nxt_conn_create(nxt_mp_t *mp, nxt_task_t *task)
 void
 nxt_conn_free(nxt_task_t *task, nxt_conn_t *c)
 {
-    nxt_mp_t  *mp;
+    nxt_mp_t            *mp;
+    nxt_event_engine_t  *engine;
 
-    task->thread->engine->connections--;
+    engine = task->thread->engine;
+    engine->connections--;
 
     mp = c->mem_pool;
-    nxt_mp_release(mp);
+
+    /*
+     * Only recycle structs backed by the persistent engine->mem_pool.  A
+     * freelist entry must outlive every per-connection pool, so when
+     * engine->mem_pool is NULL the struct lives in mp (== c->mem_pool) and
+     * must die with it -- pushing it would leave a dangling pointer on the
+     * freelist once mp is released below.  In the recycled case the struct
+     * does not live in mp, so releasing mp does not free the pushed struct.
+     *
+     * A conn must be freed on the engine that created it: recycling a struct
+     * backed by another engine's mem_pool would dangle once that engine is
+     * torn down.  The pre-existing connections-- accounting already relies on
+     * this; assert it so the freelist can too.
+     */
+
+    nxt_assert(c->task.thread == task->thread);
+
+    if (engine->mem_pool != NULL) {
+        c->next = engine->free_connections;
+        engine->free_connections = c;
+    }
+
+    if (mp != NULL) {
+        nxt_mp_release(mp);
+    }
 }
 
 

--- a/src/nxt_conn.h
+++ b/src/nxt_conn.h
@@ -193,6 +193,7 @@ struct nxt_conn_s {
     uint8_t                       tcp_nodelay;  /* 1 bit */
 
     nxt_queue_link_t              link;
+    nxt_conn_t                    *next;
 };
 
 

--- a/src/nxt_conn.h
+++ b/src/nxt_conn.h
@@ -245,6 +245,7 @@ struct nxt_conn_s {
 
 NXT_EXPORT nxt_conn_t *nxt_conn_create(nxt_mp_t *mp, nxt_task_t *task);
 NXT_EXPORT void nxt_conn_free(nxt_task_t *task, nxt_conn_t *c);
+NXT_EXPORT void nxt_conn_recycle_pending(nxt_event_engine_t *engine);
 NXT_EXPORT void nxt_conn_close(nxt_event_engine_t *engine, nxt_conn_t *c);
 
 NXT_EXPORT void nxt_conn_timer(nxt_event_engine_t *engine, nxt_conn_t *c,

--- a/src/nxt_event_engine.c
+++ b/src/nxt_event_engine.c
@@ -548,9 +548,18 @@ nxt_event_engine_start(nxt_event_engine_t *engine)
 
             if (handler == NULL) {
                 /*
-                 * Every work queue is empty here, so no queued item can still
-                 * reference a connection struct freed during this drain.  This
-                 * is the only point at which parked structs become reusable.
+                 * Every engine-local work queue is empty here, so no queued
+                 * item can still reference a connection struct freed during
+                 * this drain.  This is the only point at which parked structs
+                 * become reusable.
+                 *
+                 * engine->locked_work_queue is deliberately not covered: it is
+                 * the cross-thread post queue, drained separately by
+                 * nxt_event_engine_post_handler() after poll, and reading its
+                 * head here would race its spinlock.  Nothing posted through
+                 * nxt_event_engine_post() carries an nxt_conn_t today, so the
+                 * barrier holds -- but a future post that does would need this
+                 * revisited rather than assumed covered.
                  */
                 nxt_conn_recycle_pending(engine);
                 break;

--- a/src/nxt_event_engine.c
+++ b/src/nxt_event_engine.c
@@ -547,6 +547,12 @@ nxt_event_engine_start(nxt_event_engine_t *engine)
             handler = nxt_event_engine_queue_pop(engine, &task, &obj, &data);
 
             if (handler == NULL) {
+                /*
+                 * Every work queue is empty here, so no queued item can still
+                 * reference a connection struct freed during this drain.  This
+                 * is the only point at which parked structs become reusable.
+                 */
+                nxt_conn_recycle_pending(engine);
                 break;
             }
 

--- a/src/nxt_event_engine.h
+++ b/src/nxt_event_engine.h
@@ -484,6 +484,8 @@ struct nxt_event_engine_s {
     nxt_queue_t                active_connections;
     nxt_array_t                *mem_cache;
 
+    nxt_conn_t                 *free_connections;
+
     nxt_atomic_uint_t          accepted_conns_cnt;
     nxt_atomic_uint_t          idle_conns_cnt;
     nxt_atomic_uint_t          active_conns_cnt;

--- a/src/nxt_event_engine.h
+++ b/src/nxt_event_engine.h
@@ -485,6 +485,7 @@ struct nxt_event_engine_s {
     nxt_array_t                *mem_cache;
 
     nxt_conn_t                 *free_connections;
+    nxt_conn_t                 *pending_connections;
 
     nxt_atomic_uint_t          accepted_conns_cnt;
     nxt_atomic_uint_t          idle_conns_cnt;

--- a/test/test_conn_recycle.py
+++ b/test/test_conn_recycle.py
@@ -1,0 +1,73 @@
+import socket
+from pathlib import Path
+
+import pytest
+
+from unit.applications.proto import ApplicationProto
+
+client = ApplicationProto()
+
+BODY = '0123456789'
+
+
+@pytest.fixture(autouse=True)
+def setup_method_fixture(temp_dir, skip_fds_check):
+    # Thread-count changes intentionally add and remove each engine's epoll,
+    # signalfd, and eventfd descriptors, so the generic router FD baseline is
+    # not meaningful for this test.  The recycler itself owns no descriptors.
+    skip_fds_check(router=True)
+
+    Path(f'{temp_dir}/assets').mkdir(parents=True)
+    Path(f'{temp_dir}/assets/index.html').write_text(BODY, encoding='utf-8')
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [{"action": {"share": f'{temp_dir}/assets$uri'}}],
+            "settings": {"listen_threads": 4},
+        }
+    )
+
+    yield
+
+    # The no-restart suite preserves /settings between tests.
+    assert 'success' in client.conf_delete('settings/listen_threads')
+
+
+def _churn(n):
+    # Each short-lived connection is a nxt_conn_create (freelist pop) +
+    # nxt_conn_free (freelist push) cycle; spread across the listen_threads
+    # engines this fills each engine's connection freelist.  A corrupted
+    # recycle returns a wrong/truncated body or, under the sanitizer, crashes
+    # the worker.
+    for i in range(n):
+        sock = socket.create_connection(('127.0.0.1', 8080))
+        sock.settimeout(5)
+        try:
+            sock.sendall(
+                b'GET / HTTP/1.1\r\nHost: localhost\r\n'
+                b'Connection: close\r\n\r\n'
+            )
+            data = b''
+            while BODY.encode() not in data:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+            assert BODY.encode() in data, f'body on connection {i}'
+        finally:
+            sock.close()
+
+
+def test_conn_recycle_across_thread_churn():
+    # Populate the per-engine connection freelists.
+    _churn(120)
+
+    # Lowering listen_threads destroys worker engines, freeing their populated
+    # connection freelists (engine->mem_pool teardown); raising it recreates
+    # them.  Repeat so structs are recycled, then torn down with the engine.
+    for _ in range(2):
+        assert 'success' in client.conf('1', 'settings/listen_threads')
+        _churn(60)
+        assert 'success' in client.conf('4', 'settings/listen_threads')
+        _churn(60)

--- a/test/test_conn_recycle.py
+++ b/test/test_conn_recycle.py
@@ -1,9 +1,11 @@
 import socket
+import time
 from pathlib import Path
 
 import pytest
 
 from unit.applications.proto import ApplicationProto
+from unit.status import Status
 
 client = ApplicationProto()
 
@@ -59,6 +61,33 @@ def _churn(n):
             sock.close()
 
 
+def _wait_conns(expected, timeout=100):
+    # A client-observed EOF is not a server-side barrier.  nxt_conn_close()
+    # enqueues nxt_conn_shutdown_handler(), which performs the SHUT_RDWR the
+    # client sees as EOF and only then enqueues nxt_conn_close_handler() on
+    # the engine's close_work_queue; nxt_conn_untrack(), which moves a
+    # connection out of the active/idle queues and into closed_conns_cnt,
+    # runs in that later handler (src/nxt_conn_close.c).  So the last
+    # connection of a churn can still be counted active after the client has
+    # read the whole body and closed -- reading through to EOF does not fix
+    # this, it only narrows the window.
+    #
+    # Poll rather than sleep: the close queue drains immediately in the
+    # common case, while a fixed delay would be dead time on every run and
+    # still too short under the sanitizer.  Return the last reading either
+    # way, so that a real accounting bug fails as the counter mismatch it is
+    # rather than as an opaque timeout.
+    for _ in range(timeout):
+        conns = Status.get('/connections')
+
+        if conns == expected:
+            break
+
+        time.sleep(0.1)
+
+    return conns
+
+
 def test_conn_recycle_across_thread_churn():
     # Populate the per-engine connection freelists.
     _churn(120)
@@ -71,3 +100,24 @@ def test_conn_recycle_across_thread_churn():
         _churn(60)
         assert 'success' in client.conf('4', 'settings/listen_threads')
         _churn(60)
+
+
+def test_conn_recycle_connection_accounting():
+    # The body-integrity churn above passes identically whether structs are
+    # recycled, parked forever, or never pushed at all, so it cannot see the
+    # recycler stop working -- notably pending_connections growing without
+    # bound because some struct never settles.  Pin the counters the recycler
+    # now sits beside instead: every churned connection must be accounted for
+    # and none may be left behind once the churn is over.
+    Status.init()
+
+    _churn(60)
+
+    conns = _wait_conns(
+        {'accepted': 60, 'active': 0, 'idle': 0, 'closed': 60}
+    )
+
+    assert conns['accepted'] == 60, 'all accepted'
+    assert conns['active'] == 0, 'none left active'
+    assert conns['idle'] == 0, 'none left idle'
+    assert conns['closed'] == 60, 'all closed'


### PR DESCRIPTION
## Summary

Thread-local connection-struct freelist recycler. `nxt_conn_free` pushes the freed
`nxt_conn_t` onto its engine's `free_connections` list, and `nxt_conn_create` pops
and re-zeroes a recycled struct when one is available — avoiding a pool allocation
per accept on the hot path. Last of the 4-PR split out of #35 (the others,
#152/#153/#155, are merged).

## Status: ready for review / merge

- **Rebased onto current master** (`ae62599e`, includes merged #152/#153) — clean, no
  conflicts, no conn-file overlap, so this reflects the real release combination.
- **CI green** on `dae8cf4f` across Build & Test, Sanitize ASan+UBSan,
  Clang AST, and lint. The previous run's four failures were the new thread-churn
  test's generic router-FD baseline check, not a recycler crash: changing
  `listen_threads` intentionally replaces each engine's epoll, signalfd, and
  eventfd descriptors.
- **Local ASan battery clean**: keep-alive + mid-stream-abort (`send_timeout=1`), 3
  rounds of a combined app+static abort battery plus 900 RST-mid-stream aborts — no
  reports, workers stay up and serving.

## Correctness / review outcomes

- **Thread-churn test isolation fixed** (`dae8cf4f`). The test now uses the
  harness's router-FD skip for its intentional engine-topology changes and deletes
  its temporary global `listen_threads` setting in fixture teardown. The recycler
  owns no descriptors; body-integrity checks and sanitizer coverage remain active.
  The targeted test passes locally in both default no-restart and `--restart`
  modes.
- **OOM-path UAF fixed** (commit 2). The freelist now recycles **only** structs backed
  by the persistent `engine->mem_pool`. When `mem_pool` is NULL (reachable via the
  unchecked `nxt_mp_create` at `nxt_runtime.c:306`), the struct is allocated from the
  per-connection pool and is **not** pushed onto the freelist, so it dies with that pool
  — no dangling freelist entry. This is a plain runtime branch, safe in release builds
  (not an `nxt_assert`). Push-before-release is safe by construction (recycled structs
  never live in the pool being released).
- **Thread-affinity invariant asserted**: `nxt_assert(c->task.thread == task->thread)` in
  `nxt_conn_free` locks in that a conn is always freed on the engine that created it (a
  cross-engine free would dangle when that engine's `mem_pool` is destroyed at
  `listen_threads` churn). Verified non-firing under the abort battery.
- **The one-off ASan UAF seen during extraction is not this PR's** — it traces to a
  pre-existing master race (pending conn write work carrying `&r->task` past request-pool
  release), filed separately as #156. It ships in the release with or without this PR.

## Release note

Introduces a per-engine high-water retention of recycled `nxt_conn_t` structs (~432
bytes each, `+8` vs before for the freelist link), pinned until worker-thread exit —
bounded by peak concurrency per engine, freed wholesale at thread teardown (no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
