### PR TITLE
chore(port): drop the dead tracking fields and assert the header fits

### DIFF
--- a/src/nxt_clang.h
+++ b/src/nxt_clang.h
@@ -13,6 +13,35 @@
 #define nxt_cdecl
 
 
+/*
+ * nxt_static_assert() fails the compilation when the condition does not
+ * hold.  auto/cc/test adds -std=gnu11 only on its gcc and clang branches
+ * and leaves the generic "cc" branch alone, so a compiler defaulting to
+ * pre-C11 has to fall back to declaring an array with a negative size;
+ * there the message survives only in the type name, which has to be unique
+ * per use, hence the token pasting.
+ */
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+
+#define nxt_static_assert(cond, msg)                                          \
+    _Static_assert(cond, msg)
+
+#else
+
+#define nxt_static_assert_paste(prefix, line)                                 \
+    prefix##line
+
+#define nxt_static_assert_name(prefix, line)                                  \
+    nxt_static_assert_paste(prefix, line)
+
+#define nxt_static_assert(cond, msg)                                          \
+    typedef char nxt_static_assert_name(nxt_static_assert_failed_,            \
+                                        __LINE__)[(cond) ? 1 : -1]
+
+#endif
+
+
 #if (NXT_CLANG)
 
 /* Any __asm__ directive disables loop vectorization in GCC and Clang. */

--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -379,13 +379,11 @@ fail:
 
 
 static nxt_port_mmap_handler_t *
