### PR TITLE
fix(http): keep the chunked request body buffer alive across framing reads

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -78,12 +78,19 @@ jobs:
             # assertions are nxt_assert()s, live only in the --debug build
             # configured below.  In the release test legs both the assertions
             # and ASan's report are compiled out.
+            #
+            # test_chunked's split-read case drives a chunked request body whose
+            # framing arrives in its own segments, which is how the request read
+            # buffer reaches the parser's recycle path.  Without ASan a stale
+            # buffer is usually silently reused, so only this leg turns that
+            # back into a hard failure.
             tests: >-
               test/test_graceful_reload.py
               test/test_listener_drain.py
               test/test_static.py
               test/test_conn_task_race.py
               test/test_proxy.py
+              test/test_chunked.py
           - runtime: php
             apt: ""
             configure: php

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -925,6 +925,15 @@ nxt_h1p_request_body_read(nxt_task_t *task, nxt_http_request_t *r)
 
         r->chunked = 1;
         h1p->chunked_parse.mem_pool = r->mem_pool;
+
+        /*
+         * Every buffer this parser sees on the request path belongs to someone
+         * else: the header buffer stays linked in h1p->buffers (parsed fields
+         * still point into it) and the body buffer lives in the request memory
+         * pool and remains c->read for the rest of the body.  Neither may be
+         * handed to its completion handler when a read carries only framing.
+         */
+        h1p->chunked_parse.retain_buffers = 1;
         break;
 
     case NXT_HTTP_TE_UNSUPPORTED:

--- a/src/nxt_http_chunk_parse.c
+++ b/src/nxt_http_chunk_parse.c
@@ -180,7 +180,7 @@ nxt_http_chunk_parse(nxt_task_t *task, nxt_http_chunk_parse_t *hcp,
             }
         }
 
-        if (b->retain == 0) {
+        if (b->retain == 0 && !hcp->retain_buffers) {
             /* No chunk data was found in a buffer. */
             nxt_work_queue_add(&task->thread->engine->fast_work_queue,
                                b->completion_handler, task, b, b->parent);

--- a/src/nxt_http_parse.h
+++ b/src/nxt_http_parse.h
@@ -105,6 +105,14 @@ typedef struct {
     uint8_t                   last;         /* 1 bit */
     uint8_t                   chunk_error;  /* 1 bit */
     uint8_t                   error;        /* 1 bit */
+    /*
+     * The caller owns the buffers it passes in and releases them itself, so
+     * nxt_http_chunk_parse() must not hand a buffer that yielded no data slice
+     * to its completion handler.  Set by the request path, where the buffers
+     * are the connection's; left zero by the proxy response path, which drops
+     * its reference before parsing and relies on that recycle.
+     */
+    uint8_t                   retain_buffers;  /* 1 bit */
 } nxt_http_chunk_parse_t;
 
 

--- a/test/test_chunked.py
+++ b/test/test_chunked.py
@@ -1,4 +1,6 @@
 import re
+import socket
+import time
 
 import pytest
 from unit.applications.lang.python import ApplicationPython
@@ -194,3 +196,77 @@ def test_chunked_invalid():
         )['status']
         == 400
     ), 'Transfer-Encoding HTTP/1.0'
+
+
+def test_chunked_split_reads():
+    # Each write is delivered to the router as its own read, so it parses
+    # buffers that carry only framing bytes -- a chunk-size line, a terminal
+    # section -- and produce no body slice.  Such a buffer used to be handed
+    # back to its completion handler, which frees it, while the connection kept
+    # reading into it: a use-after-free that killed the router (visible as a
+    # dropped connection here, and as a heap-use-after-free on the sanitize
+    # leg).  freeunitorg/freeunit#148 review.
+    req_head = (
+        b'POST / HTTP/1.1\r\nHost: localhost\r\n'
+        b'Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n'
+    )
+
+    def check(writes, expect_body, with_head=True):
+        sock = socket.create_connection(('127.0.0.1', 8080))
+        sock.settimeout(15)
+
+        try:
+            if with_head:
+                sock.sendall(req_head)
+
+            for w in writes:
+                # A short pause keeps each write in its own segment; without it
+                # the kernel may coalesce them into a single read and the
+                # framing-only buffer never occurs.
+                time.sleep(0.2)
+                sock.sendall(w)
+
+            resp = b''
+            while True:
+                part = sock.recv(4096)
+                if not part:
+                    break
+                resp += part
+
+        finally:
+            sock.close()
+
+        assert resp != b'', f'router dropped the connection: {writes}'
+
+        head, _, body = resp.partition(b'\r\n\r\n')
+        assert head.split(b'\r\n')[0].split()[1] == b'200', f'status: {writes}'
+        assert expect_body in body, f'body: {writes}'
+
+    # Chunk-size line alone, then data, then the terminal section.
+    check([b'5\r\n', b'hello\r\n', b'0\r\n\r\n'], b'hello')
+
+    # Several framing-only reads in a row, across two chunks.
+    check(
+        [b'4\r\n', b'abcd\r\n', b'3\r\n', b'xyz\r\n', b'0\r\n\r\n'],
+        b'abcdxyz',
+    )
+
+    # Terminal section split from the body.
+    check([b'5\r\nhello\r\n', b'0\r\n', b'\r\n'], b'hello')
+
+    # The headers and the chunk-size line in one read, the data later.  Here
+    # the framing-only buffer is the *header* buffer, which stays linked in
+    # h1p->buffers with the parsed fields pointing into it, so recycling it
+    # crashed at request close (double completion) rather than on the next
+    # read.
+    check(
+        [req_head + b'5\r\n', b'hello\r\n', b'0\r\n\r\n'],
+        b'hello',
+        with_head=False,
+    )
+
+    # Control: an empty chunked body complete in the first read.  A complete
+    # terminal section returns from inside the parse loop, so this shape never
+    # reaches the recycle -- it is here to keep it that way if that early
+    # return is ever refactored.
+    check([req_head + b'0\r\n\r\n'], b'', with_head=False)


