### PR TITLE
http: support "json" access log format shorthand

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,15 @@
 
+Changes with FreeUnit 1.36.1                                     -- --- ----
+
+    *) Feature: the access log "format" option accepts the string "json",
+       which writes one JSON object per request with a stable set of
+       fields: "request", "status", "bytes_sent", "remote_addr",
+       "user_agent", "referer", "request_time", and "request_id".  Values
+       are JSON-escaped, so request-controlled fields cannot break the
+       enclosing string.  Any other format string keeps its existing
+       literal meaning.
+
+
 Changes with FreeUnit 1.36.0                                     16 Jul 2026
 
     *) Bugfix: the controller crashed in debug builds when a control-socket

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -36,8 +36,16 @@ struct nxt_router_access_log_format_s {
 };
 
 
+typedef struct {
+    nxt_str_t                       name;
+    nxt_str_t                       value;
+} nxt_router_access_log_field_t;
+
+
 static nxt_router_access_log_format_t *nxt_router_access_log_format_create(
     nxt_task_t *task, nxt_router_conf_t *rtcf, nxt_conf_value_t *value);
+static nxt_int_t nxt_router_access_log_format_json(nxt_router_conf_t *rtcf,
+    nxt_router_access_log_format_t *format);
 static void nxt_router_access_log_writer(nxt_task_t *task,
     nxt_http_request_t *r, nxt_router_access_log_t *access_log,
     nxt_router_access_log_format_t *format);
@@ -58,6 +66,24 @@ static void nxt_router_access_log_reopen_ready(nxt_task_t *task,
     nxt_port_recv_msg_t *msg, void *data);
 static void nxt_router_access_log_reopen_error(nxt_task_t *task,
     nxt_port_recv_msg_t *msg, void *data);
+
+
+/*
+ * The field set of the "json" format shorthand.  The names are a stable
+ * part of the configuration interface: they are what a log consumer keys
+ * on, so they are decoupled from the variable names they expand to.
+ */
+
+static const nxt_router_access_log_field_t  nxt_router_access_log_fields[] = {
+    { nxt_string("request"),      nxt_string("$request_line")      },
+    { nxt_string("status"),       nxt_string("$status")            },
+    { nxt_string("bytes_sent"),   nxt_string("$body_bytes_sent")   },
+    { nxt_string("remote_addr"),  nxt_string("$remote_addr")       },
+    { nxt_string("user_agent"),   nxt_string("$header_user_agent") },
+    { nxt_string("referer"),      nxt_string("$header_referer")    },
+    { nxt_string("request_time"), nxt_string("$request_time")      },
+    { nxt_string("request_id"),   nxt_string("$request_id")        },
+};
 
 
 static nxt_conf_map_t  nxt_router_access_log_conf[] = {
@@ -160,6 +186,7 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
 {
     size_t                          size;
     uint32_t                        i, n, next;
+    nxt_int_t                       ret;
     nxt_str_t                       name, str, *dst;
     nxt_bool_t                      has_js;
     nxt_conf_value_t                *cv;
@@ -169,6 +196,8 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     static const nxt_str_t  default_format = nxt_string("$remote_addr - - "
         "[$time_local] \"$request_line\" $status $body_bytes_sent "
         "\"$header_referer\" \"$header_user_agent\"");
+
+    static const nxt_str_t  json_format = nxt_string("json");
 
     format = nxt_mp_zalloc(rtcf->mem_pool,
                            sizeof(nxt_router_access_log_format_t));
@@ -232,6 +261,20 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
                 return format;
             }
 
+            /*
+             * No njs template in the object: serialize it to JSON text once,
+             * here, and compile that as a single template string.
+             *
+             * Note this is the one path that does NOT escape its values.
+             * Variables are substituted into the finished JSON text at
+             * request time, after nxt_conf_json_print() has run, so a value
+             * holding a '"' closes its string and can inject members --
+             * e.g. {"ua": "$header_user_agent"} with a crafted User-Agent.
+             * The member path above and the "json" shorthand both print per
+             * request and are escaped. Kept as-is for compatibility; prefer
+             * "format": "json" when the values are request-controlled.
+             */
+
             size = nxt_conf_json_length(value, NULL);
 
             str.start = nxt_mp_nget(rtcf->mem_pool, size);
@@ -244,6 +287,15 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
 
         } else {
             nxt_conf_get_string(value, &str);
+
+            if (nxt_strstr_eq(&str, &json_format)) {
+                ret = nxt_router_access_log_format_json(rtcf, format);
+                if (nxt_slow_path(ret != NXT_OK)) {
+                    return NULL;
+                }
+
+                return format;
+            }
         }
 
     } else {
@@ -257,6 +309,49 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     }
 
     return format;
