### PR TITLE
fix(port): validate peer-supplied incoming mmap id and geometry

### DIFF
--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -46,7 +46,20 @@ nxt_port_mmap_handler_use(nxt_port_mmap_handler_t *mmap_handler, int i)
 static nxt_port_mmap_t *
 nxt_port_mmap_at(nxt_port_mmaps_t *port_mmaps, uint32_t i)
 {
-    uint32_t  cap;
+    uint32_t         cap;
+    nxt_port_mmap_t  *elts;
+
+    if (nxt_fast_path(i < port_mmaps->size)) {
+        return port_mmaps->elts + i;
+    }
+
+    /*
+     * A capacity able to hold slot i is i + 1 elements, which is not
+     * representable in uint32_t for i == UINT32_MAX.
+     */
+    if (nxt_slow_path(i == UINT32_MAX)) {
+        return NULL;
+    }
 
     cap = port_mmaps->cap;
 
@@ -54,27 +67,41 @@ nxt_port_mmap_at(nxt_port_mmaps_t *port_mmaps, uint32_t i)
         cap = i + 1;
     }
 
-    while (i + 1 > cap) {
+    /*
+     * Comparing capacities rather than "i + 1 > cap": the latter wraps to
+     * 0 for i == UINT32_MAX and silently skips the growth.
+     */
+    while (cap <= i) {
 
         if (cap < 16) {
             cap = cap * 2;
 
         } else {
+            /*
+             * The 1.5x step overflows uint32_t for large capacities and
+             * wraps below the target, so the loop would spin forever with
+             * the caller's mutex held.
+             */
+            if (nxt_slow_path(cap > UINT32_MAX - cap / 2)) {
+                return NULL;
+            }
+
             cap = cap + cap / 2;
         }
     }
 
     if (cap != port_mmaps->cap) {
 
-        port_mmaps->elts = nxt_realloc(port_mmaps->elts,
-                                       cap * sizeof(nxt_port_mmap_t));
-        if (nxt_slow_path(port_mmaps->elts == NULL)) {
+        /* nxt_realloc() does not free the old array on failure. */
+        elts = nxt_realloc(port_mmaps->elts, cap * sizeof(nxt_port_mmap_t));
+        if (nxt_slow_path(elts == NULL)) {
             return NULL;
         }
 
-        nxt_memzero(port_mmaps->elts + port_mmaps->cap,
+        nxt_memzero(elts + port_mmaps->cap,
                     sizeof(nxt_port_mmap_t) * (cap - port_mmaps->cap));
 
+        port_mmaps->elts = elts;
         port_mmaps->cap = cap;
     }
 
@@ -98,14 +125,28 @@ nxt_port_mmaps_destroy(nxt_port_mmaps_t *port_mmaps, nxt_bool_t free_elts)
 
     port_mmap = port_mmaps->elts;
 
-    for (i = 0; i < port_mmaps->size; i++) {
-        nxt_port_mmap_handler_use(port_mmap[i].mmap_handler, -1);
+    if (port_mmap != NULL) {
+
+        for (i = 0; i < port_mmaps->size; i++) {
+            /*
+             * The array is indexed by the peer's segment id, so unused
+             * slots in the middle are genuinely NULL.
+             */
+            if (port_mmap[i].mmap_handler != NULL) {
+                nxt_port_mmap_handler_use(port_mmap[i].mmap_handler, -1);
+
+                port_mmap[i].mmap_handler = NULL;
+            }
+        }
     }
 
     port_mmaps->size = 0;
 
     if (free_elts != 0) {
         nxt_free(port_mmaps->elts);
+
+        port_mmaps->elts = NULL;
+        port_mmaps->cap = 0;
     }
 }
 
@@ -205,6 +246,8 @@ nxt_port_incoming_port_mmap(nxt_task_t *task, nxt_process_t *process,
     nxt_fd_t fd)
 {
     void                     *mem;
+    uint32_t                 id;
+    nxt_pid_t                src_pid, dst_pid;
     struct stat              mmap_stat;
     nxt_port_mmap_t          *port_mmap;
     nxt_port_mmap_header_t   *hdr;
@@ -221,7 +264,20 @@ nxt_port_incoming_port_mmap(nxt_task_t *task, nxt_process_t *process,
         return NULL;
     }
 
-    mem = nxt_mem_mmap(NULL, mmap_stat.st_size,
+    /*
+     * The peer sizes the segment; chunk addressing and every munmap() use
+     * the PORT_MMAP_SIZE constant, so anything else is out of bounds one
+     * way or the other.
+     */
+    if (nxt_slow_path(mmap_stat.st_size != PORT_MMAP_SIZE)) {
+        nxt_log(task, NXT_LOG_WARN, "unexpected shared memory segment size "
+                "%O from process %PI, expected %uz", mmap_stat.st_size,
+                process->pid, (size_t) PORT_MMAP_SIZE);
+
+        return NULL;
+    }
+
+    mem = nxt_mem_mmap(NULL, PORT_MMAP_SIZE,
                        PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 
     if (nxt_slow_path(mem == MAP_FAILED)) {
@@ -232,12 +288,29 @@ nxt_port_incoming_port_mmap(nxt_task_t *task, nxt_process_t *process,
 
     hdr = mem;
 
-    if (nxt_slow_path(hdr->src_pid != process->pid
-                      || hdr->dst_pid != nxt_pid))
-    {
+    /*
+     * The header lives in a segment the peer still maps writable, so every
+     * field has to be snapshotted before it is validated: re-reading one
+     * afterwards is a double fetch the peer can win, and for the segment id
+     * that would put an unvalidated value into nxt_port_mmap_at() below.
+     */
+    src_pid = hdr->src_pid;
+    dst_pid = hdr->dst_pid;
+    id = hdr->id;
+
+    if (nxt_slow_path(src_pid != process->pid || dst_pid != nxt_pid)) {
         nxt_log(task, NXT_LOG_WARN, "unexpected pid in mmap header detected: "
-                "%PI != %PI or %PI != %PI", hdr->src_pid, process->pid,
-                hdr->dst_pid, nxt_pid);
+                "%PI != %PI or %PI != %PI", src_pid, process->pid,
+                dst_pid, nxt_pid);
+
+        nxt_mem_munmap(mem, PORT_MMAP_SIZE);
+
+        return NULL;
+    }
+
+    if (nxt_slow_path(id >= NXT_PORT_MMAP_MAX_SEGMENTS)) {
+        nxt_log(task, NXT_LOG_WARN, "unexpected segment id in mmap header "
+                "detected: %uD from process %PI", id, process->pid);
 
         nxt_mem_munmap(mem, PORT_MMAP_SIZE);
 
@@ -258,7 +331,7 @@ nxt_port_incoming_port_mmap(nxt_task_t *task, nxt_process_t *process,
 
     nxt_thread_mutex_lock(&process->incoming.mutex);
 
-    port_mmap = nxt_port_mmap_at(&process->incoming, hdr->id);
+    port_mmap = nxt_port_mmap_at(&process->incoming, id);
     if (nxt_slow_path(port_mmap == NULL)) {
         nxt_log(task, NXT_LOG_WARN, "failed to add mmap to incoming array");
 
@@ -268,6 +341,15 @@ nxt_port_incoming_port_mmap(nxt_task_t *task, nxt_process_t *process,
         mmap_handler = NULL;
 
         goto fail;
+    }
+
+    /*
+     * Nothing stops the peer from reusing a segment id: without releasing
+     * the displaced handler its reference would never drop to zero and its
+     * mapping would leak for the lifetime of the router.
+     */
+    if (nxt_slow_path(port_mmap->mmap_handler != NULL)) {
+        nxt_port_mmap_handler_use(port_mmap->mmap_handler, -1);
     }
 
     port_mmap->mmap_handler = mmap_handler;

--- a/src/nxt_port_memory_int.h
+++ b/src/nxt_port_memory_int.h
@@ -30,6 +30,23 @@
 #define PORT_MMAP_SIZE          (PORT_MMAP_HEADER_SIZE + PORT_MMAP_DATA_SIZE)
 #define PORT_MMAP_CHUNK_COUNT   (PORT_MMAP_DATA_SIZE / PORT_MMAP_CHUNK_SIZE)
 
+/*
+ * The segment id of an incoming mmap is authored by the peer process and
+ * used as an index into nxt_process_t.incoming, so it has to be bounded.
+ *
+ * libunit assigns ids as append-only indices into its outgoing array and
+ * refuses to create a segment once that array reaches shm_mmap_limit, which
+ * is shm_limit / PORT_MMAP_DATA_SIZE computed in uint32_t.  So no conforming
+ * peer can exceed floor(UINT32_MAX / PORT_MMAP_DATA_SIZE), whatever the
+ * configured shm limit.
+ *
+ * Derived from the geometry rather than written out, because
+ * NXT_MMAP_TINY_CHUNK changes PORT_MMAP_DATA_SIZE by four orders of
+ * magnitude: 410 segments here, but 4194304 in a tiny-chunk build, where a
+ * hard-coded production-sized bound would reject legitimate traffic.
+ */
+#define NXT_PORT_MMAP_MAX_SEGMENTS  (UINT32_MAX / PORT_MMAP_DATA_SIZE + 1)
+
 
 typedef uint32_t  nxt_chunk_id_t;
 


### PR DESCRIPTION
Part of #172. Refs #120.

**Merge order: 1 of 4.** The four PRs in #172 touch disjoint files and cherry-pick
onto each other with no conflicts, so the order is a preference rather than a
constraint — but this one is the largest, it is the only one touching
`nxt_port_memory_int.h`, and it is what the others would have to rebase around
if it landed last.

## What is wrong

An application process authors the shared-memory segment it hands the router, so
it controls `hdr->id` and the fd's `st_size`. `nxt_port_incoming_port_mmap()`
validated `src_pid`/`dst_pid` only — values libunit itself writes and any app
trivially knows. `hdr->id` then goes straight into `nxt_port_mmap_at()` as an
array index.

Reproduced against `2f52138b` with a libunit application built to misbehave:

| input | behaviour on master |
|---|---|
| `hdr->id = 5000` | accepted; the router later parses junk-filled shm as a response header — `response buffer too small for fields count: -1515870811` (`0xA5A5A5A5`) |
| `hdr->id = 0xFFFFFFFE` | the 1.5x growth loop in `nxt_port_mmap_at()` overflows `uint32_t`, wraps below the target and never terminates — **31 s of CPU in a 36 s window**, with `process->incoming.mutex` held, so every other thread touching that app's mmaps blocks |
| `hdr->id = 0xFFFFFFFF` | `i + 1` wraps to 0, the growth is skipped, and the function returns `elts + 0xFFFFFFFF` — non-NULL, so the caller's NULL guard passes and a heap pointer is written ~32 GiB out of bounds |
| `st_size = 2 * PORT_MMAP_SIZE` | accepted silently; release unmaps only the constant, leaking 10.5 MB per segment |

A short segment is the more dangerous shape of the last one: the mapping is
peer-sized but every consumer — chunk arithmetic, `nxt_port_mmap_chunk_range_valid()`,
and all four `munmap()` sites — assumes `PORT_MMAP_SIZE`, so `chunk_id = 0`
already addresses memory outside the mapping, and `munmap(mem, PORT_MMAP_SIZE)`
over a 4 KiB mapping tears down whatever else occupies those 10 MB.

Two further defects need no attacker at all:

- `nxt_port_mmaps_destroy()` released `elts[i].mmap_handler` with no NULL check,
  but `process->incoming` is genuinely sparse. Any single pre-lock failure in
  `nxt_port_incoming_port_mmap()` (`fstat`, `mmap`, `nxt_zalloc`) leaves a
  permanent NULL hole once a later segment raises `size`, and the router then
  segfaults when that app is released.
- `port_mmaps->elts = nxt_realloc(port_mmaps->elts, ...)` overwrote `elts` with
  NULL on failure, orphaning the old array (realloc does not free on failure) and
  leaving `elts == NULL` with `size`/`cap` still non-zero, which breaks three
  other consumers.

## What this does

- Reject `hdr->id >= NXT_PORT_MMAP_MAX_SEGMENTS` (1024).
- Require `st_size == PORT_MMAP_SIZE` — `!=`, not `<`, because an oversized fd
  leaks its tail — and pass the constant to `mmap()` so the mapping length and
  every `munmap()` agree by construction rather than by coincidence.
- Rewrite the `nxt_port_mmap_at()` growth loop to compare capacities so `i + 1`
  never appears in the condition, guard the 1.5x step against overflow, add the
  `i < size` fast path `nxt_unit_mmap_at()` already has, and stage the realloc
  through a temporary.
- NULL-check the teardown loop, clear each slot as it is released, and reset
  `elts`/`cap`.
- Release the displaced handler before overwriting a slot.

`nxt_port_mmaps_destroy()` clearing slots is a **prerequisite** for the
displaced-handler release, not independent cleanup: releasing a slot's occupant
is only sound if a non-NULL slot always holds a live handler. The commit message
says so, because separating the two hunks in a rebase would produce a double
free.

## Why 1024 is safe

`hdr->id` is an append-only index into libunit's outgoing array, not a counter —
freed segments are retained and reused with the same id, so there is no drift
over uptime. libunit refuses to create a segment once that array reaches
`shm_mmap_limit`, which is `shm_limit / PORT_MMAP_DATA_SIZE` computed in
`uint32_t`, so the arithmetic maximum is `floor(UINT32_MAX / 10 MiB)` = **409**
segments, and 10 with the default 100M limit. Peak id observed in real traffic
during testing: **2**.

## Verification

`test_php_application.py` 49 passed / 3 skipped, identical to baseline, as are
`test_php_basic.py`, `test_php_targets.py`, `test_return.py`,
`test_reconfigure.py`, `test_php_compression.py`, `build/tests` and
`build/unit_close_test`. Zero warnings under `-Wall -Wextra -Werror`. Byte-exact
round-trips from 512 B to 32 MiB in both directions, including the
`PORT_MMAP_SIZE` boundary, plus 12 delete/re-add app cycles to exercise the
changed teardown. The growth loop was simulated exhaustively over the boundary
values; every case terminates and every case that returns a slot returns one
below the resulting capacity.

With the patch, each hostile input above is rejected with a warning, the request
gets a 503, and the router stays alive and serving.

Note for reviewers: a rejected segment produces `[alert] response buffer too
small: 0` on the follow-up message. Handled cleanly, but it is an `[alert]`, so
the pytest framework would fail any test that trips the bound.

Not addressed here, tracked in #172: the process-lifetime UAF in
`nxt_runtime_process_find()`, and the libunit mirrors of the `st_size` check and
the `uint32_t` wrap. `NXT_PORT_MMAP_MAX_SEGMENTS` must **not** be applied
symmetrically to `nxt_unit_mmap_at()` — the router→app direction is genuinely
uncapped and a bound there would reject legitimate segments.
