### PR TITLE
fix(process): take a reference on cross-thread process lookups

### DIFF
--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -495,6 +495,8 @@ nxt_controller_remove_pid_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     nxt_memcpy(&pid, msg->buf->mem.pos, sizeof(pid));
 
+    /* Unreferenced: the controller process runs a single engine. */
+
     process = nxt_runtime_process_find(rt, pid);
     if (process != NULL && nxt_process_type(process) == NXT_PROCESS_ROUTER) {
         nxt_controller_router_ready = 0;

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -740,6 +740,14 @@ nxt_main_process_whoami_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     rt = task->thread->runtime;
 
+    /*
+     * Unreferenced: the main process runs a single engine.  That matters
+     * here specifically because the result outlives the call -- it is
+     * linked into pprocess->children below, a weak link cleaned up in
+     * nxt_runtime_process_free().  With one engine nothing can drop the
+     * last reference concurrently, so the link cannot outlive the process.
+     */
+
     pprocess = nxt_runtime_process_find(rt, ppid);
     if (nxt_slow_path(pprocess == NULL)) {
         nxt_alert(task, "whoami: parent process %PI not found", ppid);
@@ -1059,6 +1067,16 @@ nxt_main_process_sigchld_handler(nxt_task_t *task, void *obj, void *data)
             nxt_trace(task, "process %PI exited with code %d",
                       pid, WEXITSTATUS(status));
         }
+
+        /*
+         * Unreferenced: the main process runs a single engine.  That
+         * matters here specifically because nxt_process_close_ports()
+         * below takes its own +1/-1 around the port loop, which on a
+         * process already at zero would be a second drop to zero and so a
+         * second teardown -- the defect fixed in nxt_port_remove_pid().
+         * With one engine, find() returning non-NULL implies use_count >= 1
+         * for the whole handler.
+         */
 
         process = nxt_runtime_process_find(rt, pid);
 

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -333,6 +333,8 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     rt = task->thread->runtime;
 
+    /* Unreferenced: main and prototype processes run a single engine. */
+
     process = nxt_runtime_process_find(rt, msg->port_msg.pid);
     if (nxt_slow_path(process == NULL)) {
         return;
@@ -373,7 +375,15 @@ nxt_port_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         return;
     }
 
-    process = nxt_runtime_process_find(rt, msg->port_msg.pid);
+    /*
+     * Referenced, not just found: this handler is in the router worker port
+     * handler table, so it runs on engines other than the one that can free
+     * the process.  nxt_port_incoming_port_mmap() takes and releases
+     * process->incoming.mutex without touching the reference count, so the
+     * reference has to span the whole call.
+     */
+
+    process = nxt_runtime_process_ref(rt, msg->port_msg.pid);
     if (nxt_slow_path(process == NULL)) {
         nxt_log(task, NXT_LOG_WARN, "failed to get process #%PI",
                 msg->port_msg.pid);
@@ -382,6 +392,13 @@ nxt_port_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     }
 
     nxt_port_incoming_port_mmap(task, process, msg->fd[0]);
+
+    /*
+     * Before fail_close: that label is shared with the process == NULL path,
+     * where no reference was taken.
+     */
+
+    nxt_process_use(task, process, -1);
 
 fail_close:
 
@@ -547,10 +564,21 @@ nxt_port_remove_pid(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 
     nxt_port_rpc_remove_peer(task, msg->port, pid);
 
-    process = nxt_runtime_process_find(rt, pid);
+    /*
+     * Referenced even though this only runs on main engines: the constraint
+     * that matters here is ownership, not which thread runs.  A router worker
+     * can drop the last reference to the process at any point, and
+     * nxt_process_close_ports() takes its own reference around the port loop
+     * -- on a process already at zero that would be a second drop to zero and
+     * so a second teardown, racing the one already posted to this engine.
+     */
+
+    process = nxt_runtime_process_ref(rt, pid);
 
     if (process) {
         nxt_process_close_ports(task, process);
+
+        nxt_process_use(task, process, -1);
     }
 }
 

--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -230,9 +230,20 @@ complete_buf:
     if (dst_pid == nxt_pid
         && nxt_atomic_cmp_set(&hdr->oosm, 1, 0))
     {
-        process = nxt_runtime_process_find(task->thread->runtime, src_pid);
+        process = nxt_runtime_process_ref(task->thread->runtime, src_pid);
 
         nxt_process_broadcast_shm_ack(task, process);
+
+        /*
+         * Released here rather than at the end of the function: the
+         * complete_buf back-edge below re-enters this block once per buffer
+         * of the chain, so a release outside it would leak every reference
+         * but the last.
+         */
+
+        if (process != NULL) {
+            nxt_process_use(task, process, -1);
+        }
     }
 
 release_buf:
@@ -616,7 +627,14 @@ nxt_port_get_port_incoming_mmap(nxt_task_t *task, nxt_pid_t spid, uint32_t id)
     nxt_process_t            *process;
     nxt_port_mmap_handler_t  *mmap_handler;
 
-    process = nxt_runtime_process_find(task->thread->runtime, spid);
+    /*
+     * Referenced, not just found.  This runs on whichever router worker
+     * engine received the message, while the router main engine can be
+     * releasing the same process; without the reference the mutex locked on
+     * the next line can already have been destroyed and freed underneath us.
+     */
+
+    process = nxt_runtime_process_ref(task->thread->runtime, spid);
     if (nxt_slow_path(process == NULL)) {
         return NULL;
     }
@@ -643,6 +661,17 @@ nxt_port_get_port_incoming_mmap(nxt_task_t *task, nxt_pid_t spid, uint32_t id)
     }
 
     nxt_thread_mutex_unlock(&process->incoming.mutex);
+
+    /*
+     * Strictly after the unlock.  If this is the last reference, the release
+     * runs nxt_thread_mutex_destroy(&process->incoming.mutex) -- dropping it
+     * before the unlock would destroy the mutex this function still holds.
+     *
+     * The returned handler is unaffected: the reference bumped above is its
+     * own, independent of the process, and the caller releases it.
+     */
+
+    nxt_process_use(task, process, -1);
 
     return mmap_handler;
 }
@@ -986,7 +1015,24 @@ nxt_process_broadcast_shm_ack(nxt_task_t *task, nxt_process_t *process)
     port = nxt_process_port_first(process);
 
     if (port->type == NXT_PROCESS_APP) {
-        nxt_port_post(task, port, nxt_port_broadcast_shm_ack, process);
+        /*
+         * The process is handed to another engine as a bare pointer and is
+         * dereferenced there, so the posted handler needs a reference of its
+         * own and drops it when it is done.  nxt_port_post() returns NXT_OK
+         * both when it queues the handler and when it calls it inline on the
+         * current engine, and the handler owns the reference either way; only
+         * the NXT_ERROR case leaves nothing to run, so only that case has to
+         * be undone here.  The inline call is safe: the caller still holds
+         * its own reference, so this one cannot be the last.
+         */
+
+        nxt_process_use(task, process, 1);
+
+        if (nxt_slow_path(nxt_port_post(task, port, nxt_port_broadcast_shm_ack,
+                                        process) != NXT_OK))
+        {
+            nxt_process_use(task, process, -1);
+        }
     }
 }
 