+}
+
+
+/*
+ * Build the fixed member set of the "json" format.  Going through the
+ * member path rather than compiling a JSON template as a single string
+ * makes every value pass through nxt_conf_json_print(), which escapes it;
+ * fields such as "user_agent" and "referer" are request-controlled and
+ * would otherwise be able to break out of the enclosing JSON string.
+ */
+
+static nxt_int_t
+nxt_router_access_log_format_json(nxt_router_conf_t *rtcf,
+    nxt_router_access_log_format_t *format)
+{
+    nxt_uint_t                           i, n;
+    nxt_router_access_log_member_t       *member;
+    const nxt_router_access_log_field_t  *field;
+
+    n = nxt_nitems(nxt_router_access_log_fields);
+
+    member = nxt_mp_alloc(rtcf->mem_pool,
+                          n * sizeof(nxt_router_access_log_member_t));
+    if (nxt_slow_path(member == NULL)) {
+        return NXT_ERROR;
+    }
+
+    for (i = 0; i < n; i++) {
+        field = &nxt_router_access_log_fields[i];
+
+        member[i].name = field->name;
+
+        member[i].tstr = nxt_tstr_compile(rtcf->tstr_state, &field->value,
+                                          NXT_TSTR_LOGGING);
+        if (nxt_slow_path(member[i].tstr == NULL)) {
+            return NXT_ERROR;
+        }
+    }
+
+    format->nmembers = n;
+    format->member = member;
+
+    return NXT_OK;
 }
 
 

--- a/test/test_access_log.py
+++ b/test/test_access_log.py
@@ -1,3 +1,5 @@
+import json
+import re
 import time
 
 import pytest
@@ -305,6 +307,118 @@ def test_access_log_format(wait_for_record):
         'uri': '$uri'
     }
     check_format(log_format, '{"status":"200","uri":"/"}')
