### PR TITLE
fix(websocket): check shm buffer allocation before use

### DIFF
--- a/src/nxt_http_websocket.c
+++ b/src/nxt_http_websocket.c
@@ -69,6 +69,18 @@ nxt_http_websocket_client(nxt_task_t *task, void *obj, void *data)
 
                 buf = nxt_port_mmap_get_buf(task, &req_rpc_data->app->outgoing,
                                             buf_free_size);
+                if (nxt_slow_path(buf == NULL)) {
+                    while (out != NULL) {
+                        buf = out->next;
+                        out->next = NULL;
+                        out->completion_handler(task, out, out->parent);
+                        out = buf;
+                    }
+
+                    nxt_http_websocket_error_handler(task, r, r->proto.any);
+
+                    return;
+                }
 
                 *out_tail = buf;
                 out_tail = &buf->next;


### PR DESCRIPTION
Part of #172. Refs #120.

**Merge order: 3 of 4** (independent of the others — single file, no conflict).

## What is wrong

`src/nxt_http_websocket.c`, in the frame-forwarding loop:

```c
buf = nxt_port_mmap_get_buf(task, &req_rpc_data->app->outgoing, buf_free_size);

*out_tail = buf;
out_tail = &buf->next;      /* NULL deref if the allocation failed */
```

`nxt_port_mmap_get_buf()` returns NULL on `nxt_buf_mem_ts_alloc` failure or on
shared-memory exhaustion. Every other caller in the tree checks —
`nxt_router.c:5619` and `nxt_router.c:5812` — this one does not.

Traffic alone cannot make that allocation fail (there is no shm cap on this
path), so it was verified by injecting a forced NULL on the second allocation of
a 12 MiB frame — which also exercises the non-empty `out` chain the fix has to
release — into a throwaway build:

| | unfixed router | this PR |
|---|---|---|
| websocket frame, forced allocation failure | `[alert] process 2384838 exited on signal 11 (core dumped)` | connection closed cleanly, plain HTTP still served |

## What this does

NULL-check the allocation, release the partially built `out` chain, and terminate
the connection via the state's own error handler.

The unwind loop is a verbatim copy of the existing house pattern at
`nxt_router.c:5813-5821` — same `nxt_port_mmap_get_buf()` failure, same loop,
same synchronous completion. Clearing `->next` before each `completion_handler`
call matters: `nxt_port_mmap_buf_completion()` walks the `next` chain itself and
would otherwise double-complete.

`nxt_http_websocket_error_handler()` is the right target rather than the generic
`nxt_http_request_error_handler()`: we are inside `nxt_http_websocket_client()`,
which is the `.ready_handler` of the `nxt_http_websocket` state, so calling it
directly is equivalent to `r->state->error_handler(task, r, r->proto.any)` — and
it writes `NXT_PORT_MSG_WEBSOCKET_LAST` to the app port, which the generic
handler would skip, leaving the application's websocket handler waiting.

By the time the allocation fails the loop has already advanced `b->mem.pos` and
may have completed earlier buffers, so the frame stream is desynchronised and
cannot be resumed — ending the connection is the only correct option.
`r->ws_frame` needs no special handling: its buffers come from the connection
pool, fully drained ones were already unlinked and handed to the work queue, and
whatever remains dies with the pool during close.

## Known tradeoff

The connection is closed without a WebSocket Close frame. The right vocabulary
exists — `nxt_ws_err_out_of_memory` (code 1011), used for the analogous OOM case
in `nxt_h1proto_websocket.c` — but `nxt_h1p_send_ws_error` is `static` and
proto-specific, so the generic layer genuinely cannot reach it. Sending a proper
1011 would need a small refactor; flagging rather than doing it here.

There is also no log line on this path. The sibling site at `nxt_router.c:5621`
is equally silent, so I left it consistent rather than diverging unilaterally —
but an operator currently sees a websocket vanish with no diagnostic, and a
one-line `nxt_alert()` would be cheap if reviewers prefer it.

## Verification

Builds clean under `-Wall -Wextra -Werror` (forced standalone recompile of the
translation unit, so no warning is hidden by parallel output). Websocket frames
of 16 B through 5 MiB echo byte-exact via the native `build/unit_websocket_echo`
client. All locally runnable suites identical to the `2f52138b` baseline.

Note `nxt_http_websocket.c:117` still carries `if (res != NXT_OK) { // TODO: handle }`,
which abandons the whole `out` chain when `nxt_port_socket_write()` returns
`NXT_AGAIN` *and* silently drops the frame while the router proceeds as though it
had been delivered. Left alone here — it needs a decision on whether `NXT_AGAIN`
should be queued or treated as fatal. Tracked in #172.
