### PR TITLE
conn: enforce connection-scoped socket and timer tasks

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -70,11 +70,20 @@ jobs:
             # straddling keep-alive reuse (freeunit#156): pre-fix a deferred
             # conn write item dereferenced a freed request-pool task, which
             # this leg's ASan build reports as a heap-use-after-free.
+            #
+            # test_proxy covers the upstream (peer) connection lifecycle, which
+            # only this leg can red-line: the peer teardown paths free the peer
+            # object out of the request pool while conn events may still be
+            # queued (nxt_h1p_peer_close), and the connection-task ownership
+            # assertions are nxt_assert()s, live only in the --debug build
+            # configured below.  In the release test legs both the assertions
+            # and ASan's report are compiled out.
             tests: >-
               test/test_graceful_reload.py
               test/test_listener_drain.py
               test/test_static.py
               test/test_conn_task_race.py
+              test/test_proxy.py
           - runtime: php
             apt: ""
             configure: php

--- a/src/nxt_conn.c
+++ b/src/nxt_conn.c
@@ -69,6 +69,18 @@ nxt_conn_create(nxt_mp_t *mp, nxt_task_t *task)
     c->task.thread = thr;
     c->task.log = &c->log;
     c->task.ident = c->log.ident;
+
+    /*
+     * The socket and timer tasks are captured by value into deferred work items
+     * (nxt_conn_read / nxt_conn_write / nxt_conn_connect) and into expiring
+     * timer work, so they must not be rebound to a task living in a
+     * shorter-lived pool than the connection (e.g. the request-embedded
+     * &r->task): an item still queued when that pool is released would
+     * dereference freed memory -- freeunit#156.  The ownership is asserted at
+     * the sites that used to rebind these fields: nxt_h1p_conn_request_init()
+     * and nxt_h1p_request_close() for accepted connections, nxt_conn_socket()
+     * and nxt_h1p_peer_close() for outgoing ones.
+     */
     c->socket.task = &c->task;
     c->read_timer.task = &c->task;
     c->write_timer.task = &c->task;

--- a/src/nxt_conn_connect.c
+++ b/src/nxt_conn_connect.c
@@ -103,9 +103,21 @@ nxt_conn_socket(nxt_task_t *task, nxt_conn_t *c)
 
     c->socket.fd = s;
 
