### PR TITLE
ci(sanitize): gate on what the logs contain, not on an empty directory

### DIFF
--- a/.github/sanitizer-allowlist.txt
+++ b/.github/sanitizer-allowlist.txt
@@ -1,0 +1,32 @@
+# Known UndefinedBehaviorSanitizer violations, waived by
+# .github/scripts/check-sanitizer-reports.sh so that the sanitizer gate can be
+# made blocking without first fixing every pre-existing site.
+#
+# Rules:
+#   - One POSIX extended regular expression per line, matched against the
+#     report line as it appears in the harness's unit.log.
+#   - Every entry names the issue tracking its fix.  An entry without one is a
+#     bug in this file: the point of the list is to shrink, and an unattributed
+#     waiver never does.
+#   - ASan/LSan/TSan reports cannot be waived here.  The script refuses to
+#     match them on purpose -- a memory-safety report fails the leg, always.
+#   - Pin the source location.  A bare message would waive the same class of
+#     violation everywhere in the tree, including a new one.
+#
+# Measured on master (02263309) with the php leg's own test set: entries 1 and
+# 2 fire on every run of test/test_php_application.py, entry 3 on the
+# configuration-churn workload.
+
+# freeunitorg/freeunit#188 -- nxt_conf_value_t union read through an address
+# the allocator only aligned to 4 bytes.  Benign on x86-64, a real fault on
+# strict-alignment targets; tracked for a fix in the value representation.
+src/nxt_conf\.c:[0-9]+:[0-9]+: runtime error: member access within misaligned address 0x[0-9a-f]+ for type 'union <unknown>', which requires 8 byte alignment
+
+# freeunitorg/freeunit#200 -- nxt_strstr_eq() -> memcmp() on a zero-length
+# nxt_str_t, whose .start is NULL.  memcmp() declares both pointers nonnull
+# regardless of length, so a zero-length compare is UB even though every
+# implementation returns 0 without a dereference.
+src/nxt_http_route\.c:[0-9]+:[0-9]+: runtime error: null pointer passed as argument [12], which is declared to never be null
+
+# freeunitorg/freeunit#200 -- same class in nxt_cpymem(): memcpy(dst, NULL, 0).
+src/nxt_string\.h:[0-9]+:[0-9]+: runtime error: null pointer passed as argument 2, which is declared to never be null

