### PR TITLE
test: poll the zombie check in unit_stop to fix a sanitizer flake

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -574,10 +574,23 @@ def unit_stop():
     # check zombies (only once startup got far enough to record the main pid)
 
     if main_pid is not None:
-        out = subprocess.check_output(
-            ['ps', 'ax', '-o', 'state', '-o', 'ppid']
-        ).decode()
-        z_ppids = re.findall(r'Z\s*(\d+)', out)
+        # A child that just exited can briefly remain a zombie until main reaps
+        # it; under load (notably sanitizer builds) that window can outlast a
+        # single sample and flake this check.  Poll so a transient
+        # reap-in-progress is not mistaken for a genuinely leaked zombie -- a
+        # real leak persists, a reap race clears within a few ms.  Sample after
+        # each sleep (including the last one) so a reap that lands in the final
+        # interval is still observed before the assertion.
+        z_ppids = []
+        for i in range(41):
+            if i:
+                time.sleep(0.05)
+            out = subprocess.check_output(
+                ['ps', 'ax', '-o', 'state', '-o', 'ppid']
+            ).decode()
+            z_ppids = re.findall(r'Z\s*(\d+)', out)
+            if main_pid not in z_ppids:
+                break
         assert main_pid not in z_ppids, 'no zombies'
 
     # terminate unit


### PR DESCRIPTION
## Summary

Fixes an intermittent teardown error in the ASan+UBSan CI job:

```
ERROR at teardown of test_sigterm_drops_inflight_request[3.12.3]
AssertionError: no zombies
assert '5957' not in ['5957']   # conftest.py
```

The test itself passes — the failure is in `unit_stop()`'s zombie check. It
takes a **single** `ps` sample and asserts the unit main process is not the
parent of any zombie. But a child unitd (router / controller / app worker)
that has just exited stays in `Z` state for a few milliseconds until main
reaps it, and under sanitizer load that window can outlast the single sample —
so a reap that is merely *in progress* is misread as a leaked zombie.

Observed on freeunit#152's Sanitize run
([run 30104904833](https://github.com/freeunitorg/freeunit/actions/runs/30104904833));
a plain re-run of the same commit went green, confirming it's timing, not a
real leak. It is unrelated to that PR's code (var-scratchpad touches only
`nxt_var.c`), which is why it belongs in a standalone conftest fix.

## Change

Poll the zombie check for up to 2 s (40 × 50 ms), breaking as soon as the
transient zombie is reaped:

- a **genuinely leaked** zombie persists for the full window and still fails
  the assertion — no loss of coverage;
- a **reap-in-progress** clears within a few ms and no longer flakes the run.

`test/conftest.py` only; `time`/`re`/`subprocess` are already imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
