### PR TITLE
mp: keep the nxt_mp_get() cursor aligned by rounding, not flooring

### DIFF
--- a/src/nxt_mp.c
+++ b/src/nxt_mp.c
@@ -1014,7 +1014,30 @@ nxt_mp_get(nxt_mp_t *mp, size_t size)
 #if !(NXT_DEBUG_MEMORY)
 
     if (size <= mp->page_size) {
-        size = nxt_max(size, NXT_MAX_ALIGNMENT);
+        /*
+         * nxt_mp_get_small() is a bump allocator with no per-allocation
+         * alignment step: it hands out the page cursor and then advances it
+         * by the requested size.  Flooring the size to NXT_MAX_ALIGNMENT is
+         * therefore not enough to keep the promise made in nxt_mp.h that
+         * nxt_mp_get() returns memory aligned suitably for structures: a
+         * single odd-sized get() leaves the cursor misaligned, and every
+         * later get() from that page returns a misaligned pointer.  On
+         * strict-alignment targets such as armv7 a struct copy or a 64-bit
+         * field access through such a pointer faults with SIGBUS, because
+         * the compiler emits multi-word instructions (stm, ldrd/strd) that
+         * require the pointer to be 4- or 8-aligned.  Round the size up
+         * instead, so the cursor stays a multiple of NXT_MAX_ALIGNMENT.
+         *
+         * The rounded size still fits the page.  nxt_mp_create() floors
+         * page_alignment to NXT_MAX_ALIGNMENT and nxt_mp_test_sizes()
+         * requires page_size to be a power of two not less than
+         * page_alignment, so page_size is a power of two not less than
+         * NXT_MAX_ALIGNMENT, which is itself a power of two -- hence
+         * page_size is a multiple of NXT_MAX_ALIGNMENT and rounding a size
+         * that already fits the page cannot push it past the end.
+         */
+        size = nxt_align_size(nxt_max(size, NXT_MAX_ALIGNMENT),
+                              NXT_MAX_ALIGNMENT);
         p = nxt_mp_get_small(mp, &mp->get_pages, size);
 
     } else {

--- a/src/test/nxt_mp_test.c
+++ b/src/test/nxt_mp_test.c
@@ -8,6 +8,107 @@
 #include "nxt_tests.h"
 
 
+/*
+ * nxt_mp_get() and nxt_mp_zget() promise memory aligned suitably for
+ * structures.  They are served by a bump allocator that has no
+ * per-allocation alignment step, so the promise only holds if the
+ * requested size is rounded up to NXT_MAX_ALIGNMENT: a single odd-sized
+ * get() used to leave the page cursor misaligned and every later get()
+ * from that page returned a misaligned pointer.  A struct copy or a 64-bit
+ * field access through such a pointer faults with SIGBUS on armv7; this
+ * test catches the regression on any architecture, no strict-alignment
+ * hardware needed.
+ */
+
+nxt_int_t
+nxt_mp_get_align_test(nxt_thread_t *thr)
+{
+    void        *p;
+    nxt_mp_t    *mp;
+    nxt_bool_t  valid;
+    nxt_uint_t  i, n;
+
+    /*
+     * Sizes deliberately not multiples of NXT_MAX_ALIGNMENT.  On 32-bit
+     * platforms 12 is sizeof(nxt_http_static_mtype_t) and 20 is both
+     * sizeof(nxt_tstr_t) and sizeof(nxt_list_t) - the sizes of the
+     * allocations that actually faulted on armv7.
+     */
+    static const size_t  sizes[] = {
+        1, 2, 3, 5, 7, 9, 12, 17, 20, 23, 31, 33, 45, 63, 100
+    };
+
+    const size_t  min_chunk_size = 16;
+    const size_t  page_size = 128;
+    const size_t  page_alignment = 128;
+    const size_t  cluster_size = page_size * 8;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "mem pool get alignment test "
+                  "started, alignment:%uz", (size_t) NXT_MAX_ALIGNMENT);
+
+    valid = nxt_mp_test_sizes(cluster_size, page_alignment, page_size,
+                              min_chunk_size);
+    if (!valid) {
+        return NXT_ERROR;
+    }
+
+    mp = nxt_mp_create(cluster_size, page_alignment, page_size, min_chunk_size);
+    if (mp == NULL) {
+        return NXT_ERROR;
+    }
+
+    /*
+     * Several passes over the size table so that allocations both stay
+     * within a page and spill over into freshly allocated ones.
+     */
+
+    for (i = 0; i < 64; i++) {
+
+        for (n = 0; n < nxt_nitems(sizes); n++) {
+
+            p = (i & 1) ? nxt_mp_get(mp, sizes[n])
+                        : nxt_mp_zget(mp, sizes[n]);
+
+            if (p == NULL) {
+                nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                              "mem pool get alignment test failed: "
+                              "get(%uz) returned NULL", sizes[n]);
+                return NXT_ERROR;
+            }
+
+            if (((uintptr_t) p & (NXT_MAX_ALIGNMENT - 1)) != 0) {
+                nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                              "mem pool get alignment test failed: "
+                              "get(%uz) returned %p, not %uz-aligned",
+                              sizes[n], p, (size_t) NXT_MAX_ALIGNMENT);
+                return NXT_ERROR;
+            }
+        }
+
+        /* A large allocation takes the nxt_mp_alloc_large() path. */
+
+        p = nxt_mp_get(mp, page_size + 1);
+
+        if (p == NULL || ((uintptr_t) p & (NXT_MAX_ALIGNMENT - 1)) != 0) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "mem pool get alignment test failed: "
+                          "large get(%uz) returned %p",
+                          page_size + 1, p);
+            return NXT_ERROR;
+        }
+    }
+
+    nxt_mp_destroy(mp);
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "mem pool get alignment test passed");
+
+    return NXT_OK;
+}
+
+
 nxt_int_t
 nxt_mp_test(nxt_thread_t *thr, nxt_uint_t runs, nxt_uint_t nblocks,
     size_t max_size)

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -98,6 +98,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_mp_get_align_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_mp_test(thr, 100, 40000, 128 - 1) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -53,6 +53,7 @@ void nxt_rbtree1_mb_delete(nxt_thread_t *thr);
 
 nxt_int_t nxt_mp_test(nxt_thread_t *thr, nxt_uint_t runs, nxt_uint_t nblocks,
     size_t max_size);