--- a/.github/scripts/check-sanitizer-reports.sh
+++ b/.github/scripts/check-sanitizer-reports.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+#
+# Fail a sanitizer CI leg on any ASan/UBSan report the test session produced.
+#
+# Why this scans the harness's unit.log rather than a sanitizer log_path
+# directory: ASAN_OPTIONS/UBSAN_OPTIONS log_path does not work for unitd.
+# The daemon relocates argv[]/environ[] in nxt_process_title()
+# (src/nxt_process_title.c) and overwrites the original block, so by the time a
+# forked router or application worker writes a report the options string the
+# sanitizer runtime kept a pointer into is gone.  Measured on this tree: an
+# ordinary binary run with the same UBSAN_OPTIONS honours log_path,
+# halt_on_error and print_stacktrace; inside unitd none of the three take
+# effect and the log directory stays empty on every run -- including runs that
+# produced a genuine heap-use-after-free.  Reports do reach unitd's stderr,
+# which test/conftest.py wires to <temp_dir>/unit.log, so that is what we read.
+#
+# The caller must pass --save-log to pytest: without it conftest.py removes the
+# per-restart temp dir (and with it unit.log) after every test.
+#
+# Usage: check-sanitizer-reports.sh <log-root> [allowlist-file]
+#   <log-root>       directory holding the harness's unit-test-* temp dirs
+#                    (tempfile.mkdtemp(prefix='unit-test-'), i.e. $TMPDIR or /tmp)
+#   [allowlist-file] optional; see .github/sanitizer-allowlist.txt
+
+set -eu
+
+log_root=${1:?usage: check-sanitizer-reports.sh <log-root> [allowlist-file]}
+allowlist=${2:-}
+
+# A sanitizer report line, anchored tightly enough that a request body echoed
+# into the --debug log cannot forge one.
+#   UBSan: "src/nxt_conf.c:664:26: runtime error: ..."
+#   ASan:  "==123==ERROR: AddressSanitizer: heap-use-after-free ..."
+ubsan_re='[^[:space:]]+:[0-9]+:[0-9]+: runtime error: '
+asan_re='(ERROR|SUMMARY): [A-Za-z]*Sanitizer:'
+
+logs=$(find "$log_root" -maxdepth 2 -name unit.log -type f 2>/dev/null | sort)
+
+if [ -z "$logs" ]; then
+    echo "::error::No unit.log found under ${log_root}. The sanitizer gate" \
+         "cannot certify this leg: either the test session never started, or" \
+         "pytest was invoked without --save-log and the harness removed the" \
+         "temp dirs.  Refusing to report a clean run."
+    exit 1
+fi
+
+echo "Scanning $(echo "$logs" | wc -l) unit.log file(s) under ${log_root}:"
+echo "$logs" | sed 's/^/  /'
+echo
+
+findings=$(mktemp)
+patterns=$(mktemp)
+trap 'rm -f "$findings" "$patterns"' EXIT
+
+# -a is load-bearing, not defensive.  unitd's --debug log carries raw payload
+# bytes, tens of thousands of NULs in a typical run, so grep classifies
+# unit.log as binary: it prints the matches it found before the first NUL and
+# then silently stops.  Measured on a churn log: 3 of 8 report lines survived,
+# and the two AddressSanitizer lines -- which come later in the file than the
+# first NUL -- were among the 5 dropped.  Without -a this gate reproduces the
+# exact bug it was written to remove.
+for f in $logs; do
+    grep -aEH "$ubsan_re|$asan_re" "$f" 2>/dev/null || true
+done > "$findings"
+
+if [ ! -s "$findings" ]; then
+    echo "No sanitizer reports."
+    exit 0
+fi
+
+# An ASan/LSan/TSan report is never allowlistable -- those are memory-safety
+# bugs, not style debt.  Only UBSan lines can be waived, and only by an entry
+# that names an open issue.
+hard=$(grep -aE "$asan_re" "$findings" || true)
+
+soft=$(grep -aEv "$asan_re" "$findings" || true)
+known=''
+unknown=$soft
+
+if [ -n "$allowlist" ] && [ -f "$allowlist" ] && [ -n "$soft" ]; then
+    # Patterns go through a file, not a heredoc: `grep -f -` would take its
+    # pattern list from the same stdin the findings are piped in on, match
+    # nothing, and report a clean leg -- the exact failure this gate exists to
+    # remove.
+    grep -Ev '^[[:space:]]*(#|$)' "$allowlist" > "$patterns" || true
+
+    if [ -s "$patterns" ]; then
+        known=$(printf '%s\n' "$soft" | grep -aE -f "$patterns" || true)
+        unknown=$(printf '%s\n' "$soft" | grep -aE -v -f "$patterns" || true)
+    fi
+fi
+
+if [ -n "$known" ]; then
+    echo "Known UBSan violations waived by ${allowlist} (tracked, not fixed here):"
+    printf '%s\n' "$known" | sed 's/.*unit\.log://' | sort | uniq -c | sort -rn |
+        sed 's/^/  /'
+    echo
+fi
+
+if [ -z "$hard" ] && [ -z "$unknown" ]; then
+    echo "No unwaived sanitizer reports."
+    exit 0
+fi
+
+if [ -n "$hard" ]; then
+    echo "AddressSanitizer/LeakSanitizer report(s) -- never waivable:"
+    printf '%s\n' "$hard" | sed 's/^/  /'
+    echo
+    echo "Stack frames from the same log(s):"
+    for f in $logs; do
+        grep -aE '^ *#[0-9]+ 0x' "$f" 2>/dev/null | head -40 | sed 's/^/  /'
+    done
+    echo
+fi
+
+if [ -n "$unknown" ]; then
+    echo "UBSan violation(s) not in ${allowlist:-(no allowlist)}:"
+    printf '%s\n' "$unknown" | sed 's/.*unit\.log://' | sort | uniq -c | sort -rn |
+        sed 's/^/  /'
+    echo
+fi
+
+echo "::error::Sanitizer report(s) in this leg; see the step output above and" \
+     "the uploaded unit-logs artifact.  A new UBSan site must be fixed, or" \
+     "waived in .github/sanitizer-allowlist.txt with an issue reference."
+exit 1

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -23,7 +23,13 @@ on:
       - 'go/**'
       - 'src/**'
       - 'test/**'
