### PR TITLE
test(port): make the shm chunk-range check shared and pin it against the uint32_t wrap band

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -176,6 +176,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_http_chunk_parse_test.c \
     src/test/nxt_conf_parse_test.c \
     src/test/nxt_port_fail_test.c \
+    src/test/nxt_port_mmap_range_test.c \
 "
 
 

--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -635,26 +635,6 @@ nxt_port_get_port_incoming_mmap(nxt_task_t *task, nxt_pid_t spid, uint32_t id)
 }
 
 
-/*
- * Validate that a peer-supplied (chunk_id, nchunks) pair refers to a
- * region wholly inside the mapped data area.  Returns non-zero on
- * success.  Underflow-safe: subtracts on the constant side.
- */
-nxt_inline nxt_bool_t
-nxt_port_mmap_chunk_range_valid(nxt_chunk_id_t chunk_id, size_t nchunks)
-{
-    if (chunk_id >= PORT_MMAP_CHUNK_COUNT) {
-        return 0;
-    }
-
-    if (nchunks > (size_t) PORT_MMAP_CHUNK_COUNT - chunk_id) {
-        return 0;
-    }
-
-    return 1;
-}
-
-
 nxt_buf_t *
 nxt_port_mmap_get_buf(nxt_task_t *task, nxt_port_mmaps_t *mmaps, size_t size)
 {
@@ -796,13 +776,9 @@ nxt_port_mmap_get_incoming_buf(nxt_task_t *task, nxt_port_t *port,
      * that would point outside the mapped data area before they reach
      * pointer arithmetic below.
      */
-    nchunks = mmap_msg->size / PORT_MMAP_CHUNK_SIZE;
-    if ((mmap_msg->size % PORT_MMAP_CHUNK_SIZE) != 0) {
-        nchunks++;
-    }
-
     if (nxt_slow_path(!nxt_port_mmap_chunk_range_valid(mmap_msg->chunk_id,
-                                                      nchunks)))
+                                                       mmap_msg->size,
+                                                       &nchunks)))
     {
         nxt_alert(task, "invalid mmap message from pid %PI: "
                   "chunk_id %uD, size %uD (chunks %uz, max %d)",

--- a/src/nxt_port_memory_int.h
+++ b/src/nxt_port_memory_int.h
@@ -147,13 +147,19 @@ nxt_port_mmap_chunk_start(nxt_port_mmap_header_t *hdr, nxt_chunk_id_t c)
  * it in their diagnostics before dropping the message.
  *
  * The chunk count is computed here, in size_t, with the divide-then-adjust
- * form and never as (size + PORT_MMAP_CHUNK_SIZE - 1) / PORT_MMAP_CHUNK_SIZE:
- * size is a peer-controlled uint32_t and the round-up addition wraps for
- * size in [0xFFFFC001, 0xFFFFFFFF], yielding zero chunks and thus wrongly
- * accepting the message.  Keeping the arithmetic here, out of the callers,
- * is what makes it testable.
+ * form.  For a peer-supplied uint32_t size it must never be written as
+ * (size + PORT_MMAP_CHUNK_SIZE - 1) / PORT_MMAP_CHUNK_SIZE: that addition is
+ * evaluated at 32 bits and wraps for size in [0xFFFFC001, 0xFFFFFFFF],
+ * yielding zero chunks and thus wrongly accepting the message.  (Elsewhere
+ * in this tree the same idiom is reached only with a size_t size, or with
+ * one a caller has already clamped to PORT_MMAP_DATA_SIZE.)  Keeping the
+ * arithmetic here, out of the callers, is what makes it testable.
  *
- * Underflow-safe: subtracts on the constant side.
+ * The subtraction on the constant side is underflow-safe only because the
+ * chunk_id test above has already established chunk_id < PORT_MMAP_CHUNK_COUNT.
+ * It is not an independent property: drop that test and
+ * PORT_MMAP_CHUNK_COUNT - chunk_id underflows to a huge size_t, which the
+ * count comparison then passes.
  */
 nxt_inline nxt_bool_t
 nxt_port_mmap_chunk_range_valid(nxt_chunk_id_t chunk_id, uint32_t size,

--- a/src/nxt_port_memory_int.h
+++ b/src/nxt_port_memory_int.h
@@ -138,6 +138,49 @@ nxt_port_mmap_chunk_start(nxt_port_mmap_header_t *hdr, nxt_chunk_id_t c)
 }
 
 
+/*
+ * Validate that a peer-supplied (chunk_id, size) pair describes a region
+ * wholly inside the mapped data area, and report the number of chunks the
+ * region spans via *nchunks.  Returns non-zero on success.
+ *
+ * *nchunks is always written, on the reject path as well: the callers log
+ * it in their diagnostics before dropping the message.
+ *
+ * The chunk count is computed here, in size_t, with the divide-then-adjust
+ * form and never as (size + PORT_MMAP_CHUNK_SIZE - 1) / PORT_MMAP_CHUNK_SIZE:
+ * size is a peer-controlled uint32_t and the round-up addition wraps for
+ * size in [0xFFFFC001, 0xFFFFFFFF], yielding zero chunks and thus wrongly
+ * accepting the message.  Keeping the arithmetic here, out of the callers,
+ * is what makes it testable.
+ *
+ * Underflow-safe: subtracts on the constant side.
+ */
+nxt_inline nxt_bool_t
+nxt_port_mmap_chunk_range_valid(nxt_chunk_id_t chunk_id, uint32_t size,
+    size_t *nchunks)
+{
+    size_t  n;
+
+    n = size / PORT_MMAP_CHUNK_SIZE;
+
+    if ((size % PORT_MMAP_CHUNK_SIZE) != 0) {
+        n++;
+    }
+
+    *nchunks = n;
+
+    if (chunk_id >= PORT_MMAP_CHUNK_COUNT) {
+        return 0;
+    }
+
+    if (n > (size_t) PORT_MMAP_CHUNK_COUNT - chunk_id) {
+        return 0;
+    }
+
+    return 1;
+}
+
+
 nxt_inline nxt_bool_t
 nxt_port_mmap_get_free_chunk(nxt_free_map_t *m, nxt_chunk_id_t *c)
 {

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -4456,7 +4456,8 @@ nxt_unit_mmap_read(nxt_unit_ctx_t *ctx, nxt_unit_recv_msg_t *recv_msg,
 {
     int                     res;
     void                    *start;
-    uint32_t                size, nchunks;
+    size_t                  nchunks;
+    uint32_t                size;
     nxt_unit_impl_t         *lib;
     nxt_unit_mmaps_t        *mmaps;
     nxt_unit_mmap_buf_t     *b, **incoming_tail;
@@ -4520,18 +4521,13 @@ nxt_unit_mmap_read(nxt_unit_ctx_t *ctx, nxt_unit_recv_msg_t *recv_msg,
          * would point outside the mapped data area before they reach the
          * pointer arithmetic below.
          */
-        nchunks = mmap_msg->size / PORT_MMAP_CHUNK_SIZE;
-        if ((mmap_msg->size % PORT_MMAP_CHUNK_SIZE) != 0) {
-            nchunks++;
-        }
-
-        if (nxt_slow_path(mmap_msg->chunk_id >= PORT_MMAP_CHUNK_COUNT
-                          || nchunks > (uint32_t) PORT_MMAP_CHUNK_COUNT
-                                       - mmap_msg->chunk_id))
+        if (nxt_slow_path(!nxt_port_mmap_chunk_range_valid(mmap_msg->chunk_id,
+                                                           mmap_msg->size,
+                                                           &nchunks)))
         {
             nxt_unit_alert(ctx, "#%"PRIu32": mmap_read: invalid mmap message: "
                            "chunk_id %"PRIu32", size %"PRIu32
-                           " (chunks %"PRIu32", max %d)",
+                           " (chunks %zu, max %d)",
                            recv_msg->stream, mmap_msg->chunk_id,
                            mmap_msg->size, nchunks, PORT_MMAP_CHUNK_COUNT);
 

--- a/src/test/nxt_port_mmap_range_test.c
+++ b/src/test/nxt_port_mmap_range_test.c
@@ -1,0 +1,162 @@
+
+/*
+ * Copyright (C) NGINX, Inc.
+ */
+
+/*
+ * nxt_port_mmap_chunk_range_valid() guards every consumer of a peer-authored
+ * (chunk_id, size) pair: both fields are uint32_t values written by the other
+ * side of a shared memory segment, and both feed pointer arithmetic over a
+ * 10 MB mapping.
+ *
+ * The reason this test exists is the chunk count.  The idiomatic round-up
+ *
+ *     nchunks = (size + PORT_MMAP_CHUNK_SIZE - 1) / PORT_MMAP_CHUNK_SIZE;
+ *
+ * overflows when the addition leaves uint32_t range, i.e. for every size in
+ * [0xFFFFC001, 0xFFFFFFFF] -- exactly 16383 values.  On each of them it yields
+ * nchunks == 0, which passes the "fits in the segment" test and therefore
+ * *accepts* a message claiming a ~4 GB payload.  The two-step form used by the
+ * function -- divide first, adjust for the remainder afterwards, in size_t --
+ * yields the correct 262144 for those sizes and rejects them.
+ *
+ * That one-liner compiles clean under -Wall -Wextra -Werror, reads better than
+ * what it would replace, and passes every other test in this tree while
+ * reopening a 16383-value acceptance hole.  The wrap-band rows below exist so
+ * that "simplification" fails loudly instead.
+ *
+ * The table is written for the production shm geometry; NXT_MMAP_TINY_CHUNK
+ * changes PORT_MMAP_DATA_SIZE by four orders of magnitude, so the expected
+ * counts would all have to be recomputed for such a build.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port_memory_int.h>
+#include "nxt_tests.h"
+
+
+#if (PORT_MMAP_CHUNK_SIZE != 16384 || PORT_MMAP_CHUNK_COUNT != 640            \
+     || PORT_MMAP_DATA_SIZE != 10485760 || PORT_MMAP_SIZE != 10489856)
+#error src/test/nxt_port_mmap_range_test.c: the expected chunk counts are \
+       derived from the production shm geometry; recompute the table.
+#endif
+
+
+nxt_int_t
+nxt_port_mmap_range_test(nxt_thread_t *thr)
+{
+    size_t      nchunks;
+    nxt_uint_t  i;
+    nxt_bool_t  valid;
+
+    static const struct {
+        nxt_chunk_id_t  chunk_id;
+        uint32_t        size;
+        nxt_bool_t      valid;
+        size_t          nchunks;
+
+    } tests[] = {
+        /* Boundaries.  A zero-length range is legal and spans no chunks. */
+        {     0,          0,  1,      0 },
+        {     0,          1,  1,      1 },
+        {     0,      16384,  1,      1 },
+        {     0,      16385,  1,      2 },
+
+        /* Two chunks starting two chunks from the end, and one too many. */
+        {   638,      32768,  1,      2 },
+        {   638,      32769,  0,      3 },
+
+        /* The last legal chunk, and the off-by-one on the far side. */
+        {   639,          0,  1,      0 },
+        {   639,      16384,  1,      1 },
+        {   639,      16385,  0,      2 },
+
+        /* The first illegal chunk_id, with and without a payload. */
+        {   640,          0,  0,      0 },
+        {   640,          1,  0,      1 },
+
+        /* The whole data area, and one byte past it. */
+        {     0,   10485760,  1,    640 },
+        {     0,   10485761,  0,    641 },
+
+        /*
+         * The wrap band.  0xFFFFC000 is the last size for which the naive
+         * round-up still fits in uint32_t, so both forms agree there; from
+         * 0xFFFFC001 up the naive form wraps to nchunks == 0 and accepts.
+         */
+        {     0, 0xFFFFC000,  0, 262143 },
+        {     0, 0xFFFFC001,  0, 262144 },
+        {     0, 0xFFFFC002,  0, 262144 },
+        {     0, 0xFFFFE000,  0, 262144 },
+        {     0, 0xFFFFFFFE,  0, 262144 },
+        {     0, 0xFFFFFFFF,  0, 262144 },
+
+        /*
+         * A huge count against a legal chunk_id near the end: rejected, and
+         * the subtraction on the constant side never underflows getting
+         * there.  This row does not distinguish the current form from a
+         * rewrite to "chunk_id + nchunks > PORT_MMAP_CHUNK_COUNT" -- 639 +
+         * 262144 does not wrap, so that form rejects here too.  The row that
+         * fails such a rewrite is (640, 0) above, where 640 + 0 is not
+         * greater than 640.
+         */
+        {   639, 0xFFFFFFFF,  0, 262144 },
+
+        /*
+         * The maximum peer-authored chunk_id.  Both this row and (640, 0)
+         * above fail if the chunk_id test is deleted, but through different
+         * arithmetic, so neither is redundant as documentation of why the
+         * test has to stay:
+         *
+         *   (640, 0)         limit is 640 - 640 == 0 and nchunks is 0, so
+         *                    "0 > 0" is false and the range is accepted;
+         *   (0xFFFFFFFF, 1)  limit underflows to a huge value modulo
+         *                    SIZE_MAX -- 18446744069414584961 where size_t
+         *                    is 64 bits, 641 where it is 32 -- and nchunks
+         *                    == 1 does not exceed either, so it is accepted.
+         *
+         * The second is the one worth having in view, because it shows the
+         * "subtract on the constant side" form is underflow-safe only while
+         * the chunk_id test runs first -- it is not a property of the
+         * subtraction on its own.
+         *
+         * This row also fails a rewrite to "(uint32_t) (chunk_id + nchunks) >
+         * PORT_MMAP_CHUNK_COUNT", where the sum wraps to 0 and is accepted.
+         * nchunks must be >= 1 to reach 0, so (0xFFFFFFFF, 0) would not do.
+         */
+        { 0xFFFFFFFF,       1,  0,      1 },
+    };
+
+    nxt_thread_time_update(thr);
+
+    for (i = 0; i < nxt_nitems(tests); i++) {
+        nchunks = (size_t) -1;
+
+        valid = nxt_port_mmap_chunk_range_valid(tests[i].chunk_id,
+                                                tests[i].size, &nchunks);
+
+        if ((valid != 0) != (tests[i].valid != 0)) {
+            nxt_log_alert(thr->log,
+                          "nxt_port_mmap_chunk_range_valid() test failed: "
+                          "chunk_id %uD, size %uD: got %d, expected %d",
+                          tests[i].chunk_id, tests[i].size,
+                          (int) (valid != 0), (int) (tests[i].valid != 0));
+            return NXT_ERROR;
+        }
+
+        if (nchunks != tests[i].nchunks) {
+            nxt_log_alert(thr->log,
+                          "nxt_port_mmap_chunk_range_valid() test failed: "
+                          "chunk_id %uD, size %uD: got %uz chunks, "
+                          "expected %uz",
+                          tests[i].chunk_id, tests[i].size, nchunks,
+                          tests[i].nchunks);
+            return NXT_ERROR;
+        }
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "nxt_port_mmap_chunk_range_valid() test passed");
+
+    return NXT_OK;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -190,6 +190,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_port_mmap_range_test(thr) != NXT_OK) {
+        return 1;
+    }
+
 #if (NXT_HAVE_CGROUP)
     if (nxt_cgroup_test(thr) != NXT_OK) {
         return 1;

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -71,6 +71,7 @@ nxt_int_t nxt_http_chunk_parse_test(nxt_thread_t *thr);
 nxt_int_t nxt_conf_json_depth_test(nxt_thread_t *thr);
 nxt_int_t nxt_http_route_addr_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
+nxt_int_t nxt_port_mmap_range_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);
 


### PR DESCRIPTION
Part of #172 (item P1 of the test plan). First test coverage of anything in the
shm port protocol.

Two commits: a pure refactor, then the test it enables.

## Why the refactor is a prerequisite, not a tidy-up

`nxt_port_mmap_chunk_range_valid()` lived in `src/nxt_port_memory.c` declared
`nxt_inline` — i.e. `static inline` — so it had **no external linkage and was
invisible to `build/tests`**. It could not be unit-tested where it was.

It was also duplicated. #176 added a hand-inlined second copy in
`nxt_unit_mmap_read()`, and the two computed the chunk count in **different
integer types**: `size_t` in the router, `uint32_t` in libunit. Worse, the round-up
lived in the *callers* both times, so the interesting arithmetic sat outside the
function a test could reach even after hoisting it.

So this moves the predicate into `src/nxt_port_memory_int.h` — already included by
both sides — and takes the arithmetic with it:

```c
nxt_inline nxt_bool_t
nxt_port_mmap_chunk_range_valid(nxt_chunk_id_t chunk_id, uint32_t size,
    size_t *nchunks)
```

Both call sites now do no arithmetic of their own. `*nchunks` is written
unconditionally, before either check, because both callers print the count in
their rejection alert.

**Behaviour is unchanged, and that is demonstrated rather than asserted.** A
scratch harness implementing all four variants — old router, old libunit, the new
function, and the forbidden round-up — was compared over 6,246,843 inputs: the
full boundary grid, every `chunk_id` in `[0, 642]` crossed with every chunk
multiple ±1 up to the segment size, and 5M random pairs.

```
new vs old-router diffs:         0
new vs old-libunit diffs:        0
old-router vs old-libunit diffs: 0
overflow-form (bad) diffs:       1956
```

The type mismatch between the two old copies was therefore a real inconsistency
but **not** an exploitable one — max count is 262144, comfortably inside
`uint32_t`, and libunit's `||` short-circuited so the subtraction only evaluated
once `chunk_id < 640` was known. This removes the inconsistency; it does not fix a
live bug, and the commit message says so.

## What the test pins

`src/test/nxt_port_mmap_range_test.c`, 20 rows, registered in `NXT_TEST_SRCS`,
`nxt_tests.h` and `nxt_tests.c` per the house pattern.

Boundaries — the check is exactly tight, since
`4096 + 640*16384 == 10489856 == PORT_MMAP_SIZE`: `(639, 16384)` valid,
`(639, 16385)` invalid, `(640, *)` invalid, `(0, 0)` valid with 0 chunks,
`(0, PORT_MMAP_DATA_SIZE)` valid with 640, `(0, +1)` invalid, and
`(639, 0xFFFFFFFF)` to pin the underflow direction against a future refactor to
`chunk_id + nchunks > COUNT`.

**The wrap band is the point of the whole test.** The idiomatic round-up
`(size + PORT_MMAP_CHUNK_SIZE - 1) / PORT_MMAP_CHUNK_SIZE` overflows `uint32_t`
for `size` in `[0xFFFFC001, 0xFFFFFFFF]` — exactly 16383 values — yielding
`nchunks == 0` on every one of them and therefore **accepting** a range claiming
~4 GB. The divide-then-adjust form yields 262144 and rejects.

That edit is plausible, it compiles clean, and it passes every other test in the
tree. Nothing else in the repo would catch it.

`*nchunks` is pre-poisoned to `(size_t) -1` before each call and asserted on every
row including the rejecting ones, so the contract is pinned in both directions.

## Verification

The test was mutated-tested against the real hoisted function on the combined
branch, not against a stand-in:

```
$ # header patched to the naive round-up
$ make tests            # zero warnings — the hole is invisible to -Wall -Wextra -Werror
$ ./build/tests
tests: [alert] nxt_port_mmap_chunk_range_valid() test failed: chunk_id 0, size 4294950913: got 1, expected 0
rc=1
```

`4294950913` is `0xFFFFC001` — the first value in the band, immediately after
`0xFFFFC000` which passes. The failure lands exactly on the divergence point.
Reverted, and:

```
tests: [notice] nxt_port_mmap_chunk_range_valid() test passed
rc=0
```

Also `test_php_application.py` + `test_return.py`: 55 passed, 3 skipped, matching
baseline. Zero warnings under `-Wall -Wextra -Werror`.

**No CI change needed** — `build-test.yml` already has a `c-tests` job running
`./build/tests`, and `analysis-clang-ast.yml` runs it a second time. Cost is under
a millisecond.

## What this does not cover

The end-to-end rejection paths — malformed `NXT_PORT_MSG_MMAP`, a short shm fd,
out-of-range `hdr->id` — remain untested; those are P0 and P2 in #172's plan and
need a libunit test application. This covers the arithmetic at the level where it
is affordable today, which is the cheap 90% of the `chunk_id`/`size` case.
