### PR TITLE
test(route): cover the "if" option of the route "match" object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,17 @@
 
+Changes with FreeUnit 1.36.1                                     02 Aug 2026
+
+    *) Change: the "if" option of a route "match" object, added in 1.33.0,
+       is now described in the OpenAPI specification and covered by the test
+       suite. A request matches the step only when the condition is true;
+       the condition uses the same syntax as the "if" option of the access
+       log: it is false when it renders to an empty string, "0", "false",
+       "null", or "undefined", and true otherwise, and a leading "!" negates
+       the result. Variables test for the presence of a value ("$arg_foo"),
+       njs template strings express comparisons and regular expressions
+       ("`${uri == '/admin'}`", "`${/^\/admin/.test(uri)}`").
+
+
 Changes with FreeUnit 1.36.0                                     16 Jul 2026
 
     *) Bugfix: the controller crashed in debug builds when a control-socket

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -6,6 +6,28 @@
 
 
 <changes apply="unit"
+         ver="1.36.1" rev="1"
+         date="2026-08-02" time="00:00:00 +0000"
+         packager="FreeUnit Packaging &lt;team@freeunit.org&gt;">
+
+<change type="change">
+<para>
+the "if" option of a route "match" object, added in 1.33.0, is now
+described in the OpenAPI specification and covered by the test suite.  A
+request matches the step only when the condition is true; the condition
+uses the same syntax as the "if" option of the access log: it is false
+when it renders to an empty string, "0", "false", "null", or "undefined",
+and true otherwise, and a leading "!" negates the result.  Variables test
+for the presence of a value ("$arg_foo"), njs template strings express
+comparisons and regular expressions
+("`${uri == '/admin'}`", "`${/^\/admin/.test(uri)}`").
+</para>
+</change>
+
+</changes>
+
+
+<changes apply="unit"
          ver="1.36.0" rev="1"
          date="2026-07-16" time="00:00:00 +0000"
          packager="FreeUnit Packaging &lt;team@freeunit.org&gt;">

--- a/docs/unit-openapi.yaml
+++ b/docs/unit-openapi.yaml
@@ -7132,6 +7132,14 @@ components:
           description: "Host header field."
           $ref: "#/components/schemas/stringOrStringArray"
 
+        if:
+          description: "Condition that must be true for the step to match.
+            The value is a template string; it is false when it renders to
+            an empty string, `0`, `false`, `null`, or `undefined`, and true
+            otherwise. A leading `!` negates the result."
+
+          type: string
+
         method:
           description: "Method from the request line."
           $ref: "#/components/schemas/stringOrStringArray"

