### PR TITLE
test(process): make shared-memory teardown tests able to see the corruption they target

### DIFF
--- a/test/test_process_abrupt_teardown.py
+++ b/test/test_process_abrupt_teardown.py
@@ -45,6 +45,7 @@ import pytest
 
 from unit.applications.lang.php import ApplicationPHP
 from unit.log import Log
+from unit.shm_body import describe_mismatch, make_body
 
 prerequisites = {'modules': {'php': 'all'}}
 
@@ -57,8 +58,14 @@ APP = 'mirror'
 # src/nxt_port_memory_int.h), so a request is inside the chunk allocator, and
 # the process/port lookups that reach it, for long enough that a kill on
 # another thread lands in the middle of one.
+#
+# The bytes are not uniform: every request carries a fresh body stamped, every
+# 64 bytes, with that request's tag and the byte offset of the record (see
+# unit/shm_body.py).  WORKERS requests are in shared memory at once here, so a
+# chunk recycled out from under one of them most likely holds another one's
+# payload; against 'x' * BODY_SIZE that chunk is byte-identical to what
+# belongs there and the check below cannot see it.
 BODY_SIZE = 1024 * 1024
-BODY = 'x' * BODY_SIZE
 
 # > 1 so more than one router worker engine is live; this is a top-level
 # "settings" member (src/nxt_conf_validation.c: nxt_conf_vldt_setting_members).
@@ -163,11 +170,12 @@ def test_process_abrupt_teardown(skip_alert, skip_fds_check):
 
     def request_worker():
         while not stop.is_set():
+            expected = make_body(BODY_SIZE)
             started = time.time()
 
             try:
                 resp = client.post(
-                    body=BODY,
+                    body=expected,
                     read_timeout=READ_TIMEOUT,
                     read_buffer_size=65536,
                 )
@@ -191,26 +199,20 @@ def test_process_abrupt_teardown(skip_alert, skip_fds_check):
                 # A short body is legitimate: the worker can die after its
                 # headers are on the wire.  Wrong *bytes* are not - that is
                 # what reading freed or recycled shared memory looks like.
-                if body != BODY[: len(body)]:
-                    # next() needs a default.  A body that is all 'x' but
-                    # LONGER than the request still fails the comparison
-                    # above -- BODY[:len(body)] clamps to BODY -- and then
-                    # has no mismatching byte to find.  Without the default
-                    # that raises StopIteration here, outside the try that
-                    # guards the request, killing the worker thread instead
-                    # of recording the corruption: the detector fails open
-                    # on one of the shapes it exists to catch.
-                    at = next(
-                        (i for i, c in enumerate(body) if c != 'x'), None
-                    )
+                if body != expected[: len(body)]:
+                    # describe_mismatch() reports the first wrong byte and the
+                    # record stamp found there, so a failure says whether the
+                    # bytes came from another offset of this request or from
+                    # another request entirely.  It keeps the fail-open guard
+                    # too: the overlong-but-correct-prefix shape has no
+                    # mismatching byte, and a bare next() would raise
+                    # StopIteration here, outside the try that guards the
+                    # request, killing this thread instead of recording the
+                    # corruption.
                     record(
                         failures,
                         f'corrupt body: {len(body)} bytes, '
-                        + (
-                            f'first mismatch at {at}'
-                            if at is not None
-                            else f'uniform but longer than {BODY_SIZE}'
-                        ),
+                        + describe_mismatch(body, expected),
                     )
                     continue
 
@@ -267,13 +269,15 @@ def test_process_abrupt_teardown(skip_alert, skip_fds_check):
     assert not failures, f'{len(failures)} failure(s), first: {failures[0]}'
 
     # The daemon is still alive and still serves the whole payload correctly.
+    expected = make_body(BODY_SIZE)
+
     resp = client.post(
-        body=BODY, read_timeout=READ_TIMEOUT, read_buffer_size=65536
+        body=expected, read_timeout=READ_TIMEOUT, read_buffer_size=65536
     )
 
     assert resp['status'] == 200, 'still serving'
     assert len(resp['body']) == BODY_SIZE, 'still serving whole body'
-    assert resp['body'] == BODY, 'still serving intact body'
+    assert resp['body'] == expected, 'still serving intact body'
 
     # Requests must not have been shut out entirely, or nothing was in flight
     # when a worker died.