+      # The gate is three files, not one: a change to the scan script or to
+      # the waiver list can break report detection or widen what is ignored
+      # just as effectively as a change to this workflow, and must not skip
+      # the job that would catch it.
       - '.github/workflows/sanitize.yml'
+      - '.github/scripts/check-sanitizer-reports.sh'
+      - '.github/sanitizer-allowlist.txt'
   push:
     # master is the release/default branch; pre-* are the release-prep
     # integration branches (e.g. pre-1.35.6) where the hardening actually
@@ -39,7 +45,13 @@ on:
       - 'go/**'
       - 'src/**'
       - 'test/**'
+      # The gate is three files, not one: a change to the scan script or to
+      # the waiver list can break report detection or widen what is ignored
+      # just as effectively as a change to this workflow, and must not skip
+      # the job that would catch it.
       - '.github/workflows/sanitize.yml'
+      - '.github/scripts/check-sanitizer-reports.sh'
+      - '.github/sanitizer-allowlist.txt'
 
 jobs:
   sanitize:
@@ -176,61 +188,52 @@ jobs:
       - name: Make ${{ matrix.runtime }} module
         run: make -j$(nproc) ${{ matrix.make }}
 
-      - name: Create ASan log directory
-        run: mkdir -p "${GITHUB_WORKSPACE}/asan-logs"
-
       # ASAN_OPTIONS / UBSAN_OPTIONS are step-level env so pytest and every
       # forked unitd process inherit them.
-      #   log_path=<workspace>/asan-logs/{asan,ubsan}
-      #     ASan and UBSan reports from the forked daemons land in
-      #     asan-logs/<tool>.<pid> files rather than only the per-test unit.log
-      #     the harness rotates away, so the guard step below can fail the job
-      #     even when pytest itself is green.  UBSan needs its OWN log_path:
-      #     with only ASAN_OPTIONS set, a UBSan-only violation that does not
-      #     escalate to a fatal signal writes to neither the asan-logs dir nor
-      #     a place the harness scans (it greps unit.log for "Sanitizer", not
-      #     UBSan's "runtime error"), so half the gate could pass silently.
       #   detect_leaks=0
       #     the fork-heavy daemon makes LeakSanitizer extremely noisy; turning
       #     leak detection on is tracked as a follow-up, once the teardown
       #     paths are use-after-free / null-deref clean.
-      # pytest_opts is per-runtime (e.g. --restart for the graceful tests).
+      #   print_stacktrace / halt_on_error
+      #     honoured wherever the options string survives.  They do NOT take
+      #     effect inside unitd itself -- see the header of
+      #     .github/scripts/check-sanitizer-reports.sh -- which is exactly why
+      #     the gate below reads unit.log instead of trusting a log_path
+      #     directory.  Kept because they cost nothing and do apply to any
+      #     helper binary the suite runs.
+      #
+      # --save-log keeps <temp_dir>/unit.log after each test.  Without it
+      # test/conftest.py removes the per-restart temp dir, and with it the only
+      # copy of any report a forked daemon wrote -- which is what the gate
+      # below scans.  pytest_opts is per-runtime (e.g. --restart for the
+      # graceful tests).
       - name: Run ${{ matrix.runtime }} sanitizer subset
         env:
