### PR TITLE
fix(process): serialize the process refcount on processes_mutex

### DIFF
--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -161,6 +161,7 @@ nxt_port_mmap_buf_completion(nxt_task_t *task, void *obj, void *data)
     u_char                   *p;
     nxt_mp_t                 *mp;
     nxt_buf_t                *b, *next;
+    nxt_pid_t                src_pid, dst_pid;
     nxt_process_t            *process;
     nxt_chunk_id_t           c;
     nxt_port_mmap_header_t   *hdr;
@@ -180,9 +181,21 @@ complete_buf:
 
     hdr = mmap_handler->hdr;
 
-    if (nxt_slow_path(hdr->src_pid != nxt_pid && hdr->dst_pid != nxt_pid)) {
+    /*
+     * The header lives in a segment the peer still maps writable, so the two
+     * pids are snapshotted once here and only the locals are used below:
+     * re-reading one after the check is a double fetch the peer can win, and
+     * src_pid is what the process lookup below is given.  The other header
+     * fields are left as direct reads -- hdr->id only reaches a debug
+     * message, and the free map and oosm flag are peer-shared state read
+     * through their own accessors by design.
+     */
+    src_pid = hdr->src_pid;
+    dst_pid = hdr->dst_pid;
+
+    if (nxt_slow_path(src_pid != nxt_pid && dst_pid != nxt_pid)) {
         nxt_debug(task, "mmap buf completion: mmap for other process pair "
-                  "%PI->%PI", hdr->src_pid, hdr->dst_pid);
+                  "%PI->%PI", src_pid, dst_pid);
 
         goto release_buf;
     }
@@ -205,7 +218,7 @@ complete_buf:
 
     nxt_debug(task, "mmap buf completion: %p [%p,%uz] (sent=%d), "
               "%PI->%PI,%d,%d", b, b->mem.start, b->mem.end - b->mem.start,
-              b->is_port_mmap_sent, hdr->src_pid, hdr->dst_pid, hdr->id, c);
+              b->is_port_mmap_sent, src_pid, dst_pid, hdr->id, c);
 
     while (p < b->mem.end) {
         nxt_port_mmap_set_chunk_free(hdr->free_map, c);
@@ -214,10 +227,10 @@ complete_buf:
         c++;
     }
 