@@ -1002,4 +1048,6 @@ nxt_port_broadcast_shm_ack(nxt_task_t *task, nxt_port_t *port, void *data)
         (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_SHM_ACK,
                                      -1, 0, 0, NULL);
     } nxt_queue_loop;
+
+    nxt_process_use(task, process, -1);
 }

--- a/src/nxt_process.c
+++ b/src/nxt_process.c
@@ -347,7 +347,25 @@ nxt_process_child_fixup(nxt_task_t *task, nxt_process_t *process)
 
     rt = task->thread->runtime;
 
-    /* Remove not ready processes. */
+    /*
+     * Remove not ready processes.
+     *
+     * These walks hand unreferenced processes to nxt_process_close_ports(),
+     * which takes its own +1/-1 -- the shape that made nxt_port_remove_pid()
+     * a double release once the refcount became cross-thread.  It is safe
+     * here for a different reason than everywhere else, and not because of
+     * the refcount: this runs immediately after fork() in the child, which
+     * is single-threaded by definition, so no other thread exists to have
+     * dropped the last reference.  nxt_runtime_process_each() iterating
+     * rt->processes without the mutex is safe for the same reason.
+     *
+     * The other half of that, now that nxt_process_use() locks
+     * rt->processes_mutex: the mutex is inherited across fork() and would be
+     * held forever in the child if any other thread of the parent held it at
+     * the call.  None can -- only main and prototype fork, both take the
+     * mutex on their single event engine, and their thread-pool threads
+     * never touch it.
+     */
     nxt_runtime_process_each(rt, p) {
 
         if (nxt_proc_keep_matrix[ptype][nxt_process_type(p)] == 0
@@ -1290,6 +1308,13 @@ nxt_process_type(nxt_process_t *process)
         (nxt_process_port_first(process))->type;
 }
 
+
+/*
+ * The caller must hold a reference to the process.  Closing the ports drops
+ * the reference each of them holds, so this takes one of its own to survive
+ * the loop -- but on a process that has already reached zero that same pair
+ * is a fresh 0 -> 1 -> 0 transition, which runs the teardown a second time.
+ */
 
 void
 nxt_process_close_ports(nxt_task_t *task, nxt_process_t *process)

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -6000,8 +6000,21 @@ nxt_router_oosm_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     nxt_debug(task, "oosm in %PI", msg->port_msg.pid);
 
-    process = nxt_runtime_process_find(task->thread->runtime,
-                                       msg->port_msg.pid);
+    /*
+     * Referenced, not just found: .oosm is in both the router main and the
+     * router worker port handler tables, so this runs on engines other than
+     * the one that can free the process, and the reference has to span the
+     * incoming.mutex critical section below.
+     *
+     * It has to span the broadcast too, but note what that does and does not
+     * buy: it keeps the nxt_process_t allocated, and nothing more.  The ports
+     * nxt_process_broadcast_shm_ack() reaches through process->ports are
+     * refcounted separately and that queue is walked here without a lock, so
+     * this reference does not make the walk itself safe.
+     */
+
+    process = nxt_runtime_process_ref(task->thread->runtime,
+                                      msg->port_msg.pid);
     if (nxt_slow_path(process == NULL)) {
         return;
     }
@@ -6042,6 +6055,13 @@ nxt_router_oosm_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     if (ack) {
         nxt_process_broadcast_shm_ack(task, process);
     }
+
+    /*
+     * The only release point: the process == NULL return above precedes the
+     * reference, and the loop breaks and continues but never returns.
+     */
+
+    nxt_process_use(task, process, -1);
 }
 
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -6002,9 +6002,12 @@ nxt_router_oosm_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     /*
      * Referenced, not just found: .oosm is in both the router main and the
-     * router worker port handler tables, so this runs on engines other than
-     * the one that can free the process, and the reference has to span the
-     * incoming.mutex critical section below.
+     * router worker port handler tables, and the reference has to span the
+     * incoming.mutex critical section below.  Which engine actually receives
+     * a given OOSM depends on the port libunit sends it to, so this is not
+     * assumed either way -- what makes the reference necessary is that a
+     * worker engine can drop the last reference to the same process while
+     * this runs.
      *
      * It has to span the broadcast too, but note what that does and does not
      * buy: it keeps the nxt_process_t allocated, and nothing more.  The ports

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -1727,6 +1727,16 @@ nxt_runtime_process_lhq_pid(nxt_lvlhsh_query_t *lhq, nxt_pid_t *pid)
 }
 
 
+/*
+ * Returns the process without a reference: the pointer is only valid for as
+ * long as nothing can drop the last reference to it.  That holds when the
+ * caller runs on the single engine that owns the process -- the main, the
+ * prototype or the controller process, each of which has exactly one event
+ * engine -- and nowhere else.  Any caller that can run on a router worker
+ * engine must use nxt_runtime_process_ref() instead; the router's main
+ * engine can be freeing the process concurrently.
+ */
+
 nxt_process_t *
 nxt_runtime_process_find(nxt_runtime_t *rt, nxt_pid_t pid)
 {
@@ -1741,6 +1751,47 @@ nxt_runtime_process_find(nxt_runtime_t *rt, nxt_pid_t pid)
 
     if (nxt_lvlhsh_find(&rt->processes, &lhq) == NXT_OK) {
         process = lhq.value;
+
+    } else {
+        nxt_thread_log_debug("process %PI not found", pid);
+    }
+
+    nxt_thread_mutex_unlock(&rt->processes_mutex);
+
+    return process;
+}
+
+
+/*
+ * Same lookup, but the caller adopts a reference to the result and must drop
+ * it with nxt_process_use(task, process, -1).  The find and the increment
+ * share one rt->processes_mutex critical section, and nxt_process_use()
+ * unlinks the process from rt->processes under that same mutex when the count
+ * reaches zero -- so a lookup that still sees the process in the hash cannot
+ * be racing its teardown, and the reference it takes cannot be an increment
+ * on an object that is already being freed.
+ *
+ * Cost, since this sits on the shared-memory message path: the find already
+ * took the mutex, so the increment itself is free; the matching release in
+ * nxt_process_use() is one additional acquisition of the same uncontended
+ * global mutex per lookup.
+ */
+
+nxt_process_t *
+nxt_runtime_process_ref(nxt_runtime_t *rt, nxt_pid_t pid)
+{
+    nxt_process_t       *process;
+    nxt_lvlhsh_query_t  lhq;
+
+    process = NULL;
+
+    nxt_runtime_process_lhq_pid(&lhq, &pid);
+
+    nxt_thread_mutex_lock(&rt->processes_mutex);
+
+    if (nxt_lvlhsh_find(&rt->processes, &lhq) == NXT_OK) {
+        process = lhq.value;
+        process->use_count++;
 
     } else {
         nxt_thread_log_debug("process %PI not found", pid);

--- a/src/nxt_runtime.h
+++ b/src/nxt_runtime.h
@@ -116,6 +116,7 @@ void nxt_runtime_process_unlink_locked(nxt_runtime_t *rt,
     nxt_process_t *process);
 
 nxt_process_t *nxt_runtime_process_find(nxt_runtime_t *rt, nxt_pid_t pid);
+nxt_process_t *nxt_runtime_process_ref(nxt_runtime_t *rt, nxt_pid_t pid);
 
 nxt_process_t *nxt_runtime_process_first(nxt_runtime_t *rt,
     nxt_lvlhsh_each_t *lhe);

--- a/test/php/big_response/index.php
+++ b/test/php/big_response/index.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Emits ?mb=<n> mebibytes of 'x' in 64 KiB writes.  Each write goes through
+ * the SAPI's ub_write -> nxt_unit_response_write(), which allocates the bytes
+ * out of the application's outgoing shared-memory segments, so a response
+ * larger than the application's "limits"/"shm" budget cannot be in flight all
+ * at once: the allocator runs the segment's free map dry and Unit's
+ * application library reports the out-of-shared-memory condition to the
+ * router (nxt_unit_send_oosm()).
+ */
+$mb = isset($_GET['mb']) ? (int) $_GET['mb'] : 32;
+
+header('Content-Type: text/plain');
+header('Content-Length: ' . ($mb * 1024 * 1024));
+
+$chunk = str_repeat('x', 65536);
+
+for ($i = 0; $i < $mb * 16; $i++) {
+    echo $chunk;
+}

--- a/test/test_process_abrupt_teardown.py
+++ b/test/test_process_abrupt_teardown.py
@@ -1,0 +1,316 @@
+"""Abrupt application death while large requests are in flight.
+
+What this drives: router worker engines on several event engines
+(``settings/listen_threads``) moving 1 MiB request and response bodies through
+an application's shared memory, while the test repeatedly ``kill -9``s the one
+process serving that application.  The application is configured with a single
+process, so every kill leaves the router with no worker for the application and
+forces a respawn, and every kill lands on a process that is mid-transfer.
+
+Why that matters here: this is the *abrupt* teardown path, and it is a
+different one from the graceful, configuration-driven teardown that
+test_process_teardown_churn.py drives.  A killed worker is noticed by the main
+process' SIGCHLD handler, which broadcasts NXT_PORT_MSG_REMOVE_PID; the router
+handles it in ``nxt_router_remove_pid_handler()`` -> ``nxt_port_remove_pid()``
+(src/nxt_port.c).  That function was converted from ``nxt_runtime_process_find()``
+to ``nxt_runtime_process_ref()``, and it is the site where review found a double
+free: it hands its result to ``nxt_process_close_ports()``, which takes its own
++1/-1 around the port loop, so on a process a router worker had already dropped
+to zero that pair is a second 0 -> 1 -> 0 transition and so a second teardown,
+racing the one already posted.  Nothing else in the suite reaches that site with
+shared-memory traffic in flight: test_respawn.py kills an idle worker, and the
+churn test never kills anything.
+
+What this proves and what it does not: a green run is *weak* evidence for the
+absence of the double free.  The window is a handful of instructions wide and
+an uninstrumented build will usually miss it.  The value of this test is as a
+crash and ASan/UBSan *driver* -- run under ``.github/workflows/sanitize.yml``
+instrumentation, a second teardown of the same process becomes a hard failure.
+Read a pass as "workers died hard under load, the router noticed each one, and
+the daemon kept serving correctly", nothing stronger.
+
+Correctness assertions are written so that a request legitimately failed by a
+kill is not a failure, but a corrupt or hung one is.  About two seconds of
+workload: six kills, at least 0.3 s apart, against four request threads.  Each
+round waits for a worker the run has not killed before, and then for the signal
+to have actually removed it, so all six are distinct abrupt teardowns rather
+than repeat shots at one corpse.
+"""
+
+import subprocess
+import threading
+import time
+
+import pytest
+
+from unit.applications.lang.php import ApplicationPHP
+from unit.log import Log
+
+prerequisites = {'modules': {'php': 'all'}}
+
+client = ApplicationPHP()
+
+APP = 'mirror'
+
+# Same reasoning as test_process_teardown_churn.py: 1 MiB spans 64 chunks of
+# shared memory in each direction (PORT_MMAP_CHUNK_SIZE is 16 KiB,
+# src/nxt_port_memory_int.h), so a request is inside the chunk allocator, and
+# the process/port lookups that reach it, for long enough that a kill on
+# another thread lands in the middle of one.
+BODY_SIZE = 1024 * 1024
+BODY = 'x' * BODY_SIZE
+
+# > 1 so more than one router worker engine is live; this is a top-level
+# "settings" member (src/nxt_conf_validation.c: nxt_conf_vldt_setting_members).
+LISTEN_THREADS = 4
+
+WORKERS = 4
+KILLS = 6
+KILL_INTERVAL = 0.3
+
+# Not the suite default (60s), so that a stalled request returns instead of
+# calling pytest.fail() on a helper thread; the stall is detected by timing it
+# and reported as a hard failure below.
+READ_TIMEOUT = 10
+
+
+def _app_pids():
+    """PIDs currently serving the application, via ps (as conftest does)."""
+    out = subprocess.check_output(
+        ['ps', '-ax', '-o', 'pid', '-o', 'command']
+    ).decode()
+
+    marker = f'unit: "{APP}" application'
+
+    return {line.split()[0] for line in out.splitlines() if marker in line}
+
+
+def _wait_for_fresh_app_pids(spent, timeout=5):
+    """Wait for a worker that is not one already killed, so every kill in the
+    loop below lands on a live process instead of on the gap left by the
+    previous one -- or, worse, on the corpse of it.
+
+    Excluding `spent` rather than just waiting for a non-empty set is what
+    makes each iteration a distinct abrupt teardown.  A SIGKILLed worker
+    leaves `_app_pids()` promptly, because the marker is the setproctitle
+    string in /proc/<pid>/cmdline and a zombie has no cmdline, so ps falls
+    back to "[comm] <defunct>" -- but "promptly" is a scheduling property,
+    and this test exists to be run on loaded sanitizer machines.  Making the
+    loop wait for a *new* pid turns that timing assumption into something the
+    test checks."""
+
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        pids = _app_pids() - spent
+
+        if pids:
+            return pids
+
+        time.sleep(0.05)
+
+    return set()
+
+
+def _wait_for_pids_gone(pids, timeout=5):
+    """Wait until none of `pids` serves the application any more, i.e. until
+    the SIGKILL has actually taken a worker away rather than merely being
+    queued on one."""
+
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not (_app_pids() & pids):
+            return True
+
+        time.sleep(0.05)
+
+    return False
+
+
+def test_process_abrupt_teardown(skip_alert, skip_fds_check):
+    # Killing workers leaves descriptor accounting unsettled in all three
+    # long-lived processes for as long as the respawn takes, and changing
+    # "listen_threads" leaks the destroyed engines' port socketpairs on top of
+    # that (see test_process_teardown_churn.py).  Neither is what this test is
+    # about.
+    skip_fds_check(main=True, router=True, controller=True)
+
+    # Expected, and in fact asserted on below: this is how the main process
+    # reports each kill.
+    skip_alert(r'app process \d+ exited on signal 9')
+
+    # Exactly one process, so a kill always removes the only worker and the
+    # router has to tear the process down rather than route around it, and so
+    # every request thread contends on the same incoming.mutex.
+    client.load(APP, processes={"spare": 1, "max": 1, "idle_timeout": 30})
+
+    assert 'success' in client.conf(
+        {"listen_threads": LISTEN_THREADS}, 'settings'
+    ), 'listen_threads'
+
+    assert client.post(body='ping', read_timeout=READ_TIMEOUT)['status'] == 200
+
+    stop = threading.Event()
+    lock = threading.Lock()
+    failures = []
+    outcomes = []
+    killed = []
+
+    def record(bucket, item):
+        with lock:
+            bucket.append(item)
+
+    def request_worker():
+        while not stop.is_set():
+            started = time.time()
+
+            try:
+                resp = client.post(
+                    body=BODY,
+                    read_timeout=READ_TIMEOUT,
+                    read_buffer_size=65536,
+                )
+
+            except KeyboardInterrupt:
+                raise
+
+            # pytest.fail() inside the helpers raises BaseException
+            except BaseException as exc:  # noqa: BLE001
+                # The listener stays open across a worker death, so a refused
+                # or reset connection is still not expected; record it and let
+                # the assertions below decide.
+                record(failures, f'request raised {exc!r}')
+                continue
+
+            elapsed = time.time() - started
+            status = resp.get('status')
+            body = resp.get('body', '')
+
+            if status == 200:
+                # A short body is legitimate: the worker can die after its
+                # headers are on the wire.  Wrong *bytes* are not - that is
+                # what reading freed or recycled shared memory looks like.
+                if body != BODY[: len(body)]:
+                    # next() needs a default.  A body that is all 'x' but
+                    # LONGER than the request still fails the comparison
+                    # above -- BODY[:len(body)] clamps to BODY -- and then
+                    # has no mismatching byte to find.  Without the default
+                    # that raises StopIteration here, outside the try that
+                    # guards the request, killing the worker thread instead
+                    # of recording the corruption: the detector fails open
+                    # on one of the shapes it exists to catch.
+                    at = next(
+                        (i for i, c in enumerate(body) if c != 'x'), None
+                    )
+                    record(
+                        failures,
+                        f'corrupt body: {len(body)} bytes, '
+                        + (
+                            f'first mismatch at {at}'
+                            if at is not None
+                            else f'uniform but longer than {BODY_SIZE}'
+                        ),
+                    )
+                    continue
+
+                record(outcomes, 200 if len(body) == BODY_SIZE else 'truncated')
+
+            elif status is None:
+                # No parsable response: connection closed as the worker died.
+                # Distinguish that from a hang, which is a real defect.
+                if elapsed >= READ_TIMEOUT:
+                    record(failures, f'no response in {elapsed:.1f}s')
+                else:
+                    record(outcomes, 'closed')
+
+            elif status in (500, 503):
+                record(outcomes, status)
+
+            else:
+                record(failures, f'unexpected status {status}')
+
+    workers = [threading.Thread(target=request_worker) for _ in range(WORKERS)]
+
+    for worker in workers:
+        worker.start()
+
+    for round_ in range(KILLS):
+        pids = _wait_for_fresh_app_pids(set(killed))
+
+        if not pids:
+            record(
+                failures, f'no fresh application worker for kill {round_ + 1}'
+            )
+            break
+
+        subprocess.call(['kill', '-9', *pids])
+
+        # Only count the round once the signal has demonstrably removed those
+        # workers.  Otherwise a kill that has not landed yet would leave the
+        # next iteration looking at the same process, and the run would lose
+        # abrupt-teardown coverage without losing a single assertion.
+        if not _wait_for_pids_gone(pids):
+            record(failures, f'kill -9 did not remove {sorted(pids)}')
+            break
+
+        killed.extend(pids)
+
+        time.sleep(KILL_INTERVAL)
+
+    stop.set()
+
+    for worker in workers:
+        worker.join(timeout=120)
+        assert not worker.is_alive(), 'request thread hung'
+
+    assert not failures, f'{len(failures)} failure(s), first: {failures[0]}'
+
+    # The daemon is still alive and still serves the whole payload correctly.
+    resp = client.post(
+        body=BODY, read_timeout=READ_TIMEOUT, read_buffer_size=65536
+    )
+
+    assert resp['status'] == 200, 'still serving'
+    assert len(resp['body']) == BODY_SIZE, 'still serving whole body'
+    assert resp['body'] == BODY, 'still serving intact body'
+
+    # Requests must not have been shut out entirely, or nothing was in flight
+    # when a worker died.
+    assert outcomes.count(200) > 0, f'no request completed: {outcomes[:20]}'
+
+    # Every round killed a worker that had never been killed before, and the
+    # loop ran all KILLS of them -- so the router really did tear a process
+    # down and build a new one, repeatedly, and not two or three times with
+    # the rest of the rounds shooting at the same corpse.  The loop enforces
+    # the first property; assert it anyway, since it is the coverage claim.
+    assert len(set(killed)) == len(killed), (
+        f'a worker was killed twice: {killed}'
+    )
+    assert len(killed) >= KILLS, (
+        f'only {len(killed)} worker(s) killed: {killed}'
+    )
+
+    log = Log.read()
+
+    # Available at any log level - this is the alert the main process emits
+    # from its SIGCHLD handler, and the same handler is what broadcasts
+    # NXT_PORT_MSG_REMOVE_PID to the router.  One per kill.
+    for pid in set(killed):
+        assert f'app process {pid} exited on signal 9' in log, (
+            f'main process did not report the death of {pid}'
+        )
+
+    # The direct evidence - "port remove pid <pid> handler" is logged by
+    # nxt_port_remove_pid() itself - is nxt_debug(), compiled out unless Unit
+    # was configured with --debug.  Skip loudly rather than let the test
+    # degrade into a smoke test that never checks the site it names.
+    if '[debug]' not in log:
+        pytest.skip('remove_pid evidence needs a --debug build')
+
+    for pid in set(killed):
+        assert f'port remove pid {pid} handler' in log, (
+            f'nxt_port_remove_pid() did not run for {pid}'
+        )
+
+    Log.check_alerts()

--- a/test/test_process_shm_oosm.py
+++ b/test/test_process_shm_oosm.py
@@ -1,0 +1,155 @@
+"""Router handling of an application that runs out of shared memory.
+
+What this drives: a PHP application whose shared-memory budget
+(``applications/<name>/limits/shm``) is one segment, writing a response several
+times larger than that segment.  Every write goes through
+``nxt_unit_response_write()``, which allocates out of the application's
+outgoing segments, and those chunks stay busy until the router has written them
+to the client and completed the buffers.  The client stalls before reading, so
+the queued response keeps the segment's free map full while the application
+still has output left; ``nxt_unit_mmap_get()`` (src/nxt_unit.c) then reports
+the out-of-shared-memory condition to the router and blocks until it is
+acknowledged.
+
+Why that matters here: the OOSM message is the only thing that reaches
+``nxt_router_oosm_handler()`` (src/nxt_router.c), and the ACK the application
+waits for is the only thing that reaches ``nxt_process_broadcast_shm_ack()``
+(src/nxt_port_memory.c), which the router sends from the ``hdr->oosm`` branch
+of ``nxt_port_mmap_buf_completion()`` as it frees the chunks.  All three look
+the peer process up by pid, and all three were converted from
+``nxt_runtime_process_find()``, which returns a process without a reference, to
+``nxt_runtime_process_ref()``.  Nothing else in this suite sends an OOSM
+message, so before this test those conversions had no coverage at all.
+
+Which engine runs what: ``nxt_unit_send_oosm()`` always sends to
+``lib->router_port``, so in practice ``nxt_router_oosm_handler()`` runs on the
+router's *main* engine -- confirmed by the thread id in its log record -- even
+though ``.oosm`` is in the worker port handler table too.  The reference is
+load-bearing anyway, because the engine that runs the handler is not the only
+one manipulating the process refcount: with ``listen_threads`` above one, the
+worker engines take and drop references of their own on every shared-memory
+message, and one of those drops can be the last.  ``nxt_port_mmap_buf_completion()``
+does run on a worker engine, since that is where the response was written out.
+
+What this proves and what it does not: it proves the code ran -- the assertions
+are on log records emitted from inside those handlers, not on a response that
+would look identical either way.  It does *not* prove the absence of the
+use-after-free they were converted to fix; reaching the handler is necessary
+for that race, not sufficient, and an uninstrumented build will usually survive
+a live one.  Read a pass as "the OOSM/ACK round trip happened and the daemon
+stayed correct".  The value of the test is as a driver for the sanitiser legs,
+where a stale process pointer becomes a hard failure instead of a coin flip.
+
+Cheap on purpose: one request and one deliberate client stall, about a second
+of work once the PHP worker is warm.
+"""
+
+import time
+
+import pytest
+
+from unit.applications.lang.php import ApplicationPHP
+from unit.log import Log
+
+prerequisites = {'modules': {'php': 'all'}}
+
+client = ApplicationPHP()
+
+APP = 'big_response'
+
+# One segment is PORT_MMAP_DATA_SIZE == 10 MiB (src/nxt_port_memory_int.h), and
+# nxt_unit_init() rounds "limits"/"shm" up to whole segments with a floor of
+# one, so any value at or below 10 MiB leaves the application a single segment.
+SHM_LIMIT = 1
+
+# Comfortably past that 10 MiB even after the kernel socket buffers have
+# absorbed their share of the response.  Measured on this tree: 12 MiB produces
+# no OOSM at all, because the socket buffers alone hold the overflow; 16 MiB
+# produces 1-9 messages depending on timing; 24 MiB produced 12-14 on every
+# run.  Sized for the margin, not for the minimum.
+RESPONSE_MB = 24
+RESPONSE_SIZE = RESPONSE_MB * 1024 * 1024
+
+# The client sends, then does not read for this long, so the router's queued
+# response buffers - which are the application's shared memory, busy until the
+# write to the client completes - pile up instead of draining.
+STALL = 0.3
+
+# > 1 so router worker engines exist and are taking and dropping their own
+# references on the same process while the OOSM round trip runs.
+LISTEN_THREADS = 4
+
+READ_TIMEOUT = 30
+
+
+def _body(resp, size):
+    """Trailing `size` bytes of a raw response, i.e. the body: the application
+    sets Content-Length and the connection is not chunked.  Kept as bytes so a
+    24 MiB response is not decoded into a second copy."""
+
+    return resp[-size:]
+
+
+def test_process_shm_oosm(skip_fds_check):
+    # Same pre-existing engine-teardown descriptor leak that
+    # test_process_teardown_churn.py documents: changing "listen_threads"
+    # destroys event engines, and each destroyed engine keeps its port
+    # socketpair open.  Unrelated to what this test exercises.
+    skip_fds_check(router=True)
+
+    client.load(APP, limits={"shm": SHM_LIMIT}, processes=1)
+
+    assert 'success' in client.conf(
+        {"listen_threads": LISTEN_THREADS}, 'settings'
+    ), 'listen_threads'
+
+    sock = client.get(url=f'/?mb={RESPONSE_MB}', no_recv=True)
+
+    time.sleep(STALL)
+
+    resp = client.recvall(sock, read_timeout=READ_TIMEOUT, buff_size=65536)
+    sock.close()
+
+    body = _body(resp, RESPONSE_SIZE)
+
+    assert len(body) == RESPONSE_SIZE, 'whole response'
+    assert body.count(b'x') == RESPONSE_SIZE, 'intact response'
+
+    log = Log.read()
+
+    # The records asserted on below are nxt_debug()/nxt_unit_debug(), compiled
+    # out unless Unit was configured with --debug.  Skip loudly rather than
+    # let the test degrade into a smoke test that proves nothing about the
+    # path it claims to cover.  The sanitiser workflow builds --debug, which
+    # is the leg this test exists for.
+    if '[debug]' not in log:
+        pytest.skip('OOSM evidence needs a --debug build')
+
+    # nxt_router_oosm_handler() logs this on entry, immediately before the
+    # reference it now takes; its presence is the proof that the converted
+    # call site ran.
+    assert 'oosm in ' in log, 'router handled an OOSM message'
+
+    # The application logs "oosm: retry" only after nxt_unit_wait_shm_ack()
+    # has returned OK, and that happens only on an NXT_PORT_MSG_SHM_ACK
+    # message (src/nxt_unit.c).  The router's only sender of that message is
+    # nxt_port_broadcast_shm_ack(), reached through the converted
+    # nxt_process_broadcast_shm_ack() -- so this record is proof that the
+    # cross-engine post, and the reference it now carries, ran too.
+    #
+    # Which of the two callers broadcast is deliberately not asserted: with
+    # the segment this full, nxt_router_oosm_handler() almost never finds a
+    # free chunk to acknowledge with ("oosm: already free" is absent from
+    # these runs) and the ACK comes from nxt_port_mmap_buf_completion().
+    assert 'oosm: retry' in log, 'application got a SHM_ACK back'
+
+    # Still serving, from the same worker, after the round trip.
+    sock = client.get(url='/?mb=1', no_recv=True)
+    resp = client.recvall(sock, read_timeout=READ_TIMEOUT, buff_size=65536)
+    sock.close()
+
+    assert _body(resp, 1024 * 1024).count(b'x') == 1024 * 1024, (
+        'still serving'
+    )
+
+    Log.check_alerts()

--- a/test/test_process_teardown_churn.py
+++ b/test/test_process_teardown_churn.py
@@ -1,0 +1,236 @@
+"""Application teardown churn under concurrent shared-memory traffic.
+
+What this drives: several router worker engines (``settings/listen_threads``)
+serving large POSTs to a PHP application while a second thread repeatedly
+rewrites that application's configuration.  Every configuration rewrite makes
+the router build a *new* ``nxt_app_t`` and release the previous one
+(``src/nxt_router.c``: an application is reused only when the printed JSON of
+its configuration is byte-identical), which tears the old application's
+processes down and destroys its outgoing port-mmap segments
+(``nxt_port_mmaps_destroy()``) — while router workers on other engines are
+still copying request bodies into, and reading responses out of, shared memory
+for that same application.
+
+What this proves and what it does not: a green run is *weak* evidence for the
+absence of a use-after-free on the process/port lookup path.  The window is a
+handful of instructions wide and an unsanitised build will almost always miss
+it.  The value of this test is as a crash and ASan/UBSan *driver*: run it under
+``.github/workflows/sanitize.yml``-style instrumentation and a live
+use-after-free becomes a hard failure instead of a coin flip.  Read a pass here
+as "the workload ran and the daemon stayed up", nothing stronger.
+
+Deliberately kept short - 64 requests of 1 MiB, about three seconds on an idle
+8-core box - so it is cheap enough to run on every CI leg, including the much
+slower sanitiser legs.  Correctness assertions are written so that a
+legitimately failed request during teardown is not a failure, but a corrupt or
+hung one is.
+"""
+
+import subprocess
+import threading
+import time
+
+from unit.applications.lang.php import ApplicationPHP
+from unit.log import Log
+
+prerequisites = {'modules': {'php': 'all'}}
+
+client = ApplicationPHP()
+
+# src/nxt_port_memory_int.h: PORT_MMAP_CHUNK_SIZE is 16 KiB and one shared
+# memory segment holds PORT_MMAP_DATA_SIZE (10 MiB) of payload.  The router
+# always hands requests to an application through those segments
+# (nxt_router_prepare_msg() allocates with nxt_port_mmap_get_buf()), but a
+# small request fits in a single chunk of a single segment.  1 MiB spans 64
+# chunks in each direction and keeps the worker inside the chunk allocator
+# (nxt_port_mmap_get_buf()/nxt_port_mmap_increase_buf()) long enough for a
+# teardown on another thread to overlap it.
+BODY_SIZE = 1024 * 1024
+BODY = 'x' * BODY_SIZE
+
+# > 1 so more than one router worker engine is live; this is a top-level
+# "settings" member (src/nxt_conf_validation.c: nxt_conf_vldt_setting_members).
+LISTEN_THREADS = 4
+
+WORKERS = 4
+REQUESTS_PER_WORKER = 16
+CHURN_INTERVAL = 0.05
+
+# Not the suite default (60s), so that a stalled request returns instead of
+# calling pytest.fail() on a helper thread; the stall is detected by timing it
+# and reported as a hard failure below.
+READ_TIMEOUT = 10
+
+APP = 'mirror'
+
+
+def _app_pids():
+    """PIDs currently serving the application, via ps (as conftest does)."""
+    out = subprocess.check_output(
+        ['ps', '-ax', '-o', 'pid', '-o', 'command']
+    ).decode()
+
+    marker = f'unit: "{APP}" application'
+
+    return {line.split()[0] for line in out.splitlines() if marker in line}
+
+
+def test_process_teardown_churn(skip_fds_check):
+    # Setting "listen_threads" changes the number of router worker engines,
+    # and destroying an engine leaks its descriptors: measured on this tree,
+    # shrinking the count frees each dead engine's epoll and eventfd but keeps
+    # its port socketpair open (3 sockets per destroyed engine), so the router
+    # ends the test with more descriptors than it started with.  That is a
+    # pre-existing defect in engine teardown, not something this workload
+    # causes, and it is unrelated to what the test is here to exercise.
+    skip_fds_check(router=True)
+
+    client.load(APP, processes={"spare": 2, "max": 4, "idle_timeout": 5})
+
+    assert 'success' in client.conf(
+        {"listen_threads": LISTEN_THREADS}, 'settings'
+    ), 'listen_threads'
+
+    assert client.post(body='ping', read_timeout=READ_TIMEOUT)['status'] == 200
+
+    lock = threading.Lock()
+    stop = threading.Event()
+    failures = []
+    outcomes = []
+    pids = set()
+
+    def record(bucket, item):
+        with lock:
+            bucket.append(item)
+
+    def request_worker():
+        for _ in range(REQUESTS_PER_WORKER):
+            started = time.time()
+
+            try:
+                resp = client.post(
+                    body=BODY,
+                    read_timeout=READ_TIMEOUT,
+                    read_buffer_size=65536,
+                )
+
+            except KeyboardInterrupt:
+                raise
+
+            # pytest.fail() inside the helpers raises BaseException
+            except BaseException as exc:  # noqa: BLE001
+                record(failures, f'request raised {exc!r}')
+                continue
+
+            elapsed = time.time() - started
+            status = resp.get('status')
+            body = resp.get('body', '')
+
+            if status == 200:
+                # A short body is legitimate: the application can die after its
+                # headers are on the wire.  Wrong *bytes* are not - that is
+                # what reading freed or recycled shared memory looks like.
+                if body != BODY[: len(body)]:
+                    # next() needs a default.  A body that is all 'x' but
+                    # LONGER than the request still fails the comparison
+                    # above -- BODY[:len(body)] clamps to BODY -- and then
+                    # has no mismatching byte to find.  Without the default
+                    # that raises StopIteration here, outside the try that
+                    # guards the request, killing the worker thread instead
+                    # of recording the corruption: the detector fails open
+                    # on one of the shapes it exists to catch.
+                    at = next(
+                        (i for i, c in enumerate(body) if c != 'x'), None
+                    )
+                    record(
+                        failures,
+                        f'corrupt body: {len(body)} bytes, '
+                        + (
+                            f'first mismatch at {at}'
+                            if at is not None
+                            else f'uniform but longer than {BODY_SIZE}'
+                        ),
+                    )
+                    continue
+
+                full = len(body) == BODY_SIZE
+
+                record(outcomes, 200 if full else 'truncated')
+
+            elif status is None:
+                # No parsable response: connection closed during teardown.
+                # Distinguish that from a hang, which is a real defect.
+                if elapsed >= READ_TIMEOUT:
+                    record(failures, f'no response in {elapsed:.1f}s')
+                else:
+                    record(outcomes, 'closed')
+
+            elif status in (500, 503):
+                record(outcomes, status)
+
+            else:
+                record(failures, f'unexpected status {status}')
+
+    def churn_worker():
+        generation = 0
+
+        while not stop.is_set():
+            generation += 1
+
+            try:
+                resp = client.conf(
+                    {"CHURN": str(generation)},
+                    f'applications/{APP}/environment',
+                )
+
+            except KeyboardInterrupt:
+                raise
+
+            except BaseException as exc:  # noqa: BLE001
+                record(failures, f'config update {generation} raised {exc!r}')
+                return
+
+            if 'success' not in resp:
+                record(failures, f'config update {generation} failed: {resp}')
+                return
+
+            with lock:
+                pids.update(_app_pids())
+
+            time.sleep(CHURN_INTERVAL)
+
+    churn = threading.Thread(target=churn_worker)
+    workers = [threading.Thread(target=request_worker) for _ in range(WORKERS)]
+
+    churn.start()
+    for worker in workers:
+        worker.start()
+
+    for worker in workers:
+        worker.join(timeout=120)
+        assert not worker.is_alive(), 'request thread hung'
+
+    stop.set()
+    churn.join(timeout=60)
+    assert not churn.is_alive(), 'churn thread hung'
+
+    assert not failures, f'{len(failures)} failure(s), first: {failures[0]}'
+
+    # The daemon is still alive and still serves the whole payload correctly.
+    resp = client.post(body=BODY, read_timeout=READ_TIMEOUT,
+                       read_buffer_size=65536)
+
+    assert resp['status'] == 200, 'still serving'
+    assert len(resp['body']) == BODY_SIZE, 'still serving whole body'
+    assert resp['body'] == BODY, 'still serving intact body'
+
+    # The workload has to have actually torn processes down, otherwise it is
+    # only a concurrency test.  More than one PID means the application was
+    # destroyed and respawned while requests were in flight.
+    assert len(pids) > 1, f'application processes were not replaced: {pids}'
+
+    # Requests must not have been shut out entirely, or nothing reached shared
+    # memory concurrently with a teardown.
+    assert outcomes.count(200) > 0, f'no request completed: {outcomes}'
+
+    Log.check_alerts()


### PR DESCRIPTION
Adds `nxt_runtime_process_ref()` and converts the call sites that can run on a router worker engine, so a worker can no longer hold an `nxt_process_t *` that the router main engine has already freed. **This is the change that closes [issue #120](https://github.com/freeunitorg/freeunit/issues/120).**

Stacked on [fix/process-refcount-serialize](https://github.com/freeunitorg/freeunit/pull/183) — review and merge that first. Sequenced per [issue #172](https://github.com/freeunitorg/freeunit/issues/172).

## The accessor

`nxt_runtime_process_ref()` does the lookup and the `use_count++` in a single `rt->processes_mutex` critical section — the section `nxt_runtime_process_find()` already takes. Because the base PR makes `nxt_process_use()` unlink the process under that same mutex when the count reaches zero, a lookup that still finds the process in `rt->processes` provably cannot be racing its teardown.

The bare `nxt_runtime_process_find()` stays for the single-engine sites and gains a comment naming the constraint.

## Converted sites, and where each reference is dropped

A missed release leaks an `nxt_process_t`; a double release crashes. Every exit from each converted function, including `goto` targets and error returns:

### `nxt_port_mmap_handler()` — `src/nxt_port.c`

| exit | reference held? | release |
|---|---|---|
| `msg->fd[0] == -1` early return | no — precedes the lookup | — |
| `goto fail_close` on `process == NULL` | no — the lookup failed | — |
| fall-through after `nxt_port_incoming_port_mmap()` | yes | **inside the success branch**, before the `fail_close:` label |

The release is deliberately *not* at the `fail_close:` label: that label is shared with the `process == NULL` path, and a release there would call `nxt_process_use(task, NULL, -1)`. `nxt_port_incoming_port_mmap()` takes and releases `process->incoming.mutex` internally without touching the reference count, so the reference spans the whole call.

### `nxt_port_mmap_buf_completion()` — `src/nxt_port_memory.c`

| exit | reference held? | release |
|---|---|---|
| `nxt_buf_ts_handle()` early return | no — precedes the lookup | — |
| `goto release_buf` on a foreign process pair | no — skips the lookup | — |
| end of function | see below | — |

This one is a **loop**: the `goto complete_buf` back-edge re-enters the referenced block once per buffer of a chain. The release is therefore **inside the `oosm` block**, paired with each lookup. A release at the end of the function would leak N−1 references on any multi-buffer chain.

Uses the `src_pid`/`dst_pid` locals snapshotted by the base PR. Without that snapshot the pid handed to the accessor would be peer-steerable, since `hdr` is in a segment the application still maps writable.

### `nxt_port_get_port_incoming_mmap()` — `src/nxt_port_memory.c`

The core fix. No `goto`, no early return between lock and unlock; both branches converge.

| exit | reference held? | release |
|---|---|---|
| `process == NULL` | no | — |
| single return, both branches | yes | **strictly after** `nxt_thread_mutex_unlock(&process->incoming.mutex)` |

The ordering is mandatory. Releasing before the unlock means, if it is the last reference, `nxt_runtime_process_release()` runs `nxt_thread_mutex_destroy(&process->incoming.mutex)` on a mutex this function still holds, and the unlock then operates on freed memory. Returning `mmap_handler` after dropping the process reference is safe: the `+1` on the handler is independent, and the caller releases it on all of its exits.

### `nxt_router_oosm_handler()` — `src/nxt_router.c`

| exit | reference held? | release |
|---|---|---|
| `process == NULL` return | no — precedes the lookup | — |
| end of function | yes | **one** release, after the `if (ack)` block |

The loop body contains only `continue` and `break` — no return, no goto. There is exactly one release point; a second one at the `process == NULL` return would be a double drop.

### `nxt_port_remove_pid()` — `src/nxt_port.c`

Converted for a different reason, and this one is a defect the base PR would otherwise introduce.

It runs only on main engines, which is why it looked safe to leave — but the invariant it needs is **ownership**, not thread affinity. It hands its result to `nxt_process_close_ports()`, which takes its own `+1`/`-1` around the port loop. On a process a router worker has already dropped to zero, that pair is a fresh 0 → 1 → 0 transition and runs the teardown a **second** time — racing the free already posted to this engine, for a double `nxt_mp_free()` and a double mutex destroy.

Serializing the refcount is what makes that reachable (before it, the worker freed inline and the same window was the original use-after-free), so the fix belongs with this change rather than after it. `nxt_process_close_ports()` gains a comment stating the precondition.

## `nxt_process_broadcast_shm_ack()`

Independent of the refcount race, this hands a **bare `nxt_process_t *` to another engine** via `nxt_port_post()`, and the posted handler dereferences `process->ports` there — a use-after-free with no reference count at all. The cross-engine branch is the one actually taken: the application port's engine is the router main engine, while the callers run on workers.

`nxt_port_post()` has three outcomes and the drop owner differs:

| outcome | handler runs | returns | drops the reference |
|---|---|---|---|
| same engine | inline, before returning | `NXT_OK` | the handler |
| `nxt_zalloc()` fails | never | `NXT_ERROR` | the caller |
| queued | later, on the target engine | `NXT_OK` | the handler |

So the caller takes a `+1` before posting, the handler drops it, and the caller compensates **only** on `!= NXT_OK`. That single test is exact, because the handler owns the reference in both `NXT_OK` cases. The inline case cannot free the process out from under the return path, since both callers still hold their own reference.

## Cost

`nxt_runtime_process_find()` already took `rt->processes_mutex`, so folding the increment into that critical section is free. The **matching release** is one additional acquisition of the same global mutex per lookup on the shared-memory path.

I want to be precise here rather than repeat the framing from the planning doc, because [#120](https://github.com/freeunitorg/freeunit/issues/120) began as a performance concern about this exact function: the acquisition count per lookup is **not** unchanged — it goes from one to two. What is unchanged is that no *new* lock is introduced, and `use_count` lives in a process-private `nxt_zalloc()`'d struct rather than the shared segment, so no additional cross-process cache line is touched.

I am also **not** citing the benchmark posted on that issue in July, in either direction. `NXT_UNIT_MAX_PLAIN_SIZE` is 1024 and the `php_drain` cells return an empty 204 regardless of request size, so those cells execute `nxt_port_get_port_incoming_mmap()` approximately zero times — a −20.7% median in a cell the patch cannot reach puts that harness's noise floor near ±20%, which is wider than any effect being claimed.

If a benchmark is wanted, the only geometry that could show contention is responses well over 1 KiB, `listen_threads` ≥ 8, and a **single** application process so one `incoming.mutex` is shared. That is the same geometry as the race reproduction, so one workload serves both.

## Verification

- Builds clean under `-Wall -Wextra -Werror`.
- `./build/tests` exit 0. `test_php_application.py` 49 passed / 3 skipped, `test_return.py` 6 passed, `test_reconfigure.py` 2 passed — identical to a baseline at the base of the stack. With the new test, 58 passed / 3 skipped.
- ASan+UBSan build of `unitd` and `php.unit.so`, running the new churn test plus the three suites above: no use-after-free, no double free, no invalid free. The corrected `nxt_port_remove_pid()` path was exercised across ~270 application process deaths per matrix with no double free.

**The race is demonstrated under fault injection.** With a delay opened between the lookup and its first use and the peer SIGKILLed at that point, an ASan build of this series' parent reports `heap-use-after-free` on the `nxt_process_t` in **5 runs out of 5** — a router worker inside `nxt_process_broadcast_shm_ack()` reading `process->ports` while the router main engine frees the process via `nxt_port_remove_pid()` → `nxt_process_close_ports()`. With this commit, the identical injection and workload produce **zero**, and the peer's `use_count` is 2 rather than 1 for the duration of the window. Full report in the base PR.

**The conversions are not all equally load-bearing, and the injection shows which is.** `nxt_port_get_port_incoming_mmap()` — the site the planning document called "the core fix" — could not be forced open at all, across 192 windows of 200 ms and 18 windows of 2 s with the peer killed at window open. The reason is structural: a worker reaching it while reading a response holds a reference on the app's port, which holds the process's last reference, so the sleeping worker pins the very object it is about to use. The demonstrably necessary conversion is `nxt_port_mmap_buf_completion()` → `nxt_process_broadcast_shm_ack()`, which runs *after* that port reference is gone. The other three are converted because the same reasoning does not protect them on every path, not because each was independently reproduced.

**Still true:** statistical churn does not reach any of this. The un-injected workload is clean on both trees, which is why every earlier green run meant nothing either way.

## The test

`test/test_process_teardown_churn.py` drives several router worker engines serving 1 MiB POSTs while a second thread rewrites the application config, so the router repeatedly builds a new `nxt_app_t` and tears the previous one down — destroying its port mmap segments while workers on other engines are still moving request and response bodies through shared memory for that application.

A 200 response body must be a *prefix* of the payload: a short body is legitimate when the application dies mid-response, but wrong bytes are what reading recycled shared memory looks like. It also asserts more than one application PID served the run, otherwise it silently degrades into a plain concurrency test. Runs in ~3 s.

The docstring says plainly that a green run is weak evidence and that the value is as a crash and sanitizer driver. It earned that description: on its first serious outing under ASan it reproduced a genuine, previously unreported heap-use-after-free on the unfixed tree (see residuals).

`skip_fds_check(router=True)` is needed because destroying a router engine leaks its port socketpair — pre-existing, unrelated, documented at the call site.

## Known residuals

- `nxt_runtime_process_each()` still iterates `rt->processes` unlocked. The mutual exclusion this PR relies on holds for `_find`/`_ref`/`_get`, **not** for iteration. To be precise about this PR's contribution: worker-side drops are not new — `nxt_port_release()` already calls `nxt_process_use(-1)` from whichever engine drops the last port reference — and the pairs added here are balanced, so a drop still reaches zero exactly once per process death. What changes is *which* engine performs the final drop, i.e. the shape of the hazard rather than its rate.
- `nxt_runtime_exit()` passes unreferenced pointers to `nxt_process_close_ports()` — the same shape as the `nxt_port_remove_pid()` double free fixed here. Shutdown-only, immediately followed by `exit()`.
- `nxt_process_broadcast_shm_ack()` reads `process->ports` on the *calling* engine while that queue is mutated on the router main engine. A reference keeps the struct allocated; it does not make an unsynchronised queue walk safe. Not claimed to be fixed here.
- `nxt_port_close()` does not reset `port->socket.fd` or remove the port from `process->ports`, so a late `nxt_port_socket_write()` can hit a stale descriptor. Pre-existing.

## Separate issues found while testing this

Neither is caused by this change; both reproduce on the unfixed parent.

1. **A reproducible heap-use-after-free in the config-apply path.** `nxt_locked_work_queue_move()` (`src/nxt_work_queue.c:304`) reads a `nxt_joint_job_t` out of a `tmcf->mem_pool` that `nxt_router_conf_ready()` has already released, because the job was posted to a worker engine's locked queue and that engine had not drained it. Fires on the unfixed parent at roughly 17% of churn runs.

2. **`ASAN_OPTIONS=log_path=` is silently ineffective for `unitd`** — almost certainly because `nxt_process_title()` overwrites the `argv`/`environ` block that ASan keeps a `const char *` into, so the path dangles and reports fall back to stderr. Consequence: `.github/workflows/sanitize.yml`'s "Fail on sanitizer reports" step can never fire, because `asan-logs/` is always empty. It reported *"No sanitizer reports; lifecycle paths are clean"* on a run that had just produced a heap-use-after-free. UBSan-only violations are invisible in both directions. The gate should grep the test harness's `unit.log`, where the reports actually land.