+
+
+JSON_FIELDS = [
+    'request',
+    'status',
+    'bytes_sent',
+    'remote_addr',
+    'user_agent',
+    'referer',
+    'request_time',
+    'request_id',
+]
+
+
+def get_json_record(wait_for_record, url):
+    found = wait_for_record(
+        fr'^\{{.*"request":"GET {re.escape(url)} .*\}}$', 'access.log'
+    )
+    assert found is not None, 'json record'
+
+    return json.loads(found.group(0))
+
+
+def test_access_log_json(wait_for_record):
+    load('empty')
+    set_format('json')
+
+    assert (
+        client.get(
+            url='/json_fmt',
+            headers={
+                'Host': 'localhost',
+                'Connection': 'close',
+                'User-Agent': 'unit/test',
+                'Referer': 'http://example.com/from',
+            },
+        )['status']
+        == 200
+    )
+
+    entry = get_json_record(wait_for_record, '/json_fmt')
+
+    assert list(entry.keys()) == JSON_FIELDS, 'stable field set'
+
+    assert entry['request'] == 'GET /json_fmt HTTP/1.1'
+    assert entry['status'] == '200'
+    assert entry['bytes_sent'] == '0'
+    assert entry['remote_addr'] == '127.0.0.1'
+    assert entry['user_agent'] == 'unit/test'
+    assert entry['referer'] == 'http://example.com/from'
+    assert re.match(r'^\d+\.\d+$', entry['request_time']), 'request_time'
+    assert re.match(r'^[0-9a-f]{32}$', entry['request_id']), 'request_id'
+
+
+def test_access_log_json_absent_headers(wait_for_record):
+    load('empty')
+    set_format('json')
+
+    assert client.get(url='/json_bare')['status'] == 200
+
+    entry = get_json_record(wait_for_record, '/json_bare')
+
+    assert list(entry.keys()) == JSON_FIELDS, 'stable field set'
+    assert entry['user_agent'] == '-', 'absent user agent'
+    assert entry['referer'] == '-', 'absent referer'
+
+
+def test_access_log_json_escape(wait_for_record):
+    load('empty')
+    set_format('json')
+
+    user_agent = 'evil", "injected": "yes'
+    referer = 'back\\slash"'
+
+    assert (
+        client.get(
+            url='/json_esc',
+            headers={
+                'Host': 'localhost',
+                'Connection': 'close',
+                'User-Agent': user_agent,
+                'Referer': referer,
+            },
+        )['status']
+        == 200
+    )
+
+    entry = get_json_record(wait_for_record, '/json_esc')
+
+    assert list(entry.keys()) == JSON_FIELDS, 'no injected member'
+    assert entry['user_agent'] == user_agent, 'escaped user agent'
+    assert entry['referer'] == referer, 'escaped referer'
+
+
+def test_access_log_json_literal(wait_for_record):
+    load('empty')
+
+    # Only the exact "json" string selects the JSON format; any other
+    # string stays a literal log format.
+
+    def check_literal(log_format):
+        set_format(log_format)
+
+        assert client.get()['status'] == 200
+        assert (
+            wait_for_record(fr'^{re.escape(log_format)}$', 'access.log')
+            is not None
+        ), 'literal format'
+
+    check_literal('jsonx')
+    check_literal('json ')
+    check_literal('JSON')
 
 
 def test_access_log_variables(wait_for_record):


### PR DESCRIPTION
## Summary

Adds a `"format": "json"` shorthand to `access_log`, writing one JSON object per
request with a stable, documented field set:

```json
{"request":"GET /hello HTTP/1.1","status":"200","bytes_sent":"0","remote_addr":"127.0.0.1","user_agent":"curl/test","referer":"http://example.com/x","request_time":"0.000","request_id":"94e1a670a79587bae95ca145cef505c8"}
```

Field names are a stable part of the configuration interface and are deliberately
decoupled from the variables they expand to (`bytes_sent` → `$body_bytes_sent`,
`request` → `$request_line`, `user_agent` → `$header_user_agent`, …), so a future
variable rename cannot silently reshape everyone's log schema.

## Background: the port was already done

This started as a port of the JSON access log work from `hongzhidao/unit`
(branch `unit-1.26`). It turns out **all nine of those commits are already in
`master`** — they landed as the originals rather than as cherry-picks. Verified
by reverse-applying each patch; all nine report "already present":

| hongzhidao/unit | in master as |
| --- | --- |
| `0563a2c5` introduce `nxt_router_access_log_format_t` | `a760e24a` |
| `00424a12` refactor `format` field | `a92d8149` |
| `1641bc0c` support JSON format | `bc838c5e` |
| `63087a17` drop `nxt_http_request_access_log()` | present |
| `b5a094ed` refactor out `nxt_tstr_cond_t` | `82e168fe` |
| `0984b430` adapt validation to legacy API | present |
| `3c21d698` public `nxt_tstr_is_js()` | present (`nxt_tstr.h`) |
| `27fd03d3` newline control flag | present (`NXT_TSTR_NEWLINE`) |
| `9d33dcd7` fix missing newlines with JS | `76cc071a` |

The njs-dependent commits need no adaptation — `nxt_tstr_is_js()` is already
public and `NXT_TSTR_NEWLINE` already exists.

