### PR TITLE
fix(router): release adopted response buffers on the error path

### DIFF
--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4263,7 +4263,7 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
     size_t                  b_size, count;
     nxt_int_t               ret;
     nxt_app_t               *app;
-    nxt_buf_t               *b, *next;
+    nxt_buf_t               *b, *next, *last_b, *owned_b;
     nxt_port_t              *app_port;
     nxt_unit_field_t        *f;
     nxt_http_field_t        *field;
@@ -4292,12 +4292,17 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
         return;
     }
 
+    last_b = NULL;
+    owned_b = NULL;
+
     b = (msg->size == 0) ? NULL : msg->buf;
 
     if (msg->port_msg.last != 0) {
         nxt_debug(task, "router data create last buf");
 
-        nxt_buf_chain_add(&b, nxt_http_buf_last(r));
+        last_b = nxt_http_buf_last(r);
+
+        nxt_buf_chain_add(&b, last_b);
 
         req_rpc_data->rpc_cancel = 0;
 
@@ -4322,10 +4327,17 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
     if (msg->buf == b) {
         /* Disable instant buffer completion/re-using by port. */
         msg->buf = NULL;
+
+        /*
+         * The port will not complete these buffers anymore, track them
+         * to release the shared memory they hold on the error path.
+         */
+        owned_b = b;
     }
 
     if (r->header_sent) {
         nxt_buf_chain_add(&r->out, b);
+        owned_b = NULL;
 
         ret = nxt_http_comp_compress_app_response(task, r, &r->out);
         if (ret == NXT_ERROR) {
@@ -4408,19 +4420,30 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
             next = b->next;
             b->next = NULL;
 
+            if (owned_b == b) {
+                owned_b = next;
+            }
+
             nxt_work_queue_add(&task->thread->engine->fast_work_queue,
                                b->completion_handler, task, b, b->parent);
 
             b = next;
         }
 
-        if (b != NULL) {
-            nxt_buf_chain_add(&r->out, b);
-        }
-
+        /*
+         * Check compression before handing the chain over to r->out, so that
+         * the rejection below still owns it: nothing drains r->out on the
+         * error path.  nxt_http_comp_check_compression() reads r->resp and
+         * the request configuration, never r->out, so the order is free.
+         */
         ret = nxt_http_comp_check_compression(task, r);
         if (ret != NXT_OK) {
             goto fail;
+        }
+
+        if (b != NULL) {
+            nxt_buf_chain_add(&r->out, b);
+            owned_b = NULL;
         }
 
         nxt_http_request_header_send(task, r, nxt_http_request_send_body, NULL);
@@ -4456,6 +4479,25 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 fail:
 
     nxt_http_request_error(task, r, NXT_HTTP_SERVICE_UNAVAILABLE);
+
+    /*
+     * Complete the buffers adopted from the port above, if any: nobody else
+     * holds them.  Stop at last_b: it is the request's own sync buffer and
+     * completing it here would close the request before the error response
+     * has been sent.
+     *
+     * This runs after the error response has been built on purpose.  Fields
+     * already added to r->resp point straight into the application's shared
+     * memory chunk, and completing these buffers hands that chunk back to
+     * the application; releasing it any earlier would make the response
+     * depend on nxt_http_request_error() having reset the field store first.
+     */
+    while (owned_b != NULL && owned_b != last_b) {
+        b = owned_b->next;
+        owned_b->next = NULL;
+        owned_b->completion_handler(task, owned_b, owned_b->parent);
+        owned_b = b;
+    }
 
     nxt_request_rpc_data_unlink(task, req_rpc_data);
 }


### PR DESCRIPTION
Part of #172. Refs #120.

**Merge order: 2 of 4** (after #173, though the two are independent — disjoint
files, no conflict).

## This is not a leak, it is a silent permanent hang

`nxt_router_response_ready_handler()` clears `msg->buf` to stop the port from
completing the response chain, then owns that chain until it reaches `r->out` or
the completion work queue. Four `goto fail` sites sit inside that window — the
"response buffer too small" check, the fields-count check, the
`nxt_http_resp_field_add()` OOM, and an `nxt_http_field_process()` failure — and
`fail:` only builds an error response. So each of them abandons the chain: the
mmap handler reference is never dropped, the shm chunks are never marked free,
and the `nxt_mp_retain()` each buffer holds on `port->mem_pool` keeps the pool
alive forever.

I expected a slow leak. Measured against `2f52138b`, with a libunit application
that emits a 2-byte `Status` field (which makes `nxt_http_response_status()`
return `NXT_ERROR`, reaching the fourth site), response sized above 1 KiB so the
buffer carries shm chunks:

| | master `2f52138b` | this PR |
|---|---|---|
| 2 000 error responses | router segments 1→5, RSS 4448→21940 kB | segments 1→2, RSS 4440→4780 kB |
| 20 000 error responses | **stalls permanently at request #6400** | 20 000 in 3.6 s |
| after the stall | `/ok` times out — the app never serves again, and **nothing is logged** | `/ok` → 200 |
| 50 000 error responses | not attempted, already dead | 2 segments, interleaved `/ok` fine |

The stall is the leak reaching `shm_mmap_limit` = `100 MB / PORT_MMAP_DATA_SIZE`
= 11 segments — exactly what `/proc/<pid>/maps` showed — after which libunit
blocks forever in `nxt_unit_wait_shm_ack()` because the router never frees the
leaked chunks. Any application that can be made to emit a rejected response
header can wedge itself permanently, with no diagnostic.

## What this does

Track the adopted chain in `owned_b`, drop the tracking wherever ownership moves
on (both `nxt_buf_chain_add()` calls into `r->out`, and the buffer handed to the
fast work queue when the response carries no body), and complete whatever is left
at `fail:`, one buffer at a time so the chain-walking completion handlers cannot
double-complete.

Two subtleties, both load-bearing:

- **The release runs after `nxt_http_request_error()`, not before.** Fields
  already added to `r->resp` hold `nxt_unit_sptr_get()` pointers straight into
  the application's shm chunk, and completing the buffers hands that chunk back
  to the application. Releasing earlier would make the 503 depend on
  `nxt_http_request_error()` having reset the field store first — which it does
  today, but relying on that would turn this into an information disclosure the
  moment that reset moved.
- **The buffer appended by `nxt_http_buf_last()` is deliberately excluded.** Its
  completion handler is `nxt_http_request_done` → `nxt_http_request_close_handler()`,
  which tears the request down; completing it here would close the request and
  then hand the freed `r` to `nxt_http_request_error()`. Since
  `nxt_buf_chain_add()` appends it before the adoption point, a naive unwind
  would have converted this leak into a use-after-free.

## Scope: this closes four of six sites, not all six

The other two — the compression error in the `header_sent` branch, and the
compression check after the header was parsed — are reached with the chain
already linked into `r->out`, and **nothing drains `r->out` on the error path**
(the same observation is already recorded in a comment in `nxt_http_static.c`:
discard only drains connection buffers and `r->last`). So they leak exactly as
before.

The second of those is reachable without a misbehaving application: with any
compressor configured, `Accept-Encoding: identity;q=0` makes
`nxt_http_comp_check_compression()` return `NXT_HTTP_NOT_ACCEPTABLE`, which is
positive and so fails the `!= NXT_OK` test.

I did not extend the patch to cover them, deliberately. By that point `r->out`
can also hold buffers from earlier partial responses already queued on the
connection, so completing the chain there would double-complete those — a
use-after-free, strictly worse than the leak. It needs a different mechanism
(the static-file code solves the analogous problem with an `nxt_mp_cleanup()`).
Tracked in #172.

## Verification

`test_php_application.py` 49 passed / 3 skipped, identical to baseline, as are
the other suites that run locally. Zero warnings under `-Wall -Wextra -Werror`,
including a standalone `-O2` rebuild where `-Wmaybe-uninitialized` would fire on
a bookkeeping hole.

No double-free: 100k error responses across runs, zero crashes, zero alerts, and
the 503 is byte-identical to baseline (300 samples, one distinct response).
Residual RSS growth on the error path matches the success-path `/ok` control on
both builds, i.e. it is pre-existing background growth and not attributable to
this change.

Also found while reasoning about this, pre-existing and tracked in #172:
`nxt_http_buf_last(r)` clears `r->last`, so on a `goto fail` with
`port_msg.last != 0` the error response goes out with no `NXT_BUF_SYNC_LAST` and
the request never closes until the send timeout; and
`nxt_http_comp_compress_app_response()` plain-frees the original app buffer with
`nxt_buf_free()` (a bare `nxt_mp_free()`, no completion handler), leaking the
head buffer's shm chunks on **every compressed response**.