+nxt_int_t nxt_mp_get_align_test(nxt_thread_t *thr);
 nxt_int_t nxt_mem_zone_test(nxt_thread_t *thr, nxt_uint_t runs,
     nxt_uint_t nblocks, size_t max_size);
 nxt_int_t nxt_lvlhsh_test(nxt_thread_t *thr, nxt_uint_t n,


### PR DESCRIPTION
## Summary

`nxt_mp_get()` floors the requested size to `NXT_MAX_ALIGNMENT` instead of
rounding it. The small path is a bump allocator with no per-allocation
alignment step, so a single odd-sized `get()` permanently de-aligns the page
cursor and every later `get()` from that page returns a misaligned pointer.

On x86_64 that is silent UB. On strict-alignment 32-bit ARM it is a hard
SIGBUS — which is why Alpine has shipped this package on `armv7`/`armhf` with
`_allow_fail=yes # segfault` for as long as the pytest suite has been enabled
there.

One line fixes it: round the size up instead of flooring it.

## Evidence

Captured with a `SIGBUS` handler running the suite in an Alpine `armv7`
container (clang-22, qemu, unpatched `master`): **20 crash records, two
distinct PCs, and in both the faulting address is a pointer `nxt_mp_get()`
had just returned.**

| # | Site | get size | Faulting insn | Fault addr | Misalignment |
|---|---|---|---|---|---|
| A | `nxt_http_static_mtypes_hash_add()` — `mtype->exten = *exten` | `nxt_mp_get(mp, 12)` | `stm r0, {r2,r3,r6}` (needs 4) | `0x40e3b772` | **2 mod 4** |
| B | `nxt_tstr_str()` — `*str = tstr->str` | `nxt_mp_get(pool, 20)` | `ldrd r2, [r0]` (needs 8) | `0x4149c1c9` | **1 mod 8** (odd) |

(`addr2line` resolved these to `nxt_http_static.c:1126` and `nxt_tstr.c:230`
on the build that was captured; the static one has since moved to line 1289.)

Case A is airtight — the disassembly shows the fault two instructions after
the `nxt_mp_get` that produced the pointer:

```
32d58:  mov  r1, #12
32d5c:  bl   nxt_mp_get
32d68:  mov  r7, r0
32d6c:  ldrd r2, [r4]
32d70:  stm  r0, {r2, r3, r6}   <-- SIGBUS, r0 = 0x40e3b772 (2 mod 4)
```

Fault addresses that are odd / 2-mod-4 (rather than merely 4-mod-8) show the
cursor drifts by arbitrary byte amounts — the signature of
`nxt_str_alloc(sizeof(nxt_str_t) + length)`.

## The fix

```c
-        size = nxt_max(size, NXT_MAX_ALIGNMENT);
+        size = nxt_align_size(nxt_max(size, NXT_MAX_ALIGNMENT),
+                              NXT_MAX_ALIGNMENT);
```

The rounded size still fits the page: `NXT_MAX_ALIGNMENT` is at most 16 and
`nxt_mp_test_sizes()` requires `page_size` to be a power of two ≥ 64.
`nxt_mp_zget()` inherits the fix. `nxt_mp_nget()` is documented as returning
*non-aligned* memory and is deliberately left byte-packed; the chunked
`nxt_mp_alloc()` path is already aligned by construction.

Worst-case extra memory is 15 bytes per `get()` on a `get_pages` page, and in
practice less, since the sizes involved were already being rounded up to 16 by
the old floor whenever they were smaller than that.

## Test

`nxt_mp_get_align_test()` interleaves odd-sized `get()`/`zget()` calls, across
page boundaries and through the large-allocation path, and asserts every
returned pointer is `NXT_MAX_ALIGNMENT`-aligned.

It reproduces the defect **on any architecture** — no strict-alignment
hardware needed. On x86_64 without the fix:

```
tests: [notice] mem pool get alignment test failed: get(23) returned 56C75B0F2494, not 16-aligned
```

and with it, `./build/tests` is green end to end.

## Validation

- `./build/tests` green on x86_64 — and fails as shown above without the fix.
- `./build/tests` green under **ASan + UBSan** on x86_64, zero sanitizer
  reports.
- **Alpine CI, real builders, `armv7` *and* `armhf`: full package `check()`
  passes with this patch applied and the `_allow_fail=yes` escape hatch
  disabled** —
  https://gitlab.alpinelinux.org/alpine/aports/-/jobs/2449722
  That is the entire suite with all language modules, not a subset, and it is
  the first time it has ever passed on those arches.
- Alpine `armv7` container (clang-22, qemu), full build:
  - `./build/tests` green, alignment test reports `alignment:16`.
  - `pytest test/test_static.py` run **3×**: `19 passed, 1 skipped` every time,
    with **0 SIGBUS records** under the same crash handler that recorded 20 on
    unpatched `master`.

(The 19 per-run teardown `errors` in the armv7 container are a qemu-only
artifact — the conftest process counter matches the extra `qemu-arm` command
line rows and asserts `3 == 2`. Unrelated to this change, and present on
unpatched builds too.)

## Known separate issue (not addressed here)

`nxt_list` embeds its first part in the header, and `nxt_list_t` is 20 bytes on
32-bit, so element 0 sits at `list_base + 20` — never 8-aligned once the base
is 16-aligned. This fix does not change that class; it makes it deterministic
rather than random (the base was previously arbitrary, so those elements were
already misaligned about 7 times out of 8).

This is **UB, but not fault-reachable on ARMv7**, so it is a latent
correctness issue rather than a live crash. On ARMv7 with `SCTLR.A=0`,
`ldrd`/`strd`/`ldm`/`stm` require only **word** alignment, which I confirmed
empirically on the target:

```
ldrd @ ...d0 (mod 8 = 0): OK
ldrd @ ...d4 (mod 8 = 4): OK            <- 4 mod 8 does not fault
ldrd @ ...d2 (mod 4 = 2): SIGBUS
ldrd @ ...d1 (odd):       SIGBUS
```

Both faults captured for *this* PR were word-alignment violations (2 mod 4 and
odd), which is precisely the class the cursor drift produces and the class this
fix eliminates. A 4-mod-8 list element would only fault via alignment-hinted
NEON (`vld1.64 [rN:64]`) or on a stricter target (ARMv5TE, SPARC).

Consistent with that, the Alpine `armv7`/`armhf` run above passes with these
elements deterministically at 4 mod 8, while exercising JSON array parsing on
essentially every config PUT.

The two 8-aligned element types today:

- `nxt_runtime.c:1362` `nxt_list_create(rt->mem_pool, 1, sizeof(nxt_file_t))` —
  additionally safe because log-file elements are only ever touched through
  `->name`/`->fd`/`->error`/`->log_level` (≤4-byte fields); `mtime`/`size` are
  never accessed.
- `nxt_conf.c:1788` `nxt_list_create(mp_temp, 8, sizeof(nxt_conf_value_t))` —
  `nxt_conf_value_t` is `nxt_aligned(8)` and `nxt_conf.c:1872` does
  `*element++ = *value;`. Its union holds no 64-bit scalar (JSON numbers are
  stored as `u_char number[]`), so no individual field access faults either.

Suggested follow-up: give `struct nxt_list_part_s` (or its `data[]`)
`nxt_aligned(NXT_ALIGNMENT)`, which moves the embedded part 12→16 and its data
20→24 on 32-bit, leaving 64-bit and i386 layouts unchanged. That depends on
this PR landing first (it assumes a 16-aligned list base) and changes a core
struct's layout, so it belongs in its own PR with its own review.

## Upstream

`nginx/unit` master has the identical defect at `src/nxt_mp.c:1006`; this fix
applies there unchanged.