-          ASAN_OPTIONS: "detect_leaks=0:log_path=${{ github.workspace }}/asan-logs/asan"
-          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:log_path=${{ github.workspace }}/asan-logs/ubsan"
+          ASAN_OPTIONS: "detect_leaks=0"
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
         run: |
-          python3 -m pytest -v ${{ matrix.pytest_opts }} ${{ matrix.tests }}
+          python3 -m pytest -v --save-log ${{ matrix.pytest_opts }} ${{ matrix.tests }}
 
-      - name: Show ASan/UBSan reports
-        if: always()
-        run: |
-          if [ -n "$(ls -A asan-logs 2>/dev/null)" ]; then
-            for f in asan-logs/*; do
-              echo "===== ${f} ====="
-              cat "${f}"
-            done
-          else
-            echo "No ASan/UBSan report files were produced."
-          fi
-
-      - name: Upload ASan/UBSan reports
+      - name: Upload unit logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: asan-ubsan-logs-${{ matrix.runtime }}
-          path: asan-logs/
-          if-no-files-found: ignore
+          name: unit-logs-${{ matrix.runtime }}
+          path: ${{ env.TMPDIR || '/tmp' }}/unit-test-*/unit.log
+          if-no-files-found: warn
 
-      # Sanitizer reports from forked children do not reliably fail pytest: the
-      # crash aborts a child while the session continues, and with log_path set
-      # the report never reaches the unit.log the harness scans.  Fail the job
-      # explicitly on any report file, even when pytest was green.
+      # Sanitizer reports do not reliably fail pytest.  A UBSan violation that
+      # does not escalate to a signal fails nothing at all: the harness's
+      # Log.check_alerts() greps unit.log for "[alert]" and "Sanitizer", not
+      # for UBSan's "runtime error:".  An ASan report does abort the router,
+      # but the session then fails with connection errors that read as an
+      # infrastructure flake rather than as a memory-safety bug.  Measured on
+      # master: 24 runs of the configuration-churn workload produced a UBSan
+      # violation in every run with pytest green in 23 of them, and the one
+      # ASan heap-use-after-free surfaced only as "Client can't connect to the
+      # server".  Fail the job explicitly on what the logs actually contain.
       - name: Fail on sanitizer reports
         if: always()
         run: |
-          if [ -n "$(ls -A asan-logs 2>/dev/null)" ]; then
-            echo "::error::AddressSanitizer/UBSan produced report(s) in the ${{ matrix.runtime }} leg; see the asan-ubsan-logs-${{ matrix.runtime }} artifact and the 'Show ASan/UBSan reports' step."
-            exit 1
-          fi
-          echo "No sanitizer reports; ${{ matrix.runtime }} lifecycle paths are clean."
+          .github/scripts/check-sanitizer-reports.sh \
+            "${TMPDIR:-/tmp}" .github/sanitizer-allowlist.txt

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -476,6 +476,17 @@ def unit_run(state_dir=None):
     option.temp_dir = temporary_dir
     public_dir(temporary_dir)
 
+    # Every start gets a fresh temp dir and therefore a fresh, empty
+    # unit.log, so the read offsets recorded against the previous one are
+    # meaningless here.  Teardown saves that offset unconditionally and only
+    # resets it when it removes the temp dir, which --save-log stops it from
+    # doing: without this, a --save-log --restart run seeks each test's reads
+    # to the size of the PREVIOUS test's log.  Everything log-based then sees
+    # a tail slice or nothing at all -- Log.wait_for_record misses records
+    # that are present, and, worse silently, the teardown Log.check_alerts()
+    # and _check_fds() stop examining most of what they are given.
+    Log.pos.clear()
+
     if oct(stat.S_IMODE(Path(builddir).stat().st_mode)) != '0o777':
         public_dir(builddir)
 


