### PR TITLE
test(libunit): build and run the port_recv test off Linux and older glibc

### DIFF
--- a/src/test/nxt_unit_port_recv_test.c
+++ b/src/test/nxt_unit_port_recv_test.c
@@ -43,6 +43,10 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 
+#if (NXT_HAVE_MEMFD_CREATE)
+#include <linux/memfd.h>
+#endif
+
 
 static int   nxt_port_recv_test_failures;
 static int   nxt_port_recv_test_step;
@@ -88,7 +92,7 @@ nxt_port_recv_test_send(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
 {
     int             fds[2];
     size_t          size;
-    struct msghdr   msg;
+    struct msghdr   msg = { 0 };
     struct cmsghdr  *cmsg;
 
     if (oob_size == 0 || nxt_port_recv_test_ctx_queue_fd != -1) {
@@ -252,11 +256,20 @@ main(void)
     nxt_unit_ctx_t   *ctx, *ctx2;
     nxt_unit_init_t  init;
 
-    if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, ready) == -1
-        || socketpair(AF_UNIX, SOCK_SEQPACKET, 0, router) == -1
-        || socketpair(AF_UNIX, SOCK_SEQPACKET, 0, read) == -1
-        || socketpair(AF_UNIX, SOCK_SEQPACKET, 0, shared) == -1
-        || socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sock) == -1)
+    /*
+     * SOCK_DGRAM, as libunit itself uses everywhere: its NXT_UNIX_SOCKET
+     * selector is guarded by "#if (0 || NXT_HAVE_AF_UNIX_SOCK_SEQPACKET)",
+     * so SOCK_SEQPACKET is disabled unconditionally.  The type is immaterial
+     * here -- port_recv intercepts every read and these pairs are only ever
+     * adopted as descriptors -- but SOCK_SEQPACKET would fail outright on
+     * platforms without AF_UNIX support for it.
+     */
+
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, ready) == -1
+        || socketpair(AF_UNIX, SOCK_DGRAM, 0, router) == -1
+        || socketpair(AF_UNIX, SOCK_DGRAM, 0, read) == -1
+        || socketpair(AF_UNIX, SOCK_DGRAM, 0, shared) == -1
+        || socketpair(AF_UNIX, SOCK_DGRAM, 0, sock) == -1)
     {
         perror("socketpair");
         return 1;


### PR DESCRIPTION
## Summary

Follow-up to #171 (merged as `3e27cb2a`), which landed before the last review round. Three portability problems in the `port_recv` fd-ownership test, plus a correction to the merged commit message. No behaviour change.

## What was wrong

- **`MFD_CLOEXEC` from the wrong header.** The test took it from `<sys/mman.h>`, which only defines it from glibc 2.27. `auto/shmem` probes memfd through `<linux/memfd.h>` *and* the syscall form, so on a kernel that supports `memfd_create()` with a libc that predates the wrapper, `NXT_HAVE_MEMFD_CREATE` is set and `make tests` fails to compile the file. #171 switched the call to `syscall(SYS_memfd_create, …)`, which fixed half of it; the include is the other half, mirroring `src/nxt_unit.c:18-20`.
- **`SOCK_SEQPACKET` in all five `socketpair()` calls.** `AF_UNIX` does not support it everywhere — and libunit does not use it anywhere:

  ```c
  /* src/nxt_unit.c */
  /* SOCK_SEQPACKET is disabled to test SOCK_DGRAM on all platforms. */
  #if (0 || NXT_HAVE_AF_UNIX_SOCK_SEQPACKET)
  #define NXT_UNIX_SOCKET  SOCK_SEQPACKET
  #else
  #define NXT_UNIX_SOCKET  SOCK_DGRAM
  #endif
  ```

  That `0 ||` disables it unconditionally, so every port socket libunit creates is `SOCK_DGRAM`. The test was both less portable than production and exercising a socket type production never creates. The type is immaterial here — `port_recv` intercepts every read and these pairs are only adopted as descriptors — so it now uses what libunit uses.
- **`struct msghdr` uninitialized.** Harmless, since `CMSG_FIRSTHDR`/`CMSG_NXTHDR` read only `msg_control` and `msg_controllen`, both assigned just below. Initialized anyway so that reasoning isn't required. (This one was listed as "applied" in a comment on #171 and in fact was not — my string replacement silently missed. Correcting the record.)

## Correction to `3e27cb2a`'s commit message

It states that Unit uses `SOCK_SEQPACKET` on Linux and that Go reports the peer close as `*net.OpError{Err: io.EOF}`. The measurement behind that was taken on a `unixpacket` socket, but per the selector above libunit's ports are `SOCK_DGRAM`, so how often the EOF branch runs depends on the socket type's semantics.

This does not affect the fix. The **unknown-port** path is the one app teardown reaches regardless — `nxt_go_remove_port()` drops the port from the Go registry while `nxt_unit_run_shared()`'s goroutine may still be reading it — and both paths returned without assigning `oob_size`, which is what the fix addresses.

## Verification

`./build/unit_port_recv_test` still passes all four assertions, including the reuse precondition. Reverting the `rbuf->size == 0` guard in `nxt_unit_port_recv()` still fails the two fd assertions, so the regression coverage is unchanged. Full `./build/tests` green, whitespace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhMcvYuSz1p4A3obfTt3xA
