### PR TITLE
fix(wasm): disable guest outbound HTTP to drop the rustls stack

### DIFF
--- a/src/wasm-wasi-component/Cargo.lock
+++ b/src/wasm-wasi-component/Cargo.lock
@@ -1243,20 +1243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,40 +1288,6 @@ checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
  "rustix 1.1.4",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -1439,12 +1391,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1564,17 +1510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,12 +1571,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2082,14 +2011,11 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "rustls",
  "tokio",
- "tokio-rustls",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2112,24 +2038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
 dependencies = [
  "leb128",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2271,15 +2179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2547,12 +2446,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src/wasm-wasi-component/Cargo.toml
+++ b/src/wasm-wasi-component/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1.33.0", default-features = false }
 wasi-common = "36.0.10"
 wasmtime = { version = "36.0.10", default-features = false, features = ['component-model', 'cranelift'] }
 wasmtime-wasi = "36.0.10"
-wasmtime-wasi-http = "36.0.10"
+wasmtime-wasi-http = { version = "36.0.10", default-features = false }
 
 [build-dependencies]
 bindgen = "0.68.1"

--- a/src/wasm-wasi-component/src/lib.rs
+++ b/src/wasm-wasi-component/src/lib.rs
@@ -608,6 +608,33 @@ impl WasiHttpView for StoreState {
     fn ctx(&mut self) -> &mut WasiHttpCtx { &mut self.http }
 
     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+
+    // Guest-initiated outbound HTTP is deliberately not supported.
+    //
+    // The default implementation of this method comes from the
+    // "default-send-request" feature of wasmtime-wasi-http, which pulls
+    // in the whole rustls TLS stack (rustls, tokio-rustls,
+    // webpki-roots, rustls-webpki) purely so that a guest can dial out.
+    // That subtree is a recurring source of advisories, and Unit itself
+    // never needs it.  Building with default-features = false removes
+    // it from the dependency graph and makes this method mandatory, so
+    // we implement it as an explicit denial.
+    //
+    // wasi:http/outgoing-handler is still linked, so components that
+    // merely import it (as the wasi:http/proxy world requires) continue
+    // to instantiate and run; only an actual outbound call fails, and
+    // it fails with a well-defined error rather than a trap or a hang.
+    fn send_request(
+        &mut self,
+        _request: hyper::Request<
+            wasmtime_wasi_http::body::HyperOutgoingBody,
+        >,
+        _config: wasmtime_wasi_http::types::OutgoingRequestConfig,
+    ) -> wasmtime_wasi_http::HttpResult<
+        wasmtime_wasi_http::types::HostFutureIncomingResponse,
+    > {
+        Err(ErrorCode::HttpRequestDenied.into())
+    }
 }
 
 impl StoreState {}


### PR DESCRIPTION
## What this does

Builds `wasmtime-wasi-http` with `default-features = false`, which removes the
entire rustls subtree from the wasm module's dependency graph.

`default-send-request` is that crate's **only** default feature, and it exists
solely so a guest component can dial out over TLS:

```toml
default = ["default-send-request"]
default-send-request = ["dep:tokio-rustls", "dep:rustls", "dep:webpki-roots"]
```

## Advisories closed

All four currently flagged against `src/wasm-wasi-component/Cargo.lock`, all in
`rustls-webpki 0.102.8`:

| Advisory | Issue |
|---|---|
| RUSTSEC-2026-0104 / GHSA-82j2-j2ch-gfr8 | DoS via panic on malformed CRL BIT STRING |
| RUSTSEC-2026-0049 / GHSA-pwjx-qhcg-rvj4 | CRLs not authoritative by distribution point |
| RUSTSEC-2026-0099 / GHSA-xgp8-3hg3-c2mh | name constraints vs wildcard names |
| RUSTSEC-2026-0098 / GHSA-965h-392x-2mh5 | name constraints for URI names |

This **deletes** the dependency rather than upgrading it, so there is no version
left to carry a future advisory. Worth noting because the alternative is not
cheap: `0.102.8` is the last release on the `0.102.x` line, and `rustls 0.22.4`
pins `rustls-webpki "0.102.1"` (caret ⇒ `<0.103.0`), so no `cargo update` can
fix these — only a wasmtime bump to ≥44 can.

## Verified

- **Lockfile**: `rustls`, `tokio-rustls`, `webpki-roots`, `rustls-webpki` all
  gone (−107 lines), along with `ring`, `untrusted`, `subtle`, `zeroize`,
  `rustls-pki-types`.
- **Compiles**: forced recompile of the crate, clean.

## Behaviour change — this is a policy decision, not just a cleanup

With the feature off, `WasiHttpView::send_request` loses its default body and
becomes a **required** trait method, so `StoreState` implements it and returns
`ErrorCode::HttpRequestDenied`.

`add_only_http_to_linker_sync` is **not** feature-gated, so
`wasi:http/outgoing-handler` stays linked. Components that import it — which
every `wasi:http/proxy` component does by contract — still instantiate and
serve requests exactly as before. Only an actual outbound call changes, and it
now fails with a defined error rather than trapping or hanging.

**The honest downside:** the host no longer fully satisfies the outbound half of
the `wasi:http/proxy` world. A guest that genuinely wants to make outgoing HTTP
requests will not work here. That capability arrived implicitly when the module
adopted the standard proxy world (originally Alex Crichton's work, Oct 2023,
nginx/unit#991) — it was never an explicit decision to grant guests egress.
Removing it is equally a decision, and it is yours to make.

## Not covered

This does **not** address wasmtime's own CVEs. The last bump (`64bf40e4`,
35.0.0 → 36.0.12) was for sandbox escapes, so wasmtime updates remain necessary
regardless — see the sibling PR bumping wasmtime, which fixes these same four
advisories the other way. **The two are not alternatives:** the wasmtime bump is
unavoidable, this one is optional hardening that can sit on top.

## Not tested

I did not exercise a real wasm component end to end, so "components still
instantiate" is reasoned from `add_only_http_to_linker_sync` not being
feature-gated, not observed. Worth a run against `test/wasm_component/` before
merge.