-nxt_port_new_port_mmap(nxt_task_t *task, nxt_port_mmaps_t *mmaps,
-    nxt_bool_t tracking, nxt_int_t n)
+nxt_port_new_port_mmap(nxt_task_t *task, nxt_port_mmaps_t *mmaps, nxt_int_t n)
 {
     void                     *mem;
     nxt_fd_t                 fd;
     nxt_int_t                i;
-    nxt_free_map_t           *free_map;
     nxt_port_mmap_t          *port_mmap;
     nxt_port_mmap_header_t   *hdr;
     nxt_port_mmap_handler_t  *mmap_handler;
@@ -427,22 +425,18 @@ nxt_port_new_port_mmap(nxt_task_t *task, nxt_port_mmaps_t *mmaps,
     hdr = mmap_handler->hdr;
 
     nxt_memset(hdr->free_map, 0xFFU, sizeof(hdr->free_map));
-    nxt_memset(hdr->free_tracking_map, 0xFFU, sizeof(hdr->free_tracking_map));
 
     hdr->id = mmaps->size - 1;
     hdr->src_pid = nxt_pid;
     hdr->sent_over = 0xFFFFu;
 
     /* Mark first chunk as busy */
-    free_map = tracking ? hdr->free_tracking_map : hdr->free_map;
-
     for (i = 0; i < n; i++) {
-        nxt_port_mmap_set_chunk_busy(free_map, i);
+        nxt_port_mmap_set_chunk_busy(hdr->free_map, i);
     }
 
     /* Mark as busy chunk followed the last available chunk. */
     nxt_port_mmap_set_chunk_busy(hdr->free_map, PORT_MMAP_CHUNK_COUNT);
-    nxt_port_mmap_set_chunk_busy(hdr->free_tracking_map, PORT_MMAP_CHUNK_COUNT);
 
     nxt_log(task, NXT_LOG_DEBUG, "new mmap #%D created for %PI -> ...",
             hdr->id, nxt_pid);
@@ -536,7 +530,7 @@ nxt_shm_open(nxt_task_t *task, size_t size)
 
 static nxt_port_mmap_handler_t *
 nxt_port_mmap_get(nxt_task_t *task, nxt_port_mmaps_t *mmaps, nxt_chunk_id_t *c,
-    nxt_int_t n, nxt_bool_t tracking)
+    nxt_int_t n)
 {
     nxt_int_t                i, res, nchunks;
     nxt_free_map_t           *free_map;
@@ -566,7 +560,7 @@ nxt_port_mmap_get(nxt_task_t *task, nxt_port_mmaps_t *mmaps, nxt_chunk_id_t *c,
 
         *c = 0;
 
-        free_map = tracking ? hdr->free_tracking_map : hdr->free_map;
+        free_map = hdr->free_map;
 
         while (nxt_port_mmap_get_free_chunk(free_map, c)) {
             nchunks = 1;
@@ -600,7 +594,7 @@ nxt_port_mmap_get(nxt_task_t *task, nxt_port_mmaps_t *mmaps, nxt_chunk_id_t *c,
 end:
 
     *c = 0;
-    mmap_handler = nxt_port_new_port_mmap(task, mmaps, tracking, n);
+    mmap_handler = nxt_port_new_port_mmap(task, mmaps, n);
 
 unlock_return:
 
@@ -676,7 +670,7 @@ nxt_port_mmap_get_buf(nxt_task_t *task, nxt_port_mmaps_t *mmaps, size_t size)
     b->completion_handler = nxt_port_mmap_buf_completion;
     nxt_buf_set_port_mmap(b);
 
-    mmap_handler = nxt_port_mmap_get(task, mmaps, &c, nchunks, 0);
+    mmap_handler = nxt_port_mmap_get(task, mmaps, &c, nchunks);
     if (nxt_slow_path(mmap_handler == NULL)) {
         mp = task->thread->engine->mem_pool;
         nxt_mp_free(mp, b);

--- a/src/nxt_port_memory_int.h
+++ b/src/nxt_port_memory_int.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <nxt_atomic.h>
+#include <nxt_clang.h>
 
 
 #ifdef NXT_MMAP_TINY_CHUNK
@@ -70,11 +71,40 @@ struct nxt_port_mmap_header_s {
     nxt_port_id_t   sent_over;
     nxt_atomic_t    oosm;
     nxt_free_map_t  free_map[MAX_FREE_IDX];
+    /*
+     * Not padding in the alignment sense: nxt_port_mmap_set_chunk_busy() is
+     * called with PORT_MMAP_CHUNK_COUNT to plant a permanently-busy sentinel
+     * one word past the last real word of free_map[], so that a multi-chunk
+     * allocation walking off the end of the segment fails to claim its
+     * continuation instead of reading past the end of the struct.
+     */
     nxt_free_map_t  free_map_padding;
-    nxt_free_map_t  free_tracking_map[MAX_FREE_IDX];
-    nxt_free_map_t  free_tracking_map_padding;
-    nxt_atomic_t    tracking[PORT_MMAP_CHUNK_COUNT];
+
+    /*
+     * Not a live field.  It reserves the window that a peer built before the
+     * tracking bitmap was dropped still writes: such a peer memsets
+     * MAX_FREE_IDX words of free_tracking_map starting here and plants its
+     * sentinel one word past them.  A libunit of that vintage can create
+     * segments this build maps, so the window has to stay unused while those
+     * peers are supported.
+     *
+     * Reserved in the struct rather than only described in a comment, so
+     * that the next field added lands after it by construction instead of
+     * by the author having read this.  Removing the reservation is what
+     * turns the removal of the tracking bitmap into the same latent
+     * corruption it was meant to fix.
+     */
+    nxt_free_map_t  legacy_tracking_window[MAX_FREE_IDX + 1];
 };
+
+
+/*
+ * The header struct is mapped over the first PORT_MMAP_HEADER_SIZE bytes of
+ * the segment and chunk 0 starts right after it, so anything the struct
+ * declares beyond that boundary silently aliases payload.
+ */
+nxt_static_assert(sizeof(nxt_port_mmap_header_t) <= PORT_MMAP_HEADER_SIZE,
+                  "nxt_port_mmap_header_t overflows the segment header area");
 
 
 struct nxt_port_mmap_handler_s {

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -4016,7 +4016,6 @@ nxt_unit_new_mmap(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port, int n)
     hdr = mem;
 
     memset(hdr->free_map, 0xFFU, sizeof(hdr->free_map));
-    memset(hdr->free_tracking_map, 0xFFU, sizeof(hdr->free_tracking_map));
 
     hdr->id = lib->outgoing.size - 1;
     hdr->src_pid = lib->pid;
@@ -4031,7 +4030,6 @@ nxt_unit_new_mmap(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port, int n)
 
     /* Mark as busy chunk followed the last available chunk. */
     nxt_port_mmap_set_chunk_busy(hdr->free_map, PORT_MMAP_CHUNK_COUNT);
-    nxt_port_mmap_set_chunk_busy(hdr->free_tracking_map, PORT_MMAP_CHUNK_COUNT);
 
     pthread_mutex_unlock(&lib->outgoing.mutex);
 


### PR DESCRIPTION
Part of #172 (PR-G in the roadmap).

`nxt_free_map_t` is `uintptr_t`, so the header layout is pointer-width dependent.
On the geometry everyone ships — LP64, default chunk size — the struct is **5320**
bytes against a `PORT_MMAP_HEADER_SIZE` of **4096**, so it overflows the segment
header area by 1224 bytes and `hdr->tracking[]` aliases the start of chunk 0:

| build | `MAX_FREE_IDX` | old `sizeof` | header area | |
|---|---:|---:|---:|---|
| LP64, default | 10 | 5320 | 4096 | **overflows by 1224** |
| ILP32, default | 20 | 2748 | 4096 | fits |
| LP64, `NXT_MMAP_TINY_CHUNK` | 1 | 568 | 1024 | fits |

The overlap is harmless *today* only because `hdr->tracking[]` has **zero readers
and writers anywhere in the tree** — the code that used it was removed upstream in
`b4540f09`, leaving the storage behind. The day anyone reintroduces tracking, it
silently corrupts payload.

This deletes the dead fields and adds a compile-time assertion so the overflow
cannot come back.

## Layout

| | before | after |
|---|---:|---:|
| `sizeof(nxt_port_mmap_header_t)` | 5320 | **112** |

Every surviving field keeps its exact offset:

| field | offset | size |
|---|---:|---:|
| `id` | 0 | 4 |
| `src_pid` | 4 | 4 |
| `dst_pid` | 8 | 4 |
| `sent_over` | 12 | 2 |
| `oosm` | 16 | 8 |
| `free_map` | 24 | 80 |
| `free_map_padding` | 104 | 8 |

Removed: `free_tracking_map` (112), `free_tracking_map_padding` (192),
`tracking[]` (200–5320). Also removed: the dead `tracking` boolean threaded
through `nxt_port_mmap_get()` and `nxt_port_new_port_mmap()`, both `static` with
exactly one caller each, the outer one passing the literal `0`. No non-zero caller
exists.

## Wire compatibility

This struct lives in shared memory mapped by two processes that may be running
different builds — libunit is compiled into application modules — so removing
fields is a wire-format change and needs an argument, not an assumption. Three
independent legs:

1. **All three removed fields are trailing.** Offsets 0–111 are byte-identical, so
   nothing a peer of either vintage reads or writes has moved.
2. **The mapping length never derives from `sizeof(header)`.** Both sides map the
   `PORT_MMAP_SIZE` constant, and chunk 0 is located by the `PORT_MMAP_HEADER_SIZE`
   constant in `nxt_port_mmap_chunk_start()`, not by the struct. Segment size and
   payload addresses are unchanged.
3. **An old peer's writes land in dead space.** An old `nxt_unit_new_mmap()`
   `memset`s `free_tracking_map` → bytes [112, 192) and plants its sentinel at
   `free_tracking_map[10]` → bytes [192, 200). After this change the struct ends at
   112, so both land between the struct end and the 4096-byte header boundary:
   inside the header area, below chunk 0, read by no build. `tracking[]` itself is
   never written by an old peer either, for the same reason it is not by a new one.

## `free_map_padding` is kept, and it is load-bearing

Worth stating because the name invites exactly the deletion that would break it.
It is **not** alignment padding: `FREE_IDX(640) == 10` while `free_map[]` has
indices 0..9, so `nxt_port_mmap_set_chunk_busy(hdr->free_map, PORT_MMAP_CHUNK_COUNT)`
writes `free_map[10]` — i.e. that field — as a permanently-busy sentinel.

It is also read on the allocation path: `nxt_port_mmap_get()` calls
`nxt_port_mmap_chk_set_chunk_busy(free_map, *c + nchunks)`, which for a multi-chunk
allocation starting near chunk 639 addresses index 640, finds the sentinel busy,
and backs off cleanly. Without the field that read would be out of bounds. A
comment now records this on the field.

## The assertion

`nxt_static_assert()` added to `src/nxt_clang.h`, following that file's existing
`#if`/`#else` shape for compiler-feature differences. It gates on
`__STDC_VERSION__ >= 201112L` for `_Static_assert` and falls back to a
negative-sized-array typedef.

The fallback is not theoretical: `auto/cc/test` sets `-std=gnu11` for the gcc and
clang branches but has a bare `cc` branch that sets no standard, and this header is
compiled into application modules by whatever toolchain the module uses.

**Both arms were exercised**, since a probe of the C11 path alone would not have
covered the fallback:

```
gcc -std=gnu11:   error: static assertion failed: "nxt_port_mmap_header_t overflows the segment header area"
gcc -std=gnu89:   error: size of array 'nxt_static_assert_failed_3' is negative
clang -std=gnu99: error: 'nxt_static_assert_failed_3' declared as an array with a negative size
```

The passing form is accepted with `-Wall -Wextra -pedantic` by gcc and clang under
`gnu89/gnu99/gnu11/c2x` and by g++ under `c++11/c++17`.

Both geometries fit with room to spare: 112 of 4096 normally, 40 of 1024 under
`NXT_MMAP_TINY_CHUNK`.

## Verification

Builds clean under `-Wall -Wextra -Werror` for `unitd`, `php8.unit.so` and
`tests`. `./build/tests` passes; `test_php_application.py` 49 passed, 3 skipped.

Note this touches `src/nxt_port_memory_int.h`, as does #179 — different regions of
the file (struct fields vs a function definition), so they should not conflict, but
whichever lands second may want a rebase.
