### PR TITLE
fix(unit): bounds-check router-supplied chunk_id and size in libunit

### DIFF
--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -4456,7 +4456,7 @@ nxt_unit_mmap_read(nxt_unit_ctx_t *ctx, nxt_unit_recv_msg_t *recv_msg,
 {
     int                     res;
     void                    *start;
-    uint32_t                size;
+    uint32_t                size, nchunks;
     nxt_unit_impl_t         *lib;
     nxt_unit_mmaps_t        *mmaps;
     nxt_unit_mmap_buf_t     *b, **incoming_tail;
@@ -4513,6 +4513,43 @@ nxt_unit_mmap_read(nxt_unit_ctx_t *ctx, nxt_unit_recv_msg_t *recv_msg,
             }
 
             return res;
+        }
+
+        /*
+         * mmap_msg fields originate from the router; reject offsets that
+         * would point outside the mapped data area before they reach the
+         * pointer arithmetic below.
+         */
+        nchunks = mmap_msg->size / PORT_MMAP_CHUNK_SIZE;
+        if ((mmap_msg->size % PORT_MMAP_CHUNK_SIZE) != 0) {
+            nchunks++;
+        }
+
+        if (nxt_slow_path(mmap_msg->chunk_id >= PORT_MMAP_CHUNK_COUNT
+                          || nchunks > (uint32_t) PORT_MMAP_CHUNK_COUNT
+                                       - mmap_msg->chunk_id))
+        {
+            nxt_unit_alert(ctx, "#%"PRIu32": mmap_read: invalid mmap message: "
+                           "chunk_id %"PRIu32", size %"PRIu32
+                           " (chunks %"PRIu32", max %d)",
+                           recv_msg->stream, mmap_msg->chunk_id,
+                           mmap_msg->size, nchunks, PORT_MMAP_CHUNK_COUNT);
+
+            pthread_mutex_unlock(&mmaps->mutex);
+
+            /*
+             * Entries before the rejected one are already populated, and
+             * this message is dropped rather than retried, so their chunks
+             * have to be marked free as well: nxt_unit_mmap_buf_release()
+             * alone would recycle the wrappers and leave the chunks busy in
+             * the peer's segment for good.  Entries not reached yet have a
+             * NULL hdr and are skipped by nxt_unit_free_outgoing_buf().
+             */
+            while (recv_msg->incoming_buf != NULL) {
+                nxt_unit_mmap_buf_free(recv_msg->incoming_buf);
+            }
+
+            return NXT_UNIT_ERROR;
         }
 
         start = nxt_port_mmap_chunk_start(hdr, mmap_msg->chunk_id);


### PR DESCRIPTION
Part of #172. Refs #120.

**Merge order: 4 of 4** (independent — single file, no conflict). Last because it
is the only one of the four with no reproduced failure behind it: its peer is the
router, the more privileged side, so this is defence in depth rather than a live
application-attacker path.

## Why it still matters: it makes 669987d6's own fix load-bearing

`669987d6` added `nxt_port_mmap_chunk_range_valid()` on the router side and, on
the libunit side, arrival-time validation of every request `sptr`, with the
stated goal of rejecting an out-of-range offset "before any libunit consumer
dereferences it".

That validation bounds every offset against `recv_msg->size`. And
`recv_msg->size` is assigned from `mmap_msg->size` in `nxt_unit_mmap_read()` —
an unbounded peer `uint32_t` that libunit never checked, right next to a
`nxt_port_mmap_chunk_start(hdr, mmap_msg->chunk_id)` with no counterpart to the
range check the same commit added on the other side of the boundary.

So a `size` of `0xFFFFFFFF` makes every `sptr` check pass for offsets up to 4 GB
past the chunk. The guarantee is defeated by an input the same commit fixed in
the other direction. Two more consequences of the same unbounded `size`:

- `b->buf.end = b->buf.start + size` lets `nxt_unit_buf_read()` hand the
  application bytes past the end of the 10 MB mapping;
- `nxt_unit_mmap_release()` does `memset(start, 0xA5, size)` and then walks the
  free-chunk bitmap over `size / PORT_MMAP_CHUNK_SIZE` chunks — an unbounded
  write and an unbounded bitmap walk.

## What this does

Mirror the router's range check in `nxt_unit_mmap_read()`, computing `nchunks` by
dividing before adjusting so the count itself cannot wrap — **not**
`(size + CHUNK_SIZE - 1) / CHUNK_SIZE`, which overflows for a peer-controlled
`uint32_t` — and subtracting on the constant side so the second test cannot
underflow (the first test guarantees it).

The check runs after `nxt_unit_check_rbuf_mmap()` returned `NXT_UNIT_OK`, i.e.
with `mmaps->mutex` still held. That function unlocks only on its own error and
`AGAIN` paths, which is why the existing error branch beside this one correctly
returns without unlocking and why the new one must unlock explicitly. Verified
against the code rather than assumed.

## A check this PR deliberately does NOT add

An earlier revision also added the seemingly symmetric `|| hdr->dst_pid != lib->pid`
to `nxt_unit_incoming_mmap()`, on the reasoning that it compares only `src_pid`
while its alert already formats both pairs, and the router checks both. That was
wrong and it broke everything:

`hdr->dst_pid` is assigned in exactly one place in the tree — `nxt_unit.c`, the
app side. The router's `nxt_port_new_port_mmap()` sets `id`, `src_pid` and
`sent_over` only, so on a router-created segment the field is still the zero left
by `ftruncate()`. Its own debug line says as much: `"new mmap #%D created for %PI -> ..."`,
with no destination. `test_php_application.py` went from 49 passed to a hard
"Can't read response from server" on the first request, because
`nxt_router_prepare_msg()` sends every request through `app->outgoing`.

The asymmetry between the two sides is load-bearing, and the commit message now
records that so it does not get "fixed" again. The four-value alert text is just
sloppy logging.

## Verification

`test_php_application.py` 49 passed / 3 skipped, identical to baseline, as are
the other locally runnable suites. Zero warnings under `-Wall -Wextra -Werror`
for both `unitd` and `php8.unit.so` (libunit is compiled into the module, so the
module target is what actually exercises this).

Boundary cases hand-traced and confirmed: `(639, 16384)` passes, `(639, 16385)`
fails, `(640, 0)` fails, `(0, 0)` passes — zero-length is legal and harmless —
and `(0, 0xFFFFFFFF)` fails.

**Gap, stated plainly:** only the accept path is exercised — by every request in
the verification above, with no false rejection. Testing the *reject* path needs a
hostile router, which I did not fake. Tracked in #172.

The libunit mirrors of the other router-side fixes — the `st_size` check and the
same `uint32_t` wrap in `nxt_unit_mmap_at()` — are not in this PR. Note that
`NXT_PORT_MMAP_MAX_SEGMENTS` from #173 must **not** be applied symmetrically to
`nxt_unit_mmap_at()`: the router→app direction is genuinely uncapped
(`nxt_port_memory.c` still carries `TODO introduce port_mmap limit`) and
`nxt_port_mmap_get()` needs a *contiguous* run of chunks, so fragmentation can
push the router's segment count past the ideal. A bound there would reject
legitimate segments — the same class of mistake as the `dst_pid` check above.