--- a/test/test_route_if.py
+++ b/test/test_route_if.py
@@ -1,0 +1,196 @@
+"""Tests for the "if" option of the route "match" object.
+
+The condition uses the same syntax as the "if" option of the access log:
+a template string that is false when it renders to an empty string, "0",
+"false", "null" or "undefined", and true otherwise; a leading "!" negates
+the result.
+"""
+
+import pytest
+
+from unit.applications.proto import ApplicationProto
+
+client = ApplicationProto()
+
+
+@pytest.fixture(autouse=True)
+def setup_method_fixture():
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {
+                    "match": {"method": "GET"},
+                    "action": {"return": 200},
+                }
+            ],
+            "applications": {},
+        }
+    ), 'routing configure'
+
+
+def set_if(condition):
+    assert 'success' in client.conf(
+        f'"{condition}"', 'routes/0/match/if'
+    ), 'if configure'
+
+
+def set_match(match):
+    assert 'success' in client.conf(match, 'routes/0/match'), 'match configure'
+
+
+def check_if(condition, url, status):
+    set_if(condition)
+    assert client.get(url=url)['status'] == status, f'if {condition} {url}'
+
+
+def test_route_if_const():
+    def try_if(condition, status):
+        check_if(condition, f'/{condition}', status)
+
+    try_if('', 404)
+    try_if('0', 404)
+    try_if('false', 404)
+    try_if('null', 404)
+    try_if('undefined', 404)
+    try_if('!', 200)
+    try_if('!0', 200)
+    try_if('!null', 200)
+    try_if('1', 200)
+    try_if('!1', 404)
+
+
+def test_route_if_variable():
+    set_if('$arg_foo')
+    assert client.get(url='/bar?bar')['status'] == 404, 'no argument'
+    assert client.get(url='/foo_empty?foo')['status'] == 404, 'empty argument'
+    assert client.get(url='/foo?foo=1')['status'] == 200, 'argument'
+
+    set_if('!$arg_foo')
+    assert client.get(url='/bar?bar')['status'] == 200, 'negated, no argument'
+    assert (
+        client.get(url='/foo_empty?foo')['status'] == 200
+    ), 'negated, empty argument'
+    assert client.get(url='/foo?foo=1')['status'] == 404, 'negated, argument'
+
+    set_if('$host')
+    assert client.get()['status'] == 200, 'host'
+
+    set_if('$arg_foo$arg_bar')
+    assert client.get(url='/?bar=1')['status'] == 200, 'two variables'
+    assert client.get(url='/?baz=1')['status'] == 404, 'two variables empty'
+
+
+def test_route_if_njs(require):
+    require({'modules': {'njs': 'any'}})
+
+    # comparison
+
+    set_if("`${args.foo == '1'}`")
+    assert client.get(url='/foo_1?foo=1')['status'] == 200, 'equal'
+    assert client.get(url='/foo_2?foo=2')['status'] == 404, 'not equal'
+
+    set_if("!`${args.foo == '1'}`")
+    assert client.get(url='/foo_1?foo=1')['status'] == 404, 'negated equal'
+    assert client.get(url='/foo_2?foo=2')['status'] == 200, 'negated not equal'
+
+    set_if("`${uri == '/admin'}`")
+    assert client.get(url='/admin')['status'] == 200, 'uri equal'
+    assert client.get(url='/admin/')['status'] == 404, 'uri not equal'
+
+    # regular expression
+
+    set_if('`${/^\\\\/admin/.test(uri)}`')
+    assert client.get(url='/admin/index.html')['status'] == 200, 'regexp'
+    assert client.get(url='/user/index.html')['status'] == 404, 'regexp no match'
+
+    set_if("`${headers['User-Agent'].split('/')[0] == 'curl'}`")
+    assert (
+        client.get(headers={'Host': 'localhost', 'User-Agent': 'curl/8.0'})[
+            'status'
+        ]
+        == 200
+    ), 'header split'
+    assert (
+        client.get(headers={'Host': 'localhost', 'User-Agent': 'wget/1.0'})[
+            'status'
+        ]
+        == 404
+    ), 'header split no match'
+
+    # variable existence
+
+    set_if("`${vars.arg_foo != '' ? 1 : 0}`")
+    assert client.get(url='/?foo=1')['status'] == 200, 'variable exists'
+    assert client.get(url='/?bar=1')['status'] == 404, 'variable missing'
+
+
+def test_route_if_match():
+    set_match({"method": "GET", "if": "$arg_foo"})
+    assert client.get(url='/?foo=1')['status'] == 200, 'method and if'
+    assert client.get(url='/')['status'] == 404, 'method and if, false'
+    assert (
+        client.post(url='/?foo=1', headers={'Host': 'localhost'})['status']
+        == 404
+    ), 'method and if, method mismatch'
+
+    set_match({"uri": "/admin", "host": "localhost", "if": "!$arg_foo"})
+    assert client.get(url='/admin')['status'] == 200, 'uri, host and if'
+    assert client.get(url='/admin?foo=1')['status'] == 404, 'if false'
+    assert client.get(url='/user')['status'] == 404, 'uri mismatch'
+
+    set_match({"arguments": {"foo": "1"}, "if": "$arg_bar"})
+    assert client.get(url='/?foo=1&bar=1')['status'] == 200, 'arguments and if'
+    assert client.get(url='/?foo=2&bar=1')['status'] == 404, 'arguments mismatch'
+    assert client.get(url='/?foo=1')['status'] == 404, 'if false'
+
+    set_match({"headers": {"X-Test": "yes"}, "if": "$arg_foo"})
+    assert (
+        client.get(
+            url='/?foo=1', headers={'Host': 'localhost', 'X-Test': 'yes'}
+        )['status']
+        == 200
+    ), 'headers and if'
+    assert (
+        client.get(url='/?foo=1', headers={'Host': 'localhost'})['status'] == 404
+    ), 'headers mismatch'
+
+    # "if" only
+
+    set_match({"if": "$arg_foo"})
+    assert client.get(url='/?foo=1')['status'] == 200, 'if only'
+    assert client.get(url='/')['status'] == 404, 'if only, false'
+    assert (
+        client.post(url='/?foo=1', headers={'Host': 'localhost'})['status']
+        == 200
+    ), 'if only, any method'
+
+
+def test_route_if_fallthrough():
+    assert 'success' in client.conf(
+        [
+            {"match": {"if": "$arg_foo"}, "action": {"return": 201}},
+            {"match": {"if": "$arg_bar"}, "action": {"return": 202}},
+            {"action": {"return": 203}},
+        ],
+        'routes',
+    ), 'routes configure'
+
+    assert client.get(url='/?foo=1')['status'] == 201, 'first route'
+    assert client.get(url='/?bar=1')['status'] == 202, 'second route'
+    assert client.get(url='/?baz=1')['status'] == 203, 'last route'
+
+
+def test_route_if_invalid():
+    assert 'error' in client.conf('"$arg_"', 'routes/0/match/if'), 'invalid var'
+    assert 'error' in client.conf('"$"', 'routes/0/match/if'), 'empty var'
+    assert 'error' in client.conf('1', 'routes/0/match/if'), 'not a string'
+    assert 'error' in client.conf('["$arg_foo"]', 'routes/0/match/if'), 'array'
+
+
+def test_route_if_invalid_njs(require):
+    require({'modules': {'njs': 'any'}})
+
+    assert 'error' in client.conf(
+        '"`${args.foo`"', 'routes/0/match/if'
+    ), 'invalid njs'