-    c->socket.task = task;
-    c->read_timer.task = task;
-    c->write_timer.task = task;
+    /*
+     * The socket and timer tasks are not (re)bound here: task is always
+     * &c->task already.  nxt_conn_sys_socket() is the only caller and runs as a
+     * work item enqueued by nxt_conn_connect() with c->socket.task, which
+     * nxt_conn_create() set to &c->task and no outgoing-connection path
+     * rebinds.  Keeping these tasks connection-scoped is what makes every
+     * later nxt_debug(c->socket.task, ...) and c->socket.task->thread->engine
+     * deref safe for the whole lifetime of the connection: a task bound to a
+     * shorter-lived pool (e.g. the request-embedded &r->task) would be captured
+     * by value into deferred work items and expiring timers and could outlive
+     * its pool -- the use-after-free class of freeunit#156.
+     */
+    nxt_assert(c->socket.task == &c->task);
+    nxt_assert(c->read_timer.task == &c->task);
+    nxt_assert(c->write_timer.task == &c->task);
 
     if (c->local != NULL) {
         if (nxt_slow_path(nxt_socket_bind(task, s, c->local) != NXT_OK)) {

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -3222,10 +3222,19 @@ nxt_h1p_peer_close(nxt_task_t *task, nxt_http_peer_t *peer)
     peer->closed = 1;
 
     c = peer->proto.h1->conn;
+
+    nxt_assert(c->socket.task == &c->task);
+    nxt_assert(c->read_timer.task == &c->task);
+    nxt_assert(c->write_timer.task == &c->task);
+
+    /*
+     * The upstream connection's socket and timer tasks are connection-scoped
+     * for its whole lifetime (nxt_conn_create() sets them; nxt_conn_socket()
+     * only rechecks), so there is nothing to reset here -- only the local task
+     * is switched to the connection for the close below, which runs after the
+     * request may already be gone.
+     */
     task = &c->task;
-    c->socket.task = task;
-    c->read_timer.task = task;
-    c->write_timer.task = task;
 
     /*
      * Block further I/O on the upstream connection and cancel its timers.


### PR DESCRIPTION
## Summary

Turns the two remaining "rebind the conn's task" sites into assertions on the
ownership invariant they silently rely on, and documents that invariant where it is
established. No behavior change: both assignments were provably self-assignments.

Closes #159 (which I first filed with a wrong mechanism — see the correction there;
what survived is this hardening item).

## Why they were dead stores

`nxt_conn_socket()` (`src/nxt_conn_connect.c`) assigned `c->socket.task`,
`c->read_timer.task` and `c->write_timer.task` from its `task` argument:

- `nxt_conn_sys_socket()` is the **only** caller and passes its work-item task straight
  through.
- That work item was enqueued by the `nxt_conn_connect()` macro (`src/nxt_conn.h:294`)
  with **`c->socket.task`** itself.
- Every conn on that path (`nxt_h1p_peer_connect()`, `nxt_conn_proxy.c:117/224/846`)
  comes from `nxt_conn_create()`, which sets all three to `&c->task`, and nothing
  rebinds them before the dispatch.

So `task == &c->task` always. That in turn makes `nxt_h1p_peer_close()`'s reset of the
same three fields a no-op — only its local `task = &c->task;` switch is load-bearing,
since the close can run after the request is gone.

## Why replace them rather than leave them

These fields are captured **by value** into deferred work items (`nxt_conn_read` /
`nxt_conn_write` / `nxt_conn_connect`) and into expiring timer work, so a task from a
pool shorter-lived than the connection can be dereferenced after that pool is released
— #156 exactly: the client conn's tasks were repointed at the request-pool-embedded
`&r->task` and a queued write item outlived `nxt_mp_release(r->mem_pool)`.

Keeping them at `&c->task` for the connection's lifetime is what makes every reader
lifetime-safe: all the `nxt_debug(c->socket.task, ...)` sites plus `nxt_conn_wait()`'s
`c->socket.task->thread->engine` (`nxt_conn_read.c:19`) and `nxt_conn_io_write()`'s
`task->thread->engine` (`nxt_conn_write.c:38`) — the latter two live in release builds,
not only under `nxt_debug`. Code that looks like it binds a caller-supplied task is an
invitation to reintroduce that shape.

`nxt_assert()` is debug-only (`nxt_log.h:118/133`), so release builds carry nothing.

## Validation

- **`--debug` build (assertions live)**, proxying one unit listener to another
  (`proxy` → static `share`, `send_timeout=1`): 47 upstream connects, 4 MB relays
  compared byte-for-byte, 30 mid-relay client aborts and 10 upstream send-timeout
  straddles → 47 assert-site executions, 47 `nxt_h1p_peer_close()` calls, **zero**
  assertion failures, router alive and byte-correct after the abort battery.
- **Oracle checked**: temporarily rebinding the peer conn's socket task to `&r->task`
  in `nxt_h1p_peer_connect()` makes `assertion failed: c->socket.task == &c->task`
  fire on the first proxied request (router aborts, request fails) — so the assertions
  are not vacuous.
- Release build clean, `build/tests` C suite passes, `git diff --check` clean.
- The python module is not buildable on my host (no `python3-config`), so `test_proxy.py`
  under ASan is left to this PR's sanitize leg rather than pre-verified locally.

## CI coverage

`nxt_assert` is `NXT_DEBUG`-only, and the sanitize (ASan+UBSan) legs are the only ones
configured with `--debug` -- but they ran no proxy traffic, so this also adds
`test/test_proxy.py` to the sanitize python leg. No new dependency: the python module is
already built there and the test's upstream is a plain python server from its module
fixture.

That also gives the upstream (peer) connection lifecycle its first ASan coverage, which
is where it is most wanted -- `nxt_h1p_peer_close()` tears down a connection whose peer
object lives in the request memory pool and can be freed while conn events are still
queued for it (the hazard its `block_read` / `block_write` guards exist for).

#157's `test_conn_task_race.py` line landed first; this branch is rebased on it and the
`tests:` conflict is resolved here (the leg now runs both). #154 still touches that block
and will need the same one-line resolution.

## Relationship to #157

#157 (merged as 9b7bff67) removed the *real* rebinding on accepted connections -- the #156
fix -- and asserted the ownership at `nxt_h1p_conn_request_init()` / `nxt_h1p_request_close()`.
This PR covers outgoing connections, where the rebinding was already vestigial. With both in,
`c->socket.task == &c->task` holds for every connection in the tree, and the comment at
`nxt_conn_create()` names all four assert sites.

## Rebase note

Rebased onto master at c243c072 (past #157, #166, #163 and #161), and folded to a single
commit to match how #157 landed (fix + its CI wiring together). Re-validated on that base: debug
build warning-free, `build/tests` green, and the proxy battery re-run -- 44 upstream connects,
44 `nxt_h1p_peer_close()` calls, 90 client request closes (so #157's assertions were live
too), 4 MB relays byte-identical, zero assertion failures, zero alerts.