--- a/test/test_process_teardown_churn.py
+++ b/test/test_process_teardown_churn.py
@@ -52,6 +52,10 @@ BODY = 'x' * BODY_SIZE
 # "settings" member (src/nxt_conf_validation.c: nxt_conf_vldt_setting_members).
 LISTEN_THREADS = 4
 
+# Prestarted workers.  Named because the baseline below has to wait for
+# exactly this many before it means anything.
+SPARE = 2
+
 WORKERS = 4
 REQUESTS_PER_WORKER = 16
 CHURN_INTERVAL = 0.05
@@ -75,6 +79,25 @@ def _app_pids():
     return {line.split()[0] for line in out.splitlines() if marker in line}
 
 
+def _wait_for_pids(count, timeout=100):
+    """Poll until at least `count` application workers are visible.
+
+    Returns the last sample either way, so a shortfall is reported by the
+    caller's assertion as the pid set it actually saw rather than as a bare
+    timeout.
+    """
+
+    for _ in range(timeout):
+        pids = _app_pids()
+
+        if len(pids) >= count:
+            break
+
+        time.sleep(0.1)
+
+    return pids
+
+
 def test_process_teardown_churn(skip_fds_check):
     # Setting "listen_threads" changes the number of router worker engines,
     # and destroying an engine leaks its descriptors: measured on this tree,
@@ -85,13 +108,33 @@ def test_process_teardown_churn(skip_fds_check):
     # causes, and it is unrelated to what the test is here to exercise.
     skip_fds_check(router=True)
 
-    client.load(APP, processes={"spare": 2, "max": 4, "idle_timeout": 5})
+    client.load(APP, processes={"spare": SPARE, "max": 4, "idle_timeout": 5})
 
     assert 'success' in client.conf(
         {"listen_threads": LISTEN_THREADS}, 'settings'
     ), 'listen_threads'
 
     assert client.post(body='ping', read_timeout=READ_TIMEOUT)['status'] == 200
+
+    # The set of workers that exist *before* any configuration rewrite.  The
+    # final assertion needs it to tell "the churn replaced processes" from
+    # "the churn changed nothing and these are the ones we started with".
+    #
+    # Wait for the configured spares rather than assuming the warm-up request
+    # brought them up.  Unit starts spare processes asynchronously as the
+    # first one becomes idle, so an immediate sample can hold one of the two
+    # -- and the second would then appear in a later sample and be counted as
+    # a replacement, restoring the exact false positive the `fresh` check
+    # below exists to rule out.
+    baseline = _wait_for_pids(SPARE)
+
+    # >=, not ==: "spare" is a floor, not a cap ("max" is 4), so the pool is
+    # allowed to be larger by the time the warm-up request has been served.
+    # What matters is that it is not still filling.
+    assert len(baseline) >= SPARE, (
+        f'expected at least {SPARE} spare workers before the churn, '
+        f'saw {sorted(baseline)}'
+    )
 
     lock = threading.Lock()
     stop = threading.Event()
@@ -225,9 +268,27 @@ def test_process_teardown_churn(skip_fds_check):
     assert resp['body'] == BODY, 'still serving intact body'
 
     # The workload has to have actually torn processes down, otherwise it is
-    # only a concurrency test.  More than one PID means the application was
-    # destroyed and respawned while requests were in flight.
-    assert len(pids) > 1, f'application processes were not replaced: {pids}'
+    # only a concurrency test.  A count is not enough to show that: "spare": 2
+    # above means `baseline` already holds two PIDs, so `len(pids) > 1` passes
+    # on a run where no process was ever replaced.  What proves a teardown and
+    # respawn is a PID that was not serving the application before the churn
+    # started.
+    fresh = pids - baseline
+    gone = baseline - _app_pids()
+
+    assert fresh, (
+        f'no new application process appeared: saw {sorted(pids)}, '
+        f'baseline {sorted(baseline)}'
+    )
+
+    # A new pid on its own only proves the pool grew, which "max": 4 permits
+    # without any teardown at all.  A pre-churn worker that is no longer
+    # serving is the direct evidence that the configuration rewrites actually
+    # tore an application down -- which is the whole point of the workload.
+    assert gone, (
+        f'no pre-churn application process was torn down: '
+        f'baseline {sorted(baseline)} all still serving'
+    )
 
     # Requests must not have been shut out entirely, or nothing reached shared
     # memory concurrently with a teardown.

