### PR TITLE
router: close the engine port when a worker thread exits

### DIFF
--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4245,6 +4245,18 @@ nxt_router_thread_exit_handler(nxt_task_t *task, void *obj, void *data)
 
     port->engine = task->thread->engine;
     nxt_mp_thread_adopt(port->mem_pool);
+
+    /*
+     * The worker thread is gone, so nothing reads port->pair[0] any more:
+     * close the socket pair and the queue memfd, and drop the reference
+     * nxt_router_rt_add_port() took when it published the port in
+     * rt->ports.  Without this every engine removed by a listen_threads
+     * decrease leaks 3 descriptors (2 socketpair + 1 memfd) for the
+     * router's lifetime.
+     */
+    nxt_port_close(task, port);
+    nxt_runtime_port_remove(task, port);
+
     nxt_port_use(task, port, -1);
 
     nxt_mp_thread_adopt(engine->mem_pool);

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -175,8 +175,8 @@ static int nxt_unit_get_port(nxt_unit_ctx_t *ctx, nxt_unit_port_id_t *port_id);
 static ssize_t nxt_unit_port_send(nxt_unit_ctx_t *ctx,
     nxt_unit_port_t *port, const void *buf, size_t buf_size,
     const nxt_send_oob_t *oob);
-static ssize_t nxt_unit_sendmsg(nxt_unit_ctx_t *ctx, int fd,
-    const void *buf, size_t buf_size, const nxt_send_oob_t *oob);
+static ssize_t nxt_unit_sendmsg(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
+    int fd, const void *buf, size_t buf_size, const nxt_send_oob_t *oob);
 static int nxt_unit_ctx_port_recv(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
     nxt_unit_read_buf_t *rbuf);
 nxt_inline void nxt_unit_rbuf_cpy(nxt_unit_read_buf_t *dst,
@@ -1058,7 +1058,7 @@ nxt_unit_ready(nxt_unit_ctx_t *ctx, int ready_fd, uint32_t stream, int queue_fd)
 
     nxt_socket_msg_oob_init(&oob, fds);
 
-    res = nxt_unit_sendmsg(ctx, ready_fd, &msg, sizeof(msg), &oob);
+    res = nxt_unit_sendmsg(ctx, NULL, ready_fd, &msg, sizeof(msg), &oob);
     if (res != sizeof(msg)) {
         return NXT_UNIT_ERROR;
     }
@@ -6223,7 +6223,7 @@ nxt_unit_port_send(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
             msg.type = _NXT_PORT_MSG_READ_QUEUE;
 
             if (lib->callbacks.port_send == NULL) {
-                ret = nxt_unit_sendmsg(ctx, port->out_fd, &msg,
+                ret = nxt_unit_sendmsg(ctx, port, port->out_fd, &msg,
                                        sizeof(nxt_port_msg_t), NULL);
 
                 nxt_unit_debug(ctx, "port{%d,%d} send %d read_queue",
@@ -6269,7 +6269,7 @@ nxt_unit_port_send(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
                        (int) ret);
 
     } else {
-        ret = nxt_unit_sendmsg(ctx, port->out_fd, buf, buf_size, oob);
+        ret = nxt_unit_sendmsg(ctx, port, port->out_fd, buf, buf_size, oob);
 
         nxt_unit_debug(ctx, "port{%d,%d} sendmsg %d",
                        (int) port->id.pid, (int) port->id.id,
@@ -6281,12 +6281,13 @@ nxt_unit_port_send(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
 
 
 static ssize_t
-nxt_unit_sendmsg(nxt_unit_ctx_t *ctx, int fd,
+nxt_unit_sendmsg(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port, int fd,
     const void *buf, size_t buf_size, const nxt_send_oob_t *oob)
 {
     int                  err;
     ssize_t              n;
     struct iovec         iov[1];
+    nxt_unit_impl_t      *lib;
     nxt_unit_ctx_impl_t  *ctx_impl;
 
     iov[0].iov_base = (void *) buf;
@@ -6323,9 +6324,36 @@ retry:
          * too and cannot be used to distinguish steady state from
          * shutdown.  The unambiguous flag is ctx_impl->online.
          */
+        lib = nxt_container_of(ctx->unit, nxt_unit_impl_t, unit);
         ctx_impl = nxt_container_of(ctx, nxt_unit_ctx_impl_t, ctx);
 
-        if (ctx_impl->online) {
+        /*
+         * A router engine port whose peer has already closed is not an
+         * application fault even while online: the router closes an
+         * engine's port pair when a "listen_threads" decrease retires
+         * that engine (nxt_router_thread_exit_handler()), and it does
+         * not tell the applications that still hold a copy of the port,
+         * so a response to a request that engine had handed out fails:
+         * with ECONNREFUSED on the SOCK_DGRAM pairs used on Linux
+         * (src/nxt_socketpair.c), with EPIPE or ECONNRESET on a stream
+         * pair.  The request was abandoned on the router side already;
+         * say so at warn level.
+         *
+         * That reasoning covers only the per-engine ports learned through
+         * NEW_PORT/GET_PORT.  The main router port, the shared port and
+         * the readiness descriptor have no such lifecycle: a broken one
+         * of those is a real problem and keeps the alert, because for
+         * some of its messages this log line is the only visible signal
+         * (nxt_unit_mmap_release() ignores nxt_unit_send_shm_ack()'s
+         * return value).
+         */
+        if (ctx_impl->online
+            && !(port != NULL
+                 && port != lib->router_port
+                 && port != lib->shared_port
+                 && (err == ECONNREFUSED || err == EPIPE
+                     || err == ECONNRESET)))
+        {
             nxt_unit_alert(ctx, "sendmsg(%d, %d) failed: %s (%d)",
                            fd, (int) buf_size, strerror(err), err);
 

--- a/test/test_conn_recycle.py
+++ b/test/test_conn_recycle.py
@@ -13,12 +13,7 @@ BODY = '0123456789'
 
 
 @pytest.fixture(autouse=True)
-def setup_method_fixture(temp_dir, skip_fds_check):
-    # Thread-count changes intentionally add and remove each engine's epoll,
-    # signalfd, and eventfd descriptors, so the generic router FD baseline is
-    # not meaningful for this test.  The recycler itself owns no descriptors.
-    skip_fds_check(router=True)
-
+def setup_method_fixture(temp_dir):
     Path(f'{temp_dir}/assets').mkdir(parents=True)
     Path(f'{temp_dir}/assets/index.html').write_text(BODY, encoding='utf-8')
 

--- a/test/test_listen_threads.py
+++ b/test/test_listen_threads.py
@@ -1,0 +1,105 @@
+import time
+from pathlib import Path
+
+import pytest
+from conftest import _count_fds, pid_by_name
+
+from unit.applications.proto import ApplicationProto
+
+client = ApplicationProto()
+
+BODY = '0123456789'
+
+# Enough engines that shrinking destroys several of them on any host.  The
+# leak is per destroyed engine, so a cycle that starts from the default
+# (nxt_ncpu) would destroy nothing on a single-CPU machine; pinning the high
+# water mark here makes the delta the same everywhere.
+THREADS = 4
+
+
+@pytest.fixture(autouse=True)
+def setup_method_fixture(temp_dir):
+    Path(f'{temp_dir}/assets').mkdir(parents=True)
+    Path(f'{temp_dir}/assets/index.html').write_text(BODY, encoding='utf-8')
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [{"action": {"share": f'{temp_dir}/assets$uri'}}],
+        }
+    )
+
+    yield
+
+    # The no-restart suite preserves /settings between tests.
+    assert 'success' in client.conf_delete('settings/listen_threads')
+
+
+def _router_fds():
+    return _count_fds(pid_by_name('unit: router'))
+
+
+def _settle_fds(stable=5, timeout=100):
+    # Engines are created and destroyed asynchronously with respect to the
+    # configuration reply, so a reading taken right after it can catch the
+    # router mid-transition.  Wait for the count to hold still instead of
+    # sleeping a fixed amount.
+    fds = _router_fds()
+    same = 0
+
+    for _ in range(timeout):
+        time.sleep(0.1)
+
+        cur = _router_fds()
+
+        same = same + 1 if cur == fds else 0
+        fds = cur
+
+        if same >= stable:
+            break
+
+    return fds
+
+
+def _wait_fds(expected, timeout=100):
+    # Return the last reading either way, so a leak fails as the count it is
+    # rather than as an opaque timeout.
+    for _ in range(timeout):
+        fds = _router_fds()
+
+        if fds <= expected:
+            break
+
+        time.sleep(0.1)
+
+    return fds
+
+
+def _set_threads(threads):
+    assert 'success' in client.conf(
+        {"listen_threads": threads}, 'settings'
+    ), f'listen_threads {threads}'
+
+    assert client.get()['status'] == 200, f'request with {threads} engines'
+
+
+def test_listen_threads_engine_fds():
+    # A destroyed router engine used to keep its port socketpair and queue
+    # memfd open for the router's lifetime (3 descriptors each), because
+    # nxt_router_thread_exit_handler() only dropped one of the port's two
+    # references and nxt_port_release() closes nothing.  Every shrink of
+    # "listen_threads" therefore cost descriptors that no later grow
+    # returned.
+    _set_threads(THREADS)
+
+    before = _settle_fds()
+
+    _set_threads(1)
+    _set_threads(THREADS)
+
+    after = _wait_fds(before)
+
+    assert after <= before, (
+        f'router leaked {after - before} descriptors over a listen_threads'
+        f' {THREADS} -> 1 -> {THREADS} cycle ({before} before, {after} after)'
+    )

--- a/test/test_process_abrupt_teardown.py
+++ b/test/test_process_abrupt_teardown.py
@@ -137,10 +137,8 @@ def _wait_for_pids_gone(pids, timeout=5):
 
 def test_process_abrupt_teardown(skip_alert, skip_fds_check):
     # Killing workers leaves descriptor accounting unsettled in all three
-    # long-lived processes for as long as the respawn takes, and changing
-    # "listen_threads" leaks the destroyed engines' port socketpairs on top of
-    # that (see test_process_teardown_churn.py).  Neither is what this test is
-    # about.
+    # long-lived processes for as long as the respawn takes, which is not what
+    # this test is about.
     skip_fds_check(main=True, router=True, controller=True)
 
     # Expected, and in fact asserted on below: this is how the main process

--- a/test/test_process_shm_oosm.py
+++ b/test/test_process_shm_oosm.py
@@ -90,13 +90,7 @@ def _body(resp, size):
     return resp[-size:]
 
 
-def test_process_shm_oosm(skip_fds_check):
-    # Same pre-existing engine-teardown descriptor leak that
-    # test_process_teardown_churn.py documents: changing "listen_threads"
-    # destroys event engines, and each destroyed engine keeps its port
-    # socketpair open.  Unrelated to what this test exercises.
-    skip_fds_check(router=True)
-
+def test_process_shm_oosm():
     client.load(APP, limits={"shm": SHM_LIMIT}, processes=1)
 
     assert 'success' in client.conf(

--- a/test/test_process_teardown_churn.py
+++ b/test/test_process_teardown_churn.py
@@ -105,16 +105,7 @@ def _wait_for_pids(count, timeout=100):
     return pids
 
 
-def test_process_teardown_churn(skip_fds_check):
-    # Setting "listen_threads" changes the number of router worker engines,
-    # and destroying an engine leaks its descriptors: measured on this tree,
-    # shrinking the count frees each dead engine's epoll and eventfd but keeps
-    # its port socketpair open (3 sockets per destroyed engine), so the router
-    # ends the test with more descriptors than it started with.  That is a
-    # pre-existing defect in engine teardown, not something this workload
-    # causes, and it is unrelated to what the test is here to exercise.
-    skip_fds_check(router=True)
-
+def test_process_teardown_churn():
     client.load(APP, processes={"spare": SPARE, "max": 4, "idle_timeout": 5})
 
     assert 'success' in client.conf(


### PR DESCRIPTION
**Bug.** Every router engine removed by a `settings.listen_threads` decrease leaks 3 descriptors for the router's lifetime: the engine port's socketpair (`pair[0]`, `pair[1]`) and its queue memfd. `nxt_router_thread_exit_handler()` (src/nxt_router.c) only drops the reference taken by `nxt_port_new()`; the one taken by `nxt_router_rt_add_port()` when the port was published in `rt->ports` is never dropped, and `nxt_port_release()` does not close descriptors anyway — only `nxt_port_close()` does. The engine's epoll and eventfd are freed correctly by `nxt_event_engine_free()`.

Reproduced standalone on an 8-CPU host (router `/proc/<pid>/fd`, shrink→1 / grow→8): 58 → 79 → 100 → 121 over three cycles, never returning (+7 memfd, +14 sockets per shrink). This is also why three tests in the suite carried `skip_fds_check(router=True)` with comments calling it a pre-existing engine-teardown defect, and why the #204 follow-up could not pin `listen_threads` in the fd test.

**Fix** (`90906433`): in the thread-exit handler, `nxt_port_close()` + `nxt_runtime_port_remove()` before the final `nxt_port_use(-1)` — the same close → remove → drop sequence `nxt_process_close_ports()` uses. The handler runs on the main router engine, the same thread that ran `nxt_router_rt_add_port()`, so `rt->ports` needs no locking; the worker thread has already been joined (`nxt_thread_wait()`), so nothing reads `pair[0]` any more; `nxt_port_mp_cleanup()`'s `pair == -1` asserts are now satisfied instead of being reached live. With the fix: 58 → 23 → 58 on every cycle, 3000 requests during five rapid shrink/grow cycles all 200, no alerts in a `--debug` build, C unit tests pass.

**Test** (`65b5a189`): new `test/test_listen_threads.py` — static `share` route (no language module), `listen_threads` 4 → 1 → 4 with a 200 response at each step, router fd count compared across the cycle with a bounded wait. On unpatched master: `router leaked 9 descriptors over a listen_threads 4 -> 1 -> 4 cycle (44 before, 53 after)` (3 engines × 3 fds) plus the teardown `descriptors leak router / assert 21 <= 0`; with the fix: passes. The three `skip_fds_check(router=True)` suppressions whose comments described this exact leak (`test_process_teardown_churn.py`, `test_process_shm_oosm.py`, `test_conn_recycle.py`) are removed and those tests now pass with the router descriptor check armed; `test_process_abrupt_teardown.py` keeps its skip for its own kill/respawn reason.

**Out of scope**: the pre-existing `TODO notify all apps` — applications keep their copy of a dead engine port's write descriptor (libunit drops ports only on `REMOVE_PID`); no traffic flows through it.
