### PR TITLE
port: bound the log file slot a CHANGE_FILE message claims

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -178,6 +178,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_port_fail_test.c \
     src/test/nxt_port_mmap_range_test.c \
     src/test/nxt_port_ready_test.c \
+    src/test/nxt_port_change_file_test.c \
 "
 
 

--- a/src/nxt_file.c
+++ b/src/nxt_file.c
@@ -621,7 +621,8 @@ nxt_file_fclose(nxt_task_t *task, FILE *fp)
 
 /*
  * nxt_file_redirect() redirects the file to the fd descriptor.
- * Then the fd descriptor is closed.
+ * Then the fd descriptor is closed -- on the failing paths as well, so that
+ * the caller can hand the descriptor over unconditionally.
  */
 
 nxt_int_t
@@ -632,6 +633,14 @@ nxt_file_redirect(nxt_file_t *file, nxt_fd_t fd)
     if (dup2(fd, file->fd) == -1) {
         nxt_thread_log_alert("dup2(%FD, %FD, \"%FN\") failed %E",
                              fd, file->fd, file->name, nxt_errno);
+
+        /*
+         * The descriptor is consumed whatever the outcome, as the comment
+         * above states: callers hand it over and never close it on success,
+         * so failing without closing it here leaked it instead.
+         */
+        (void) close(fd);
+
         return NXT_ERROR;
     }
 

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -518,7 +518,9 @@ nxt_port_change_log_file(nxt_task_t *task, nxt_runtime_t *rt, nxt_uint_t slot,
 void
 nxt_port_change_log_file_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 {
+    size_t         size;
     nxt_buf_t      *b;
+    nxt_int_t      ret;
     nxt_uint_t     slot;
     nxt_file_t     *log_file;
     nxt_runtime_t  *rt;
@@ -526,18 +528,82 @@ nxt_port_change_log_file_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     rt = task->thread->runtime;
 
     b = msg->buf;
-    slot = *(nxt_uint_t *) b->mem.pos;
 
+    /*
+     * The payload is whatever the sender chose to write: a message with a
+     * short -- or empty -- buffer would have the slot read past its end.
+     * The size the sender declared is what nxt_port_read_msg_process()
+     * advanced b->mem.free by, so the used size is the only bound here.
+     * nxt_assert() is not used because it compiles out in release builds,
+     * which is exactly where this message arrives unauthenticated.
+     */
+    size = 0;
+
+    if (nxt_fast_path(b != NULL)) {
+        size = (size_t) nxt_buf_mem_used_size(&b->mem);
+    }
+
+    if (nxt_slow_path(size < sizeof(nxt_uint_t))) {
+        nxt_log(task, NXT_LOG_WARN, "CHANGE_FILE with a %uz byte payload, "
+                "which is too short to name a log file slot", size);
+
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
+
+    /* The payload is not aligned for a nxt_uint_t load. */
+    nxt_memcpy(&slot, b->mem.pos, sizeof(nxt_uint_t));
+
+    /*
+     * nxt_list_elt() returns NULL past the end of the list, and every
+     * process that installs this handler -- the discovery and prototype
+     * processes, the router and the controller -- would then dereference
+     * it.
+     */
     log_file = nxt_list_elt(rt->log_files, slot);
 
+    if (nxt_slow_path(log_file == NULL)) {
+        nxt_log(task, NXT_LOG_WARN, "CHANGE_FILE claiming log file slot "
+                "%ui, which does not exist", slot);
+
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
+
+    if (nxt_slow_path(msg->fd[0] == -1)) {
+        nxt_log(task, NXT_LOG_WARN, "CHANGE_FILE claiming log file slot "
+                "%ui without a descriptor to redirect it to", slot);
+
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
+
     nxt_debug(task, "change log file %FD:%FD", msg->fd[0], log_file->fd);
+
+    /*
+     * A second descriptor is never used on this path, but a message can
+     * carry one whatever its type: close it before the redirect, so that
+     * neither outcome of the redirect leaves it behind.
+     */
+    if (msg->fd[1] != -1) {
+        nxt_fd_close(msg->fd[1]);
+        msg->fd[1] = -1;
+    }
 
     /*
      * The old log file descriptor must be closed at the moment when no
      * other threads use it.  dup2() allows to use the old file descriptor
      * for new log file.  This change is performed atomically in the kernel.
+     *
+     * nxt_file_redirect() consumes the descriptor on every outcome, so drop
+     * it from the message rather than letting close_fds() reach a number
+     * that has already been reused.
      */
-    if (nxt_file_redirect(log_file, msg->fd[0]) == NXT_OK) {
+    ret = nxt_file_redirect(log_file, msg->fd[0]);
+
+    msg->fd[0] = -1;
+
+    if (nxt_fast_path(ret == NXT_OK)) {
         if (slot == 0) {
             (void) nxt_file_stderr(log_file);
         }

--- a/src/test/nxt_port_change_file_test.c
+++ b/src/test/nxt_port_change_file_test.c
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for nxt_port_change_log_file_handler() (src/nxt_port.c).
+ *
+ * CHANGE_FILE carries a log file slot in its payload and the descriptor the
+ * slot is to be redirected to.  Neither is authenticated, and the discovery
+ * and prototype processes, the router and the controller all install this
+ * handler.
+ *
+ * The handler read the slot without bounding it against the payload, passed
+ * it to nxt_list_elt() -- which returns NULL past the end of the list -- and
+ * dereferenced the result, so a forged slot crashed the receiver.  It also
+ * never closed the second descriptor of the message, and lost the first one
+ * when the redirect failed; the dispatcher does not reclaim fds once the
+ * handler returns (see nxt_port_recv_msg_close_fds()), so a peer attaching
+ * descriptors to forged messages can exhaust the receiver's descriptor
+ * table.
+ *
+ * A message can carry two descriptors regardless of how many its type
+ * normally uses, so the rejected cases attach both and expect both back.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_runtime.h>
+#include "nxt_tests.h"
+
+#include <fcntl.h>
+
+
+static nxt_bool_t
+nxt_port_change_file_test_fd_is_open(nxt_fd_t fd)
+{
+    return fcntl(fd, F_GETFD) != -1;
+}
+
+
+/*
+ * Feed the handler a message it has to refuse, and check that nothing the
+ * message carried outlives the call.
+ */
+static nxt_int_t
+nxt_port_change_file_test_reject(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_bool_t with_fd0, const char *name)
+{
+    nxt_fd_t  fd0, fd1;
+
+    fd0 = -1;
+
+    if (with_fd0) {
+        fd0 = open("/dev/null", O_RDONLY);
+    }
+
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if ((with_fd0 && fd0 == -1) || fd1 == -1) {
+        nxt_log_alert(thr->log, "port change file test failed to open "
+                      "/dev/null");
+        goto fail;
+    }
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    nxt_port_change_log_file_handler(task, msg);
+
+    if ((fd0 != -1 && nxt_port_change_file_test_fd_is_open(fd0))
+        || nxt_port_change_file_test_fd_is_open(fd1))
+    {
+        nxt_log_alert(thr->log, "port change file test: %s leaked a "
+                      "descriptor", name);
+        goto fail;   /* closes only what is still open */
+    }
+
+    if (msg->fd[0] != -1 || msg->fd[1] != -1) {
+        nxt_log_alert(thr->log, "port change file test: %s left fds in the "
+                      "message", name);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+
+fail:
+
+    /*
+     * Close only what the handler left open: the descriptors it consumed
+     * are gone already, and closing them again could reach an unrelated
+     * descriptor that reused the number.
+     */
+    if (fd0 != -1 && nxt_port_change_file_test_fd_is_open(fd0)) {
+        (void) close(fd0);
+    }
+
+    if (fd1 != -1 && nxt_port_change_file_test_fd_is_open(fd1)) {
+        (void) close(fd1);
+    }
+
+    return NXT_ERROR;
+}
+
+
+/*
+ * The accepted case: the slot exists, so the first descriptor is redirected
+ * onto the log file -- and consumed by dup2() doing so -- while the second
+ * one, which this message type has no use for, is closed rather than left
+ * behind.
+ */
+static nxt_int_t
+nxt_port_change_file_test_accept(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_file_t *log_file, const char *name)
+{
+    nxt_fd_t  fd0, fd1;
+
+    fd0 = open("/dev/null", O_WRONLY);
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (fd0 == -1 || fd1 == -1) {
+        nxt_log_alert(thr->log, "port change file test failed to open "
+                      "/dev/null");
+        goto fail;
+    }
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    nxt_port_change_log_file_handler(task, msg);
+
+    if (nxt_port_change_file_test_fd_is_open(fd0)
+        || nxt_port_change_file_test_fd_is_open(fd1))
+    {
+        nxt_log_alert(thr->log, "port change file test: %s leaked a "
+                      "descriptor", name);
+        goto fail;
+    }
+
+    if (msg->fd[0] != -1 || msg->fd[1] != -1) {
+        nxt_log_alert(thr->log, "port change file test: %s left fds in the "
+                      "message", name);
+        return NXT_ERROR;
+    }
+
+    if (!nxt_port_change_file_test_fd_is_open(log_file->fd)) {
+        nxt_log_alert(thr->log, "port change file test: %s closed the log "
+                      "file", name);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+
+fail:
+
+    if (fd0 != -1 && nxt_port_change_file_test_fd_is_open(fd0)) {
+        (void) close(fd0);
+    }
+
+    if (fd1 != -1 && nxt_port_change_file_test_fd_is_open(fd1)) {
+        (void) close(fd1);
+    }
+
+    return NXT_ERROR;
+}
+
+
+nxt_int_t
+nxt_port_change_file_test(nxt_thread_t *thr)
+{
+    nxt_mp_t             *mp;
+    nxt_buf_t            *b;
+    nxt_file_name_t      *name;
+    nxt_uint_t           slot;
+    nxt_task_t           *task;
+    nxt_int_t            ret;
+    nxt_file_t           *log_file;
+    nxt_runtime_t        *rt, *saved_rt;
+    nxt_port_recv_msg_t  msg;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "port change file test started");
+
+    task = thr->task;
+    task->thread = thr;
+
+    name = (nxt_file_name_t *) "port change file test";
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    if (nxt_slow_path(rt == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    /*
+     * Two slots.  Slot 0 stays unopened, so a redirect onto it fails, and
+     * the accepted case uses slot 1: a successful redirect of slot 0 makes
+     * the handler point stderr at the new file, which would follow the test
+     * process out of this function.
+     */
+    rt->log_files = nxt_list_create(mp, 2, sizeof(nxt_file_t));
+    if (nxt_slow_path(rt->log_files == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    log_file = nxt_list_add(rt->log_files);
+    if (nxt_slow_path(log_file == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    nxt_memzero(log_file, sizeof(nxt_file_t));
+
+    /*
+     * Never opened, so redirecting onto it fails -- and the failure path
+     * logs the name, which therefore cannot be left NULL.
+     */
+    log_file->name = name;
+    log_file->fd = NXT_FILE_INVALID;
+
+    log_file = nxt_list_add(rt->log_files);
+    if (nxt_slow_path(log_file == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    nxt_memzero(log_file, sizeof(nxt_file_t));
+
+    log_file->name = name;
+    log_file->fd = open("/dev/null", O_WRONLY);
+    if (nxt_slow_path(log_file->fd == -1)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    saved_rt = thr->runtime;
+    thr->runtime = rt;
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    /*
+     * No payload at all.  The dispatcher always hands the handler a buffer,
+     * but a NULL one costs a single test to rule out and would be a NULL
+     * dereference otherwise.
+     */
+    msg.buf = NULL;
+
+    ret = nxt_port_change_file_test_reject(thr, task, &msg, 1, "no payload");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * A buffer shorter than the slot it is supposed to carry: the sender
+     * declares the size, so a zero-length payload arrives the same way a
+     * full one does, and reading the slot out of it reads past its end.
+     */
+    b = nxt_buf_mem_alloc(mp, sizeof(nxt_uint_t), 0);
+    if (nxt_slow_path(b == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    msg.buf = b;
+
+    ret = nxt_port_change_file_test_reject(thr, task, &msg, 1,
+                                           "short payload");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * A slot past the end of rt->log_files.  nxt_list_elt() returns NULL
+     * for it, and the handler used to dereference that straight away.
+     */
+    slot = 4242;
+    b->mem.free = nxt_cpymem(b->mem.free, &slot, sizeof(nxt_uint_t));
+
+    ret = nxt_port_change_file_test_reject(thr, task, &msg, 1,
+                                           "out of range slot");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /* An existing slot, but nothing to redirect it to. */
+    b->mem.free = b->mem.pos;
+    slot = 1;
+    b->mem.free = nxt_cpymem(b->mem.free, &slot, sizeof(nxt_uint_t));
+
+    ret = nxt_port_change_file_test_reject(thr, task, &msg, 0,
+                                           "slot without a descriptor");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * A slot whose file was never opened: dup2() onto NXT_FILE_INVALID
+     * fails, and nxt_file_redirect() used to return without closing the
+     * descriptor it had been handed -- the caller does not close it on the
+     * success path, so nobody did.
+     */
+    b->mem.free = b->mem.pos;
+    slot = 0;
+    b->mem.free = nxt_cpymem(b->mem.free, &slot, sizeof(nxt_uint_t));
+
+    ret = nxt_port_change_file_test_reject(thr, task, &msg, 1,
+                                           "slot that cannot be redirected");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    b->mem.free = b->mem.pos;
+    slot = 1;
+    b->mem.free = nxt_cpymem(b->mem.free, &slot, sizeof(nxt_uint_t));
+
+    ret = nxt_port_change_file_test_accept(thr, task, &msg, log_file,
+                                           "redirected slot");
+
+done:
+
+    thr->runtime = saved_rt;
+
+    if (log_file->fd != -1) {
+        (void) close(log_file->fd);
+    }
+
+    nxt_mp_destroy(mp);
+
+    if (nxt_fast_path(ret == NXT_OK)) {
+        nxt_thread_time_update(thr);
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "port change file test passed");
+    }
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -198,6 +198,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_port_change_file_test(thr) != NXT_OK) {
+        return 1;
+    }
+
 #if (NXT_HAVE_CGROUP)
     if (nxt_cgroup_test(thr) != NXT_OK) {
         return 1;

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -73,6 +73,7 @@ nxt_int_t nxt_http_route_addr_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_mmap_range_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_ready_test(nxt_thread_t *thr);
+nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);
 


### PR DESCRIPTION
Stacked on #208 — base is `fix/ipc-fd-and-ready-auth`, so the diff here is
this change alone. Retarget to `master` once #208 merges.

`nxt_port_change_log_file_handler()` reads a log file slot out of the
message payload and hands it to `nxt_list_elt()`, which returns NULL past
the end of the list. The result was dereferenced immediately, so a forged
CHANGE_FILE naming a slot that does not exist crashes whichever process
handles it — the discovery and prototype processes, the router and the
controller all install this handler, and the message is not authenticated.

The slot was also read without checking how much the sender actually
wrote. The payload length is whatever arrives on the wire
(`nxt_port_read_msg_process()` does `b->mem.free += msg->size`), so a
header-only CHANGE_FILE leaves the read running past the buffer.

Descriptors were mishandled on both sides: `fd[1]` was never closed, and
`fd[0]` was lost when the redirect failed.

## The `nxt_file.c` hunk

The `fd[0]` leak lives in `nxt_file_redirect()`, not in the caller, and is
fixed there. The caller cannot tell which of the two failure branches
fired, and the `close()` branch has already released the descriptor — so
closing in the caller would double-close on that path. There are exactly
two callers tree-wide; neither closes the descriptor after calling
redirect on any path, so no double-close is introduced. This also fixes
the same leak in `nxt_main_process_new_log_file()` (`nxt_main_process.c:988`),
where a failed `dup2()` lost the freshly opened descriptor.

## Scope

Not a regression and not a fix for any published advisory. Every path is
reachable only from a peer that is already compromised — the trust
boundary Unit states. Not release-blocking for 1.36.1.

The `slot == 0` case still lets an accepted CHANGE_FILE repoint stderr.
That is what log rotation *is*, and no bound check addresses it; a sender
ACL is the answer, tracked by `TODO(audit-V5-medium)` in `src/nxt_port.c`.

## Tests

`src/test/nxt_port_change_file_test.c` — no payload, short payload,
out-of-range slot, valid slot with no descriptor, valid slot whose
redirect fails, and the accepted redirect. Verified against the unfixed
handler: the forged slot gives SIGSEGV inside `nxt_file_redirect()` (not
at the `nxt_debug()` line — `nxt_debug` only evaluates its arguments at
debug level, so the fault is reachable in release builds), and both
descriptor cases fail with the leak assertions.

The accept case uses slot 1 deliberately: redirecting slot 0 would
repoint the test process's own stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMTKtFcf3YhmBPvTSKTkfg