--- a/test/test_process_teardown_churn.py
+++ b/test/test_process_teardown_churn.py
@@ -32,6 +32,7 @@ import time
 
 from unit.applications.lang.php import ApplicationPHP
 from unit.log import Log
+from unit.shm_body import describe_mismatch, make_body
 
 prerequisites = {'modules': {'php': 'all'}}
 
@@ -45,8 +46,14 @@ client = ApplicationPHP()
 # chunks in each direction and keeps the worker inside the chunk allocator
 # (nxt_port_mmap_get_buf()/nxt_port_mmap_increase_buf()) long enough for a
 # teardown on another thread to overlap it.
+#
+# The bytes are not uniform: every request carries a fresh body stamped, every
+# 64 bytes, with that request's tag and the byte offset of the record (see
+# unit/shm_body.py).  WORKERS requests are in shared memory at once here, so a
+# chunk recycled out from under one of them most likely holds another one's
+# payload; against 'x' * BODY_SIZE that chunk is byte-identical to what
+# belongs there and the check below cannot see it.
 BODY_SIZE = 1024 * 1024
-BODY = 'x' * BODY_SIZE
 
 # > 1 so more than one router worker engine is live; this is a top-level
 # "settings" member (src/nxt_conf_validation.c: nxt_conf_vldt_setting_members).
@@ -148,11 +155,12 @@ def test_process_teardown_churn(skip_fds_check):
 
     def request_worker():
         for _ in range(REQUESTS_PER_WORKER):
+            expected = make_body(BODY_SIZE)
             started = time.time()
 
             try:
                 resp = client.post(
-                    body=BODY,
+                    body=expected,
                     read_timeout=READ_TIMEOUT,
                     read_buffer_size=65536,
                 )
@@ -173,26 +181,20 @@ def test_process_teardown_churn(skip_fds_check):
                 # A short body is legitimate: the application can die after its
                 # headers are on the wire.  Wrong *bytes* are not - that is
                 # what reading freed or recycled shared memory looks like.
-                if body != BODY[: len(body)]:
-                    # next() needs a default.  A body that is all 'x' but
-                    # LONGER than the request still fails the comparison
-                    # above -- BODY[:len(body)] clamps to BODY -- and then
-                    # has no mismatching byte to find.  Without the default
-                    # that raises StopIteration here, outside the try that
-                    # guards the request, killing the worker thread instead
-                    # of recording the corruption: the detector fails open
-                    # on one of the shapes it exists to catch.
-                    at = next(
-                        (i for i, c in enumerate(body) if c != 'x'), None
-                    )
+                if body != expected[: len(body)]:
+                    # describe_mismatch() reports the first wrong byte and the
+                    # record stamp found there, so a failure says whether the
+                    # bytes came from another offset of this request or from
+                    # another request entirely.  It keeps the fail-open guard
+                    # too: the overlong-but-correct-prefix shape has no
+                    # mismatching byte, and a bare next() would raise
+                    # StopIteration here, outside the try that guards the
+                    # request, killing this thread instead of recording the
+                    # corruption.
                     record(
                         failures,
                         f'corrupt body: {len(body)} bytes, '
-                        + (
-                            f'first mismatch at {at}'
-                            if at is not None
-                            else f'uniform but longer than {BODY_SIZE}'
-                        ),
+                        + describe_mismatch(body, expected),
                     )
                     continue
 
@@ -260,12 +262,14 @@ def test_process_teardown_churn(skip_fds_check):
     assert not failures, f'{len(failures)} failure(s), first: {failures[0]}'
 
     # The daemon is still alive and still serves the whole payload correctly.