### PR DESCRIPTION
Fixes https://github.com/freeunitorg/freeunit/issues/185.

The sanitizer job could not fail. Its guard step listed `asan-logs/`, that
directory was always empty, and every run took the clean branch and printed
`No sanitizer reports; <runtime> lifecycle paths are clean.`

### Why the directory was always empty

`ASAN_OPTIONS`/`UBSAN_OPTIONS` `log_path` does not work for `unitd`. The
daemon relocates `argv[]`/`environ[]` in `nxt_process_title()` and overwrites
the original block, so the options string the sanitizer runtime kept a pointer
into is gone by the time a forked router or application worker writes a
report.

Measured on this tree: an ordinary binary run with the same `UBSAN_OPTIONS`
honours `log_path`, `halt_on_error` **and** `print_stacktrace`; inside `unitd`
none of the three take effect and the log directory stays empty on every run.
So it is not only string-valued flags, as the issue supposed — the whole
options string is lost.

### What that cost, measured

Against the configuration-churn workload under an ASan+UBSan build, on master:

- **24 runs, a UBSan violation in every one of them, pytest green in 23.**
  `Log.check_alerts()` greps `unit.log` for `[alert]` and `Sanitizer`, not for
  UBSan's `runtime error:`, so a UBSan-only violation fails nothing and
  appears nowhere.
- The one run that hit the
  https://github.com/freeunitorg/freeunit/issues/186 heap-use-after-free in
  `nxt_locked_work_queue_move()` failed only as 35 `Client can't connect to
  the server` errors — an infrastructure flake, to any reader — while the gate
  still reported the leg clean.

### The fix

Reports do reach `unitd`'s stderr, which `conftest.py` wires to
`<temp_dir>/unit.log`. So: drop `log_path`, pass `--save-log` so conftest
keeps that file instead of removing the temp dir after each test, and scan it
for both `Sanitizer` and `runtime error:`.

The scan lives in `.github/scripts/check-sanitizer-reports.sh` rather than
inline YAML so it can be run against a captured log — which is how each of its
five behaviours was checked:

| case | expected | result |
|---|---|---|
| leg whose only violations are allowlisted | pass | exit 0 |
| an unknown UBSan site | fail | exit 1 |
| the real #186 ASan log | fail | exit 1, with stacks |
| ASan against an allowlist containing `.*` | fail | exit 1 — never waivable |
| no `unit.log` produced at all | fail | exit 1 |

That last one matters: "no evidence" must not read as "no findings", which is
the bug being removed.

### `grep -a` is load-bearing

The `--debug` log carries raw payload bytes — tens of thousands of NULs in a
typical run — so `grep` classifies `unit.log` as binary, prints the matches
preceding the first NUL and stops. On the captured churn log that dropped 5 of
8 report lines, **including both `AddressSanitizer` lines**. Without `-a` this
gate reproduces the exact bug it was written to remove. It was caught only
because the script was run under `sh`, the way CI runs it.

### The allowlist

Pre-existing UBSan sites are waived in `.github/sanitizer-allowlist.txt`
rather than fixed here, so the gate can become blocking in one step instead of
waiting on unrelated fixes. Every entry pins a source location and names the
issue tracking its fix — https://github.com/freeunitorg/freeunit/issues/188
for the misaligned union in `nxt_conf.c`, and
https://github.com/freeunitorg/freeunit/issues/200 for the NULL-with-zero-
length `memcmp`/`memcpy` pair. ASan/LSan/TSan reports are not waivable there
by construction.

`Log.check_alerts()` is deliberately unchanged: enforcement lives in one
place, and the allowlist with it.

### Watch on this PR

The sanitize legs are now able to go red for the first time. If a UBSan site
has appeared on master since the allowlist was measured, this PR is where it
surfaces — that is the gate working, and the fix is either a real fix or a new
allowlist entry naming an issue.