### PR DESCRIPTION
## Summary

Fixes a remotely triggerable use-after-free in the chunked **request** body path. Found by review on #148 (Codex P1 + the follow-up analysis), verified here to be a `master` bug that #148 does not introduce.

## The bug

`nxt_http_chunk_parse()` returns a buffer it drained without producing a data slice to its completion handler:

```c
if (b->retain == 0) {
    /* No chunk data was found in a buffer. */
    nxt_work_queue_add(&task->thread->engine->fast_work_queue,
                       b->completion_handler, task, b, b->parent);
}
```

That is correct for the **proxy response** path: `nxt_h1p_peer_read_done()` sets `c->read = NULL` before parsing, so the buffer is the parser's to release.

The **request** path never transferred ownership. `nxt_h1p_request_body_read()` allocates the body buffer from `r->mem_pool` and installs it as `c->read`; `nxt_h1p_conn_request_body_read()` parses that same buffer in place and re-arms `nxt_conn_read()` on it. Its completion handler is `nxt_buf_completion()` → `nxt_mp_free()`. So a read that carries only framing bytes frees the buffer the connection is about to read into again.

No malformed input is needed — a client just has to write the chunk-size line in its own segment:

```
POST / HTTP/1.1 … Transfer-Encoding: chunked
  write 1: "5\r\n"        <- framing only, no data slice -> buffer freed
  write 2: "hello\r\n"    <- recv() into freed memory
  write 3: "0\r\n\r\n"
```

The freed region is then handed to `recv()`, so this is an attacker-influenced **write into freed heap**, not only a crash.

## Reproduction (master, before this commit)

`--debug` ASan+UBSan build, PHP app reading the body, three writes as above:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 in nxt_recvbuf_mem_coalesce src/nxt_recvbuf.c:24
  nxt_conn_io_recvbuf src/nxt_conn_read.c:145
  nxt_conn_io_read    src/nxt_conn_read.c:69
freed by thread T5 here:
  nxt_buf_completion  src/nxt_buf.c:214 -> nxt_mp_free
```

Router dies; the client sees a connection reset. Reproduced on `2f52138b` with no trailer involved.

## The fix

Two request-side buffers reach the parser, and both belong to someone else:

- the **header buffer**, parsed once by `nxt_h1p_request_body_read()` for whatever body bytes arrived with the headers. When the body is not yet complete it goes onto `h1p->buffers` and is completed later by `nxt_h1p_complete_buffers()` — so recycling it is a **double free**, which crashes at request close:

  ```
  AddressSanitizer: SEGV in nxt_event_engine_mem_free (nxt_event_engine.c:653)
    nxt_h1p_complete_buffers  src/nxt_h1proto.c:1619
    nxt_h1p_shutdown          src/nxt_h1proto.c:2223
  ```

- the **body buffer**, parsed in place by `nxt_h1p_conn_request_body_read()` while the connection keeps reading into it — recycling it is the read-after-free above.

So ownership is a property of the caller, not of one buffer: `nxt_http_chunk_parse_t` gains `retain_buffers`, set where the request path marks the request chunked (before either parse), and the recycle is skipped when it is set. The proxy response path leaves it zero and keeps recycling, which is correct there — `nxt_h1p_peer_read_done()` drops `c->read` before parsing. Non-chunked bodies never reach the parser at all.

Only shapes with `body_rest != 0` can reach the recycle: a complete terminal section returns from inside the parse loop, so an empty chunked body in one packet is unaffected (kept as a control case in the test).

Same build with the fix: 200 with the body intact for the crashing input, for several framing-only reads in a row, and for a terminal section split from the body — no sanitizer report.

## Tests

`test_chunked.py::test_chunked_split_reads` sends the body in separate writes so framing lands in its own read, and asserts the response survives with the body round-tripped. It covers both owners: the chunk-size line, several framing-only reads in a row and a split terminal section for the body buffer, and headers-plus-size-line in one write for the header buffer, plus the control case above. Without ASan a stale buffer is usually reused silently, so the file is also added to the sanitize python leg, where the freed buffer is a hard failure.

I could not run the python suite locally (no `python3-config` on this host); the end-to-end verification above used the PHP module, and the python leg is left to CI.

## Relationship to #148

#148 (chunked trailer parsing) widens the input surface — a read boundary in the terminal region now drains instead of hitting `chunk_error`'s early `return`, so more shapes reach the recycle — but the defect and its reachability predate it. This PR is independent and applies to `master` on its own; #148 can merge before or after.

## Note

Two pre-existing UBSan findings surfaced during config load in the same runs, unrelated to this fix and worth their own issue: `src/nxt_string.h:61` (null pointer passed as a non-null argument) and `src/nxt_conf.c:643` (misaligned member access). They land in `unit.log` rather than the sanitize workflow's `log_path` directory, which is why the ASan/UBSan legs stay green despite them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhMcvYuSz1p4A3obfTt3xA