-    resp = client.post(body=BODY, read_timeout=READ_TIMEOUT,
+    expected = make_body(BODY_SIZE)
+
+    resp = client.post(body=expected, read_timeout=READ_TIMEOUT,
                        read_buffer_size=65536)
 
     assert resp['status'] == 200, 'still serving'
     assert len(resp['body']) == BODY_SIZE, 'still serving whole body'
-    assert resp['body'] == BODY, 'still serving intact body'
+    assert resp['body'] == expected, 'still serving intact body'
 
     # The workload has to have actually torn processes down, otherwise it is
     # only a concurrency test.  A count is not enough to show that: "spare": 2

--- a/test/unit/shm_body.py
+++ b/test/unit/shm_body.py
@@ -1,0 +1,124 @@
+"""Self-identifying request bodies for the shared-memory teardown tests.
+
+Why not ``'x' * SIZE``: test_process_teardown_churn.py and
+test_process_abrupt_teardown.py exist to notice the router serving freed or
+recycled shared memory, and the most likely shape of that is a 16 KiB chunk
+(PORT_MMAP_CHUNK_SIZE, src/nxt_port_memory_int.h) belonging to a *different*
+concurrent request turning up in this one.  Against a uniform body such a
+chunk is byte-identical to the bytes that belong there, so the integrity
+check cannot see it at all: it only ever catches garbage that happens not to
+be 'x'.  Both tests run several request threads on purpose, so a cross-request
+chunk is exactly the corruption they are best placed to catch and exactly the
+one a uniform body hides.
+
+The body is a run of fixed-width records, each stamped with the request's own
+tag and with its own byte offset:
+
+    | tag: 8 hex digits | offset: 8 hex digits | 48 filler letters |
+
+so every 64 bytes of the payload say both *which* request the bytes came from
+and *where in it* they belong.  A chunk swapped in from another request
+mismatches on the tag; a chunk from another offset of the same request
+mismatches on the offset field; a shift of less than one record mismatches on
+the filler letter, which advances with the record index.  Byte-wise, that
+means any splice at a chunk boundary is wrong within at most 64 bytes of the
+splice, and the record header at the first wrong byte names the culprit.
+
+Cost matters - these tests send 64 to 100 bodies of 1 MiB each and are meant
+to stay at a few seconds - so the offset skeleton is built once per size at
+import time and a per-request body is a single str.replace() of the tag
+placeholder: one C-speed pass over 1 MiB instead of a Python loop.
+"""
+
+import itertools
+
+# One record per 64 bytes: short enough that a corrupt region is localised to
+# within 64 bytes of where it starts, long enough that a 1 MiB body is 16384
+# records rather than ten times that.
+RECORD_SIZE = 64
+
+TAG_LEN = 8
+OFFSET_LEN = 8
+
+_FILLER_LEN = RECORD_SIZE - TAG_LEN - OFFSET_LEN
+
+_LETTERS = 'abcdefghijklmnopqrstuvwxyz'
+
+# Tags are hex digits, so '~' cannot occur in a finished body and replacing
+# the placeholder cannot corrupt payload that happens to look like it.
+_PLACEHOLDER = '~' * TAG_LEN
+
+_counter = itertools.count(1)
+
+_skeletons = {}
+
+
+def _skeleton(size):
+    if size % RECORD_SIZE:
+        raise ValueError(f'size must be a multiple of {RECORD_SIZE}')
+
+    if size not in _skeletons:
+        _skeletons[size] = ''.join(
+            _PLACEHOLDER
+            + f'{offset:0{OFFSET_LEN}X}'
+            + _LETTERS[(offset // RECORD_SIZE) % len(_LETTERS)] * _FILLER_LEN
+            for offset in range(0, size, RECORD_SIZE)
+        )
+
+    return _skeletons[size]
+
+
+def make_body(size):
+    """A body of `size` bytes, distinguishable from every other body this
+    process has handed out.
+
+    next() on an itertools.count is a single bytecode under the GIL, so
+    request threads can call this without a lock, and consecutive tags always
+    differ in at least one hex digit - which is all the byte-wise comparison
+    in the tests needs to tell two in-flight requests apart.
+    """
+
+    return _skeleton(size).replace(_PLACEHOLDER, f'{next(_counter):08X}')
+
+
+def describe_mismatch(body, expected):
+    """One line saying how `body` differs from `expected`, for a failure
+    message.
+
+    Reports the first wrong byte and the record header found there against
+    the header that belongs there, which is what separates "a chunk from
+    another request" (tag differs) from "a chunk from another offset of this
+    request" (offset differs) from plain garbage (neither parses).
+    """
+
+    # next() needs a default.  zip() stops at the shorter of the two, so a
+    # body that is a correct prefix but LONGER than the request - which still
+    # fails the caller's `body != expected[:len(body)]` test, since that
+    # slice clamps to `expected` - has no mismatching byte to find here.  A
+    # bare next() would raise StopIteration out of the caller's request loop
+    # and kill the thread instead of recording the corruption: the detector
+    # would fail open on one of the shapes it exists to catch.
+    at = next(
+        (i for i, (c, e) in enumerate(zip(body, expected)) if c != e), None
+    )
+
+    if at is None:
+        return f'correct prefix but longer than {len(expected)} bytes'
+
+    return (
+        f'first mismatch at {at} ({body[at]!r} != {expected[at]!r}): '
+        f'got {_record_header(body, at)}, '
+        f'want {_record_header(expected, at)}'
+    )
+
+
+def _record_header(text, at):
+    """The tag/offset stamp of the record containing byte `at`."""
+
+    start = at - at % RECORD_SIZE
+    head = text[start : start + TAG_LEN + OFFSET_LEN]
+
+    if len(head) < TAG_LEN + OFFSET_LEN:
+        return f'<truncated record at {start}>'
+
+    return f'tag={head[:TAG_LEN]} offset={head[TAG_LEN:]}'


### PR DESCRIPTION
Follow-up to https://github.com/freeunitorg/freeunit/pull/184, addressing two
Codex findings that were deliberately left out of that PR's rebase because
they were strengthenings rather than blockers.

### 1. The churn test's core assertion was trivially true

`test_process_teardown_churn.py` loads the app with `processes={"spare": 2,
...}`, so two workers exist before any configuration rewrite. `pids` is only
ever fed from `_app_pids()` *after* a rewrite, so the first sample already
held two PIDs and `assert len(pids) > 1` passed on a run where **no process
was ever replaced** — the test silently degraded to a plain concurrency test.

It now samples a `baseline` before the churn and asserts `pids - baseline` is
non-empty, so the assertion means what its comment claims.

### 2. The corruption detector could not see the corruption it targets

Both tests used `BODY = 'x' * BODY_SIZE`. These tests exist to notice the
router serving freed or recycled shared memory, and the most likely shape of
that is a 16 KiB chunk (`PORT_MMAP_CHUNK_SIZE`) belonging to a *different*
concurrent request turning up in this one. Against a uniform body such a chunk
is byte-identical to the bytes that belong there. Both tests run four request
threads on purpose, and in the abrupt test the app is pinned to a single
process, so all four 1 MiB bodies share one worker's segments — the exposure
is real and the check was blind to it.

Bodies are now self-identifying, via a new `test/unit/shm_body.py`: a run of
64-byte records, each stamped with the request's own tag and its own byte
offset.

```
| tag: 8 hex digits | offset: 8 hex digits | 48 filler letters |
```

A chunk from another request mismatches on the tag; a chunk from another
offset of the same request mismatches on the offset; a shift of less than one
record mismatches on the filler letter, which advances with the record index.
Any splice at a chunk boundary is wrong within at most 64 bytes of it.

**Demonstrated, not assumed.** Splicing a 16 KiB chunk at a chunk boundary:

| case | old uniform body | new body |
|---|---|---|
| chunk from another request | **not detected** | `tag=00000002 … want tag=00000001` |
| chunk from another offset, same request | **not detected** | `tag=00000001 offset=00050000 … want offset=00010000` |
| short body (legitimate) | not detected | not detected |
| correct prefix but overlong | — | `correct prefix but longer than 1048576 bytes` |

### Properties preserved

- A short body is still legitimate — a worker can die after its headers are on
  the wire — so the check stays a prefix comparison.
- The fail-open guard added in
  https://github.com/freeunitorg/freeunit/pull/184 is kept: `next()` takes a
  default, and the correct-prefix-but-overlong case is *recorded* rather than
  raising `StopIteration` out of the request loop and killing the worker
  thread.
- 1 MiB, so bodies still span 64 chunks each way.
- Cost is ~2 ms per 1 MiB body: the offset skeleton is built once per size at
  import and each request is one `str.replace()` of the tag placeholder. Test
  durations are unchanged.

### Verification

`--debug` and PHP module builds clean; `test_process_teardown_churn.py`,
`test_process_abrupt_teardown.py` and `test_process_shm_oosm.py` pass on
current master.

### Not done

`test_process_shm_oosm.py` still uses a uniform payload. It is a single
request with no concurrency, so the cross-request swap is not its exposure —
but its check also cannot see an offset shift within its one response. Left
for a decision rather than folded in silently.