### PR DESCRIPTION
### Proposed changes

The task behind this branch was to port the `"if"` option of the route `"match"` object from hongzhidao/unit (`99e1b369`, `9d43582e`). It turned out the implementation is **already in this tree** — commit `debd61c3` "http: Add \"if\" option to the \"match\" object" (Aug 2024, the same upstream commit hongzhidao cherry-picked), released in Unit 1.33.0 and already listed in `CHANGES` under that release:

- `src/nxt_conf_validation.c` — the `"if"` member of `nxt_conf_vldt_match_members`, validated by `nxt_conf_vldt_if()`
- `src/nxt_http_route.c` — `nxt_tstr_cond_t condition` in `nxt_http_route_match_t`, the conf-map entry, `nxt_tstr_cond_compile()` in `nxt_http_route_match_create()`, and the condition evaluated first in `nxt_http_route_match()`
- `src/nxt_tstr.c` / `src/nxt_http_request.c` — `nxt_tstr_cond_compile()` and `nxt_http_cond_value()`, shared with the access log `"if"`

What was missing was test coverage and the OpenAPI description, so **no C code is touched here**.

**`test/test_route_if.py`** (new, 7 tests):

- constant conditions — `""`, `"0"`, `"false"`, `"null"`, `"undefined"` are false, anything else is true, and a leading `!` negates the result
- variable conditions — presence of a value (`$arg_foo`, `$host`, two variables concatenated) and the negated form
- njs conditions — comparison (`` `${args.foo == '1'}` ``, `` `${uri == '/admin'}` ``), regular expression (`` `${/^\/admin/.test(uri)}` ``), splitting a header, and testing a variable through `vars`
- interaction with the rest of `match` — `"if"` combined with `method`, `uri` + `host`, `arguments`, `headers`, and a match consisting of `"if"` alone
- fall-through across several route steps whose conditions are false
- configuration-time rejection of `$arg_`, `$`, a non-string, an array, and an unterminated njs template

The njs cases are gated on `require({'modules': {'njs': 'any'}})`, so the file also passes on a build without njs.

**`docs/unit-openapi.yaml`** — `if` added to `configRouteStepMatch`; it was the only `match` member missing from the schema.

**`CHANGES` / `docs/changes.xml`** — a 1.36.1 section describing the option and the added coverage. Typed `Change` rather than `Feature`, because the feature itself shipped in 1.33.0 and is already listed there; `version` and the OpenAPI title are untouched, since those move in the release commit.

Testing, against a local build of njs 1.0.0 (`freeunitorg/njs`, `36a5764`) — the option goes through `nxt_tstr_*` rather than the njs API directly, so no 1.0.0 adaptation was needed:

| Run | Result |
| --- | --- |
| `test_route_if.py`, `--njs` build | 7 passed |
| `test_route_if.py`, build without njs | 5 passed, 2 skipped |
| `test_routing.py test_njs.py test_access_log.py test_variables.py test_configuration.py test_route_if.py` | 198 passed, 8 failed |

All 8 failures are `[::1]` listener binds — the test container has no IPv6 (`socket.AF_INET6` → `EAFNOSUPPORT`) — and are unrelated to this branch.

### Checklist
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] If applicable, I have added tests
- [x] If applicable, I have updated documentation