What that work gives you is the *object* form, `"format": {"name": "$var", …}`.
The `"json"` shorthand with a fixed schema did not exist; that is what this PR
adds.

## Escaping

The shorthand builds a member array and prints per request, rather than
compiling a JSON template into a single string at config time. That routes every
value through `nxt_conf_json_print()`, which escapes it:

```
User-Agent: evil","injected":"yes
→ {…,"user_agent":"evil\",\"injected\":\"yes",…}
```

This matters because `user_agent` and `referer` are request-controlled and would
otherwise be able to close the enclosing JSON string and inject log members.

## Compatibility

- Only the exact string `json` selects the format. `jsonx`, `json ` and `JSON`
  all keep their existing literal meaning — covered by a test.
- The default format (no `format` key) is unchanged.
- The object format is untouched.

## Testing

`test/test_access_log.py` gains `test_access_log_json`,
`test_access_log_json_absent_headers`, `test_access_log_json_escape` and
`test_access_log_json_literal`.

Run via `./test/run-local.sh -t test_access_log.py` (the project's Docker
harness, so njs is present):

```
collected 25 items
...
test/test_access_log.py::test_access_log_json                 PASSED
test/test_access_log.py::test_access_log_json_absent_headers  PASSED
test/test_access_log.py::test_access_log_json_escape          PASSED
test/test_access_log.py::test_access_log_json_literal         PASSED
======================== 24 passed, 1 skipped in 11.50s ========================
```

The whole file is green, including the pre-existing `test_access_log_format_njs`
and `test_access_log_if_njs`. The one skip is `test_access_log_partial_5`
("not yet"), which is pre-existing and unrelated.

### Follow-up coverage

Deliberately not in this PR, but the gaps are known — every existing assertion
uses a 200 with an empty body, so these tests would still pass if `status` and
`bytes_sent` were hardcoded. Probed by hand against a built `unitd` and
confirmed working but unasserted:

- non-200 status and non-zero `bytes_sent` (404 → `"404"`/`"54"`, static file → `"16"`)
- an **empty** header value yields `""` while an **absent** one yields `"-"` —
  these differ, and nothing documents or locks that
- `request` field escaping (`GET /q"uote` → `"GET /q\"uote HTTP/1.1"`)
- keep-alive: two requests on one connection → two separately parseable lines
- control characters (tab → `\t`)
- `if` + `json` together (verified: only the matching request is logged)

### Known limitation: invalid UTF-8

`nxt_conf_json_escape()` escapes `"`, `\` and bytes < 0x20, but passes bytes
above 0x7F through unchanged. A header value that is not valid UTF-8 therefore
produces a line that strict parsers reject outright:

```
User-Agent: caf\xe9  →  json.loads(...) UnicodeDecodeError: invalid continuation byte
```

Any client can trigger this, and log shippers doing strict UTF-8 decoding will
drop or quarantine the line — so the cost lands on the operator. This is
pre-existing and shared with the object format and the njs path, not introduced
here. It is left alone because `nxt_conf_json_escape()` is also used by the
config API and the stats endpoint, so changing it would alter how `GET /config`
renders every non-ASCII value; a log-specific escape belongs in its own PR.

## Pre-existing issue found while working on this (not fixed here)

The **object** format does not escape values. Confirmed on current `master`:

```
"format": {"ua": "$header_user_agent"}   with   User-Agent: evil","injected":"yes
→ {"ua":"evil","injected":"yes"}
```

That is a valid JSON object carrying an attacker-chosen member — log injection /
log-parser confusion. It is inherited from upstream: the non-njs branch of
`nxt_router_access_log_format_create()` serializes the object to a JSON *text*
template and substitutes variables into it unescaped, while the njs branch
correctly builds a member array.

Left alone deliberately, since fixing it changes the behaviour of an existing
feature and this PR is scoped to not do that. Worth its own PR — and a decision
on whether it warrants an advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChfpbvjnCiJ2Xohp2S7yLH