-    if (hdr->dst_pid == nxt_pid
+    if (dst_pid == nxt_pid
         && nxt_atomic_cmp_set(&hdr->oosm, 1, 0))
     {
-        process = nxt_runtime_process_find(task->thread->runtime, hdr->src_pid);
+        process = nxt_runtime_process_find(task->thread->runtime, src_pid);
 
         nxt_process_broadcast_shm_ack(task, process);
     }

--- a/src/nxt_process.c
+++ b/src/nxt_process.c
@@ -136,10 +136,70 @@ nxt_process_new(nxt_runtime_t *rt)
 void
 nxt_process_use(nxt_task_t *task, nxt_process_t *process, int i)
 {
-    process->use_count += i;
+    nxt_int_t      use_count;
+    nxt_bool_t     released;
+    nxt_runtime_t  *rt;
 
-    if (process->use_count == 0) {
-        nxt_runtime_process_release(task->thread->runtime, process);
+    rt = task->thread->runtime;
+
+    /*
+     * The count is mutated from every engine thread, so it is serialized on
+     * rt->processes_mutex rather than made atomic: an atomic increment would
+     * still let a lookup take a reference on a process whose teardown has
+     * already started.  Dropping to zero therefore unlinks the process from
+     * rt->processes while the mutex is still held, which makes {find, ref}
+     * and {unref to zero, unlink} mutually exclusive.  The teardown itself
+     * runs after the unlock -- it takes other locks and must not nest.
+     *
+     * This makes rt->processes_mutex reachable from any nxt_port_use()
+     * that drops a last port reference, including callers that already hold
+     * app->mutex (nxt_router.c).  rt->processes_mutex must therefore stay a
+     * leaf: nothing may take another lock while holding it.  It is one today
+     * only because the single outward call made while holding it,
+     * nxt_runtime_process_add() -> nxt_runtime_port_add() -> nxt_port_use(),
+     * passes a positive delta and so cannot reach nxt_port_release() and
+     * back into this function.  A -1 reached under this mutex would
+     * self-deadlock the calling thread.
+     */
+
+    nxt_thread_mutex_lock(&rt->processes_mutex);
+
+    process->use_count += i;
+    use_count = process->use_count;
+
+    /*
+     * A second drop to zero is not detectable from use_count or registered
+     * -- a resurrect-then-release leaves both exactly as the first teardown
+     * left them -- so it is latched here instead.  This has to act rather
+     * than assert: nxt_assert() compiles to nothing in a non-debug build,
+     * and the second release is worse than a double free.  On rt->main_engine
+     * it tears the process down while the first teardown is still queued; off
+     * it, it posts process->free_work a second time, and
+     * nxt_locked_work_queue_add() then self-links the item so that the
+     * engine draining it spins forever.
+     */
+
+    released = process->released;
+
+    if (use_count == 0 && !released) {
+        process->released = 1;
+
+        nxt_runtime_process_unlink_locked(rt, process);
+    }
+
+    nxt_thread_mutex_unlock(&rt->processes_mutex);
+
+    if (use_count == 0) {
+        if (nxt_slow_path(released)) {
+            nxt_assert(!released);
+
+            nxt_alert(task, "process %PI dropped to zero twice, leaking it "
+                      "rather than tearing it down again", process->pid);
+
+            return;
+        }
+
+        nxt_runtime_process_release(task, rt, process);
     }
 }
 

--- a/src/nxt_process.h
+++ b/src/nxt_process.h
@@ -115,6 +115,14 @@ struct nxt_process_s {
     nxt_bool_t               registered;
     nxt_int_t                use_count;
 
+    /*
+     * Latched, under rt->processes_mutex, when use_count reaches zero.  A
+     * second drop to zero is not detectable from use_count or registered --
+     * a resurrect-then-release leaves both at their post-teardown values --
+     * so nxt_process_use() tests this and refuses the second teardown.
+     */
+    nxt_bool_t               released;
+
     nxt_port_mmaps_t         incoming;
 
 
@@ -129,6 +137,14 @@ struct nxt_process_s {
 
     nxt_queue_t              children;   /* of nxt_process_t.link */
     nxt_queue_link_t         link;       /* for nxt_process_t.children */
+
+    /*
+     * Used only by nxt_runtime_process_release() to hand the teardown to
+     * rt->main_engine, at which point the process is unlinked with use_count
+     * 0 and nothing else can reach it.  Embedded rather than allocated so
+     * that deferring the free cannot itself fail.
+     */
+    nxt_work_t               free_work;
 
     nxt_process_data_t       data;
 

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -308,6 +308,8 @@ nxt_runtime_event_engines(nxt_task_t *task, nxt_runtime_t *rt)
     nxt_queue_init(&rt->engines);
     nxt_queue_insert_tail(&rt->engines, &engine->link);
 
+    rt->main_engine = engine;
+
     return NXT_OK;
 }
 
@@ -1565,14 +1567,10 @@ nxt_runtime_pid_file_create(nxt_task_t *task, nxt_file_name_t *pid_file)
 }
 
 
-void
-nxt_runtime_process_release(nxt_runtime_t *rt, nxt_process_t *process)
+static void
+nxt_runtime_process_free(nxt_runtime_t *rt, nxt_process_t *process)
 {
     nxt_process_t  *child;
-
-    if (process->registered == 1) {
-        nxt_runtime_process_remove(rt, process);
-    }
 
     if (process->link.next != NULL) {
         nxt_queue_remove(&process->link);
@@ -1597,6 +1595,101 @@ nxt_runtime_process_release(nxt_runtime_t *rt, nxt_process_t *process)
     }
 
     nxt_mp_free(rt->mem_pool, process);
+}
+
+
+static void
+nxt_runtime_process_free_handler(nxt_task_t *task, void *obj, void *data)
+{
+    nxt_process_t  *process;
+
+    process = obj;
+
+    nxt_runtime_process_free(task->thread->runtime, process);
+}
+
+
+/*
+ * Runs with no lock held, from nxt_process_use(), once the reference count
+ * has reached zero and the process has already been unlinked from
+ * rt->processes under rt->processes_mutex.  Nothing can look the process up
+ * any more, so the teardown itself needs no lock -- but it does need the
+ * right thread.  rt->mem_pool carries no lock of its own, so nxt_mp_free()
+ * of the process, and the parent/children queue surgery that goes with it,
+ * must not run on whichever router worker engine happened to drop the last
+ * reference; hand them to the engine that owns the runtime instead.
+ *
+ * Only the router runs more than one event engine (nxt_router.c,
+ * nxt_router_engines_create()), and only the main process links a process
+ * into a parent's children queue (nxt_main_process_whoami_handler(), and
+ * nxt_proto_process_add() for the prototype's own list).  So a process that
+ * takes the deferred path below is never on a children queue, and the
+ * window between the unlink and the posted free is not observable.
+ */
+
+void
+nxt_runtime_process_release(nxt_task_t *task, nxt_runtime_t *rt,
+    nxt_process_t *process)
+{
+    /*
+     * rt->main_engine is the engine that owns rt->mem_pool, recorded when it
+     * is created.  It is deliberately not derived from
+     * rt->port_by_type[rt->type]: that slot is NULL before the runtime
+     * registers its own port and again once nxt_runtime_port_remove() has
+     * cleared it, which nxt_runtime_exit() does while router worker engines
+     * are still running -- so "no port" must never be read as "safe to free
+     * here".  Reading the slot at all would also be a use of a port this
+     * thread holds no reference to.  Before rt->main_engine is set nothing
+     * but the creating thread exists, and it compares equal to a NULL
+     * task->thread->engine.
+     */
+
+    if (task->thread->engine == rt->main_engine) {
+        nxt_runtime_process_free(rt, process);
+
+        return;
+    }
+
+    /*
+     * Reached once cross-thread lookups hold references -- see
+     * nxt_runtime_process_ref().  Until they do, every drop lands on
+     * rt->main_engine: a router worker engine's own port is not on any
+     * process's port queue, so nxt_port_release() never reaches
+     * nxt_process_use() there.
+     *
+     * The work item is embedded in the process rather than allocated, and is
+     * posted straight to the engine instead of through a port, so this path
+     * cannot fail: an allocation failure here would have to either leak the
+     * process -- unbounded, under exactly the memory pressure that caused it
+     * -- or free rt->mem_pool memory from this thread, which is what the
+     * deferral exists to prevent.  The process is unlinked with use_count 0,
+     * so nothing else can reach the field.
+     *
+     * Not guaranteed to be drained: nxt_runtime_exit() destroys rt->mem_pool
+     * and calls exit() without running the engine again, so a free posted
+     * just before shutdown may never happen.  That leak is bounded by the
+     * process exiting immediately afterwards.
+     *
+     * The work item is single-instance, which changes what a double release
+     * would look like here: posting it again while the first is still queued
+     * makes nxt_locked_work_queue_add() do lwq->tail->next = work with
+     * tail == work, and nxt_locked_work_queue_move() then loops on itself.
+     * So a second drop to zero landing on a worker would hang rather than
+     * crash -- the failure mode a sanitizer is least able to show.  That is
+     * why nxt_process_use() latches nxt_process_t.released and refuses the
+     * second teardown outright, rather than only asserting on it.
+     */
+
+    nxt_assert(process->link.next == NULL);
+    nxt_assert(nxt_queue_is_empty(&process->children));
+
+    process->free_work.handler = nxt_runtime_process_free_handler;
+    process->free_work.task = &rt->main_engine->task;
+    process->free_work.obj = process;
+    process->free_work.data = NULL;
+    process->free_work.next = NULL;
+
+    nxt_event_engine_post(rt->main_engine, &process->free_work);
 }
 
 
@@ -1672,10 +1765,17 @@ nxt_runtime_process_get(nxt_runtime_t *rt, nxt_pid_t pid)
     if (nxt_lvlhsh_find(&rt->processes, &lhq) == NXT_OK) {
         nxt_thread_log_debug("process %PI found", pid);
 
-        nxt_thread_mutex_unlock(&rt->processes_mutex);
+        /*
+         * The reference has to be taken before the mutex is dropped:
+         * nxt_process_use() unlinks the process under the same mutex when
+         * the count reaches zero, so a lookup that still sees the process
+         * in rt->processes cannot be racing its teardown.
+         */
 
         process = lhq.value;
         process->use_count++;
+
+        nxt_thread_mutex_unlock(&rt->processes_mutex);
 
         return process;
     }
@@ -1769,21 +1869,44 @@ nxt_runtime_process_add(nxt_task_t *task, nxt_process_t *process)
 }
 
 
+/*
+ * Must be called with rt->processes_mutex held.  Unlinking the process has
+ * to be atomic with the reference count reaching zero, otherwise
+ * nxt_runtime_process_find()/_get() can hand out a pointer to a process
+ * whose teardown has already begun.
+ *
+ * Nothing beyond the hash delete belongs here.  In particular
+ * nxt_port_mmaps_destroy() stays in nxt_runtime_process_free(): a router
+ * worker holds process->incoming.mutex while the main engine can hold
+ * rt->processes_mutex, so taking incoming.mutex under processes_mutex would
+ * add a lock-order edge in the opposite direction.
+ *
+ * The registered check is not defensive: nxt_runtime_exit() unregisters a
+ * process before closing its ports, so a drop to zero on an already
+ * unregistered process is a normal shutdown path.
+ *
+ * The lhq.pool assignment below looks like it frees rt->mem_pool memory on
+ * whichever thread dropped the last reference -- one call before the
+ * deferral that exists to prevent exactly that.  It does not:
+ * lvlhsh_processes_proto uses nxt_lvlhsh_alloc()/_free(), which ignore the
+ * pool argument and use nxt_memalign()/nxt_free().
+ */
+
 void
-nxt_runtime_process_remove(nxt_runtime_t *rt, nxt_process_t *process)
+nxt_runtime_process_unlink_locked(nxt_runtime_t *rt, nxt_process_t *process)
 {
     nxt_pid_t           pid;
     nxt_lvlhsh_query_t  lhq;
 
-    nxt_assert(process->registered != 0);
+    if (process->registered == 0) {
+        return;
+    }
 
     pid = process->pid;
 
     nxt_runtime_process_lhq_pid(&lhq, &pid);
 
     lhq.pool = rt->mem_pool;
-
-    nxt_thread_mutex_lock(&rt->processes_mutex);
 
     switch (nxt_lvlhsh_delete(&rt->processes, &lhq)) {
 
@@ -1801,6 +1924,17 @@ nxt_runtime_process_remove(nxt_runtime_t *rt, nxt_process_t *process)
         nxt_thread_log_alert("process %PI remove failed", pid);
         break;
     }
+}
+
+
+void
+nxt_runtime_process_remove(nxt_runtime_t *rt, nxt_process_t *process)
+{
+    nxt_assert(process->registered != 0);
+
+    nxt_thread_mutex_lock(&rt->processes_mutex);
+
+    nxt_runtime_process_unlink_locked(rt, process);
 
     nxt_thread_mutex_unlock(&rt->processes_mutex);
 }

--- a/src/nxt_runtime.h
+++ b/src/nxt_runtime.h
@@ -84,6 +84,14 @@ struct nxt_runtime_s {
 
     nxt_queue_t            engines;            /* of nxt_event_engine_t */
 
+    /*
+     * The engine that owns this runtime, recorded when it is created.  The
+     * router adds worker engines to the queue above, so "the runtime's own
+     * engine" cannot be derived from it, and rt->port_by_type[rt->type] is
+     * cleared during shutdown while worker engines are still running.
+     */
+    nxt_event_engine_t     *main_engine;
+
     nxt_sockaddr_t         *controller_listen;
     nxt_listen_socket_t    *controller_socket;
 };
@@ -104,13 +112,16 @@ nxt_int_t nxt_runtime_thread_pool_create(nxt_thread_t *thr, nxt_runtime_t *rt,
 
 void nxt_runtime_process_add(nxt_task_t *task, nxt_process_t *process);
 void nxt_runtime_process_remove(nxt_runtime_t *rt, nxt_process_t *process);
+void nxt_runtime_process_unlink_locked(nxt_runtime_t *rt,
+    nxt_process_t *process);
 
 nxt_process_t *nxt_runtime_process_find(nxt_runtime_t *rt, nxt_pid_t pid);
 
 nxt_process_t *nxt_runtime_process_first(nxt_runtime_t *rt,
     nxt_lvlhsh_each_t *lhe);
 
-void nxt_runtime_process_release(nxt_runtime_t *rt, nxt_process_t *process);
+void nxt_runtime_process_release(nxt_task_t *task, nxt_runtime_t *rt,
+    nxt_process_t *process);
 
 #define nxt_runtime_process_next(rt, lhe)                                     \
     nxt_lvlhsh_each(&rt->processes, lhe)


### PR DESCRIPTION
Serializes the `nxt_process_t` reference count on `rt->processes_mutex`, so that a lookup and a drop-to-zero cannot overlap. This is the first of two PRs; it is a prerequisite for the second and does **not** close the issue on its own.

Part of [issue #120](https://github.com/freeunitorg/freeunit/issues/120), sequenced per [issue #172](https://github.com/freeunitorg/freeunit/issues/172).

## The race

Four facts combine:

1. `nxt_runtime_process_find()` returns the process **without taking a reference** — unlike `nxt_runtime_process_get()` in the same file, which does `use_count++`.
2. `nxt_process_use()` is a plain non-atomic `process->use_count += i`, mutated from multiple engine threads.
3. `nxt_runtime_process_release()` calls `nxt_port_mmaps_destroy(&process->incoming, 1)` with no mutex, then destroys `process->incoming.mutex` and `nxt_mp_free()`s the process.
4. The `.mmap` and `.oosm` handlers run on **every** router worker engine (`nxt_router_app_port_handlers`), while `.remove_pid` runs only on the main engine (`nxt_router_process_port_handlers`).

So:

| Thread A — router worker, app response | Thread B — router main, app died |
|---|---|
| `nxt_runtime_process_find(spid)` → non-NULL, unreferenced | |
| | `nxt_port_mmaps_destroy(&process->incoming, 1)` → `munmap`, `nxt_free(elts)` |
| | `nxt_thread_mutex_destroy(&process->incoming.mutex)` |
| | `nxt_mp_free(rt->mem_pool, process)` |
| `nxt_thread_mutex_lock(&process->incoming.mutex)` → **use-after-free** | |

Making `use_count` atomic does not fix this. Lookup and drop-to-zero have to be *mutually exclusive*, or `find()` can hand out a pointer to an object whose teardown has already begun — an atomic increment on a doomed object is still a use-after-free. The primitive used here is the `rt->processes_mutex` that already exists.

## What this PR does

1. **`nxt_runtime_process_get()`** did `use_count++` *after* releasing `processes_mutex`; the increment moves inside the lock, closing an unlocked read-modify-write.
2. **`nxt_process_use()`** takes `rt->processes_mutex`, applies the delta, and — if the count reaches zero — unlinks the process from `rt->processes` **while still holding the lock**. This is what makes `{lookup, ref}` and `{unref-to-zero, unlink}` mutually exclusive.
3. **`nxt_runtime_process_release()`** is restructured so it no longer calls `nxt_runtime_process_remove()` (which would re-take the same mutex and deadlock). It splits into `nxt_runtime_process_unlink_locked()`, called with the mutex held, and `nxt_runtime_process_free()`, called after the unlock. `nxt_runtime_process_remove()` remains as the locking wrapper for its existing caller.
4. **`rt->mem_pool` is not thread-safe** — `nxt_mp` carries no lock, and the release path does `nxt_mp_free(rt->mem_pool, process)`. Once the follow-up PR makes `find()` take references, the last drop can land on a router worker thread, so the free half is posted to the engine that owns the runtime.

   The target engine is recorded once as `rt->main_engine` when it is created, rather than derived from `rt->port_by_type[rt->type]`. That slot is NULL before the runtime registers its own port and again once `nxt_runtime_port_remove()` has cleared it — which `nxt_runtime_exit()` does *while router worker engines are still running* — so "no port" must never be read as "safe to free here".

   The work item is **embedded in the `nxt_process_t`** and posted straight to the engine with `nxt_event_engine_post()`, rather than allocated by `nxt_port_post()`. That means deferring the free cannot itself fail: an allocation failure there would have to either leak the process — unbounded, under exactly the memory pressure that caused it — or free `rt->mem_pool` memory from the wrong thread, which is the corruption this change exists to prevent. It also means `rt->port_by_type[]` is never read from a worker thread, so there is no use of a port this thread holds no reference to.

   The one thing not guaranteed is drainage: `nxt_runtime_exit()` destroys `rt->mem_pool` and calls `exit()` without running the engine again, so a free posted just before shutdown may never happen. That leak is bounded by the process exiting immediately afterwards.

5. **A shared-header double fetch** in `nxt_port_mmap_buf_completion()`: it validated `hdr->src_pid`/`hdr->dst_pid`, then later re-read `dst_pid` for a branch and `src_pid` as the argument to `nxt_runtime_process_find()`. `hdr` points into a `MAP_SHARED` segment the peer still maps writable and is not `volatile`, so those were genuine double fetches. All peer-controlled fields are now snapshotted into locals at the top, matching the shape already used in `nxt_port_incoming_port_mmap()`. Left unfixed, the follow-up PR would turn that re-read into a peer-steerable reference count on an arbitrary pid.

## What this PR does not do

It does **not** close [#120](https://github.com/freeunitorg/freeunit/issues/120). `nxt_runtime_process_find()` still returns an unreferenced pointer; converting the cross-thread call sites is the follow-up. What lands here is the unlocked read-modify-write in `nxt_runtime_process_get()`, the double fetch, and the `{unref, unlink}` atomicity the follow-up is built on.

## Cost

No change on any path that exists today: `nxt_runtime_process_get()` already took the mutex, and the increment now happens inside that same critical section.

`nxt_process_use()` does now take the mutex on **every** call, including the `+1`s from `nxt_process_port_add()` and `nxt_process_close_ports()`, where before it was an unlocked non-atomic add. Those are per-port-lifecycle operations, not per-message.

## Verification

- Builds clean under `-Wall -Wextra -Werror`; `unitd` and the PHP module.
- `./build/tests` exit 0. `test_php_application.py` 49 passed / 3 skipped, `test_return.py` 6 passed, `test_reconfigure.py` 2 passed — identical to a baseline build at the parent commit.
- Exercised under an ASan+UBSan build with a teardown-churn workload (see the follow-up PR, which carries the test): no new memory error attributable to this change.

**The race is now demonstrated rather than argued.** Statistical churn never reaches the window — 27 churn runs on the unfixed parent (2,230 responses, 417 application process starts, `listen_threads` up to 8) produced no use-after-free on this path, which is why every earlier test run was green on both trees. Under **fault injection** it reproduces reliably:

With a delay opened between the process lookup and its first use, and the peer application SIGKILLed at that point, an ASan build of the unfixed parent reports `heap-use-after-free` on the `nxt_process_t` in **5 runs out of 5** (12 reports). Same signature every time:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 ... thread T1
    #0 nxt_process_broadcast_shm_ack   src/nxt_port_memory.c:998
    #1 nxt_port_mmap_buf_completion    src/nxt_port_memory.c:225
    #3 nxt_router_thread_start         src/nxt_router.c:3728     <- router worker
freed by thread T0 here:
    #3 nxt_runtime_process_release     src/nxt_runtime.c:1712
    #5 nxt_process_close_ports         src/nxt_process.c:1249
    #6 nxt_port_remove_pid             src/nxt_port.c:553
    #8 nxt_router_remove_pid_handler   src/nxt_router.c:1053     <- router main
```

That is exactly the interleaving described above: a router worker holding an unreferenced `nxt_process_t *` while the main engine frees it. The 416-byte region is the `nxt_process_t`. The same runs also produced two `SIGSEGV`s from the same corruption.

**With the fix applied, the same injection, workload and iteration count produce zero reports.** The instrumentation shows the mechanism: during the window the peer's `use_count` is 2 rather than 1, so the teardown cannot complete.

The reproduction needs 24 MiB response bodies, because `hdr->oosm` is only set once an application fills a whole 10 MiB segment — that is what puts `nxt_process_broadcast_shm_ack()` on the path at all.

## Known residuals

Not introduced here, not fixed here, stated so they are not silently inherited:

- `nxt_runtime_process_each()` still walks `rt->processes` with no lock. The mutual exclusion described above holds for `_find`/`_ref`/`_get`, **not** for iteration, and worker-side deletes are about to become routine.
- `nxt_runtime_exit()` passes unreferenced pointers to `nxt_process_close_ports()`, which is the same shape as a double free fixed in the follow-up PR. Shutdown-only, immediately followed by `exit()`.
- A separate, reproducible heap-use-after-free was found while testing this and is present on the unfixed parent too — `nxt_locked_work_queue_move()` reading `nxt_joint_job_t` work items out of a `tmcf->mem_pool` already released by `nxt_router_conf_ready()`. Unrelated to this change; it needs its own issue.
