### PR TITLE
port: validate the size of a queue a peer hands over

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -178,6 +178,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_port_fail_test.c \
     src/test/nxt_port_mmap_range_test.c \
     src/test/nxt_port_ready_test.c \
+    src/test/nxt_router_new_port_test.c \
     src/test/nxt_port_change_file_test.c \
 "
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -425,9 +425,9 @@ nxt_main_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         && port->type == NXT_PROCESS_APP
         && msg->fd[1] != -1)
     {
-        mem = nxt_mem_mmap(NULL, sizeof(nxt_port_queue_t),
-                           PROT_READ | PROT_WRITE, MAP_SHARED, msg->fd[1], 0);
-        if (nxt_fast_path(mem != MAP_FAILED)) {
+        mem = nxt_port_queue_mmap(task, msg->fd[1], sizeof(nxt_port_queue_t));
+
+        if (nxt_fast_path(mem != NULL)) {
             port->queue = mem;
         }
 

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -19,6 +19,73 @@ static void nxt_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 static nxt_atomic_uint_t nxt_port_last_id = 1;
 
 
+/*
+ * Map a queue a peer sent over a port.
+ *
+ * mmap() succeeds when the descriptor refers to an object shorter than the
+ * mapping, and the first access past the object's last page raises SIGBUS
+ * in this process -- main, the prototype or the router, depending on which
+ * handler took the message.  That is cheaper for a hostile peer than
+ * exhausting the descriptor table, so the size has to be validated before
+ * the mapping is made.
+ *
+ * Only a short object is refused.  Both senders do size the queue with
+ * ftruncate() to exactly the size the receiver maps -- nxt_shm_open() in
+ * the runtime and nxt_unit_shm_open() in libunit -- but fstat() does not
+ * have to report that size back: a shm object is rounded up to a page on
+ * some systems, and the queue is not a whole number of pages, so requiring
+ * the exact size would refuse every legitimate queue there.  A larger
+ * object is harmless -- only the first size bytes are mapped, and every
+ * access uses fixed offsets derived from the same type.
+ *
+ * The check does not make a hostile peer harmless: the sender keeps the
+ * descriptor and can shrink the object after the check, and neither
+ * MAP_POPULATE nor a probe read would close that window -- both only touch
+ * the pages before the shrink.  Sealing the object is not available to the
+ * receiver, and is Linux-only.  What the check does close is the whole
+ * class of short objects a peer can simply hand over, which is what the
+ * receiver can decide on its own.
+ */
+
+void *
+nxt_port_queue_mmap(nxt_task_t *task, nxt_fd_t fd, size_t size)
+{
+    void         *mem;
+    struct stat  queue_stat;
+
+    if (nxt_slow_path(fstat(fd, &queue_stat) == -1)) {
+        nxt_log(task, NXT_LOG_WARN, "fstat(%FD) failed %E", fd, nxt_errno);
+
+        return NULL;
+    }
+
+    /*
+     * Only a short object is refused, not a differing one: the producers
+     * size the queue exactly, but fstat() does not have to report that.
+     * A shm object is rounded up to a page on some systems, and the queue
+     * is not a whole number of pages, so requiring equality would refuse
+     * every legitimate queue there.
+     */
+    if (nxt_slow_path(queue_stat.st_size < (off_t) size)) {
+        nxt_log(task, NXT_LOG_WARN, "port queue on descriptor %FD is %O "
+                "bytes, less than the %uz it must hold", fd,
+                queue_stat.st_size, size);
+
+        return NULL;
+    }
+
+    mem = nxt_mem_mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+    if (nxt_slow_path(mem == MAP_FAILED)) {
+        nxt_log(task, NXT_LOG_WARN, "mmap(%FD) failed %E", fd, nxt_errno);
+
+        return NULL;
+    }
+
+    return mem;
+}
+
+
 static void
 nxt_port_mp_cleanup(nxt_task_t *task, void *obj, void *data)
 {
@@ -392,9 +459,9 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_debug(task, "process %PI ready", msg->port_msg.pid);
 
     if (msg->fd[0] != -1) {
-        mem = nxt_mem_mmap(NULL, sizeof(nxt_port_queue_t),
-                           PROT_READ | PROT_WRITE, MAP_SHARED, msg->fd[0], 0);
-        if (nxt_fast_path(mem != MAP_FAILED)) {
+        mem = nxt_port_queue_mmap(task, msg->fd[0], sizeof(nxt_port_queue_t));
+
+        if (nxt_fast_path(mem != NULL)) {
             /*
              * Release what a previous PROCESS_READY installed, so that
              * replacing the queue does not leak the old mapping and its
@@ -421,9 +488,15 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
             msg->fd[0] = -1;
 
         } else {
-            nxt_log(task, NXT_LOG_WARN, "process %PI ready: queue mmap "
-                    "failed %E, falling back to the socket", msg->port_msg.pid,
-                    nxt_errno);
+            /*
+             * A refused queue leaves the port as it was, as a failed
+             * mapping always did -- on the socket if it had no queue yet,
+             * on the one it already has otherwise.  Refusing the message
+             * outright would let a forged PROCESS_READY carrying a bad
+             * descriptor keep the process from ever being marked ready.
+             */
+            nxt_log(task, NXT_LOG_WARN, "process %PI ready: cannot map the "
+                    "queue, leaving the port as it was", msg->port_msg.pid);
         }
     }
 

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -407,6 +407,7 @@ nxt_int_t nxt_port_send_port(nxt_task_t *task, nxt_port_t *port,
 void nxt_port_change_log_file(nxt_task_t *task, nxt_runtime_t *rt,
     nxt_uint_t slot, nxt_fd_t fd);
 void nxt_port_remove_notify_others(nxt_task_t *task, nxt_process_t *process);
+void *nxt_port_queue_mmap(nxt_task_t *task, nxt_fd_t fd, size_t size);
 
 void nxt_port_quit_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 void nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -106,8 +106,6 @@ static void nxt_router_greet_controller(nxt_task_t *task,
 
 static nxt_int_t nxt_router_start_app_process(nxt_task_t *task, nxt_app_t *app);
 
-static void nxt_router_new_port_handler(nxt_task_t *task,
-    nxt_port_recv_msg_t *msg);
 static void nxt_router_conf_data_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 static void nxt_router_app_restart_handler(nxt_task_t *task,
@@ -676,7 +674,7 @@ nxt_request_rpc_data_unlink(nxt_task_t *task,
 }
 
 
-static void
+void
 nxt_router_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 {
     nxt_int_t      res;
@@ -709,12 +707,34 @@ nxt_router_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     } else {
         if (msg->fd[1] != -1) {
             res = nxt_router_port_queue_map(task, port, msg->fd[1]);
-            if (nxt_slow_path(res != NXT_OK)) {
-                return;
-            }
+
+            /*
+             * Closed whether or not the mapping succeeded: the mapping does
+             * not keep the descriptor, and the dispatcher reclaims nothing a
+             * handler leaves behind.  The size check above is what makes this
+             * matter -- it lets a peer choose to be refused, so the failure
+             * return below handed that peer a descriptor of ours per message,
+             * which is the exhaustion the check exists to prevent.
+             *
+             * The return itself is left alone.  It also walks past the RPC
+             * dispatch below, so a refused queue leaves the pending start
+             * outstanding, and the port stays registered although a port
+             * whose queue was refused can never be reached.  Both are worth
+             * fixing and neither is fixable here: the port this handler is
+             * holding may be one nxt_port_new_port_handler() just created or
+             * one that was already live and serving, and nothing at this call
+             * site can tell them apart -- so failing the start or releasing
+             * the port would, for a forged duplicate NEW_PORT, do it to a
+             * working application port.  That needs the two handlers to agree
+             * on provenance first; see #223.
+             */
 
             nxt_fd_close(msg->fd[1]);
             msg->fd[1] = -1;
+
+            if (nxt_slow_path(res != NXT_OK)) {
+                return;
+            }
         }
     }
 
@@ -2751,9 +2771,8 @@ nxt_router_port_queue_map(nxt_task_t *task, nxt_port_t *port, nxt_fd_t fd)
 
     nxt_assert(fd != -1);
 
-    mem = nxt_mem_mmap(NULL, sizeof(nxt_port_queue_t),
-                       PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    if (nxt_slow_path(mem == MAP_FAILED)) {
+    mem = nxt_port_queue_mmap(task, fd, sizeof(nxt_port_queue_t));
+    if (nxt_slow_path(mem == NULL)) {
 
         return NXT_ERROR;
     }

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -262,6 +262,9 @@ void nxt_router_access_log_use(nxt_thread_spinlock_t *lock,
     nxt_router_access_log_t *access_log);
 void nxt_router_access_log_release(nxt_task_t *task,
     nxt_thread_spinlock_t *lock, nxt_router_access_log_t *access_log);
+/* Not static so the descriptor-ownership test can drive it directly. */
+void nxt_router_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
+
 void nxt_router_access_log_reopen_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 

--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -177,6 +177,72 @@ fail:
     return NXT_ERROR;
 }
 
+
+/*
+ * Hand the handler a descriptor too short for the queue.  mmap() succeeds
+ * on it, so nothing fails until the first access past the object's last
+ * page, which raises SIGBUS in the process that mapped it -- main or the
+ * prototype.  The handler has to refuse the descriptor and keep the queue
+ * it already had.
+ */
+static nxt_int_t
+nxt_port_ready_test_short_queue(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_port_t *port)
+{
+    void                       *prev_queue;
+    nxt_fd_t                   fd, prev_fd;
+    volatile nxt_port_queue_t  *queue;
+
+    fd = syscall(SYS_memfd_create, "nxt_port_ready_test", MFD_CLOEXEC);
+    if (fd == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to create the queue");
+        return NXT_ERROR;
+    }
+
+    /*
+     * One page: mmap() of the whole queue over it succeeds, and every byte
+     * beyond it faults.
+     */
+    if (ftruncate(fd, nxt_pagesize) == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to size the queue");
+        (void) close(fd);
+        return NXT_ERROR;
+    }
+
+    prev_fd = port->queue_fd;
+    prev_queue = port->queue;
+
+    msg->fd[0] = fd;
+    msg->fd[1] = -1;
+
+    nxt_port_process_ready_handler(task, msg);
+
+    if (port->queue != prev_queue || port->queue_fd != prev_fd) {
+        nxt_log_alert(thr->log, "port ready test: short queue replaced the "
+                      "installed one");
+        return NXT_ERROR;
+    }
+
+    if (msg->fd[0] != -1 || nxt_port_ready_test_fd_is_open(fd)) {
+        nxt_log_alert(thr->log, "port ready test: short queue leaked its "
+                      "descriptor");
+        return NXT_ERROR;
+    }
+
+    /*
+     * Touch the last item of the queue the port holds, the way
+     * nxt_port_queue_send() would, to prove the mapping the port kept is
+     * backed all the way to its end.  The check above already catches a
+     * handler that installs the short mapping, and catches it before this
+     * access, which on such a handler takes SIGBUS and kills the test
+     * binary -- verified by moving this access ahead of the check.
+     */
+    queue = port->queue;
+    queue->items[NXT_PORT_QUEUE_SIZE - 1].size = 0;
+
+    return NXT_OK;
+}
+
 #endif
 
 
@@ -297,6 +363,11 @@ nxt_port_ready_test(nxt_thread_t *thr)
     }
 
     ret = nxt_port_ready_test_queue(thr, task, &msg, port, "replacing ready");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    ret = nxt_port_ready_test_short_queue(thr, task, &msg, port);
 
 #endif
 

--- a/src/test/nxt_router_new_port_test.c
+++ b/src/test/nxt_router_new_port_test.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for descriptor ownership in
+ * nxt_router_new_port_handler() (src/nxt_router.c).
+ *
+ * An application NEW_PORT carries the worker's socket in fd[0] and the
+ * queue it wants the router to map in fd[1].  The router maps the queue
+ * and closes fd[1] afterwards -- but the failure branch of that mapping
+ * used to return before the close, leaking the descriptor.
+ *
+ * That branch used to need the router to be out of address space, which is
+ * why it went unnoticed.  Since the queue object is validated for size, a
+ * peer decides when it is taken: it hands over a short object and the
+ * router refuses it.  The dispatcher reclaims nothing once a handler has
+ * returned (see nxt_port_recv_msg_close_fds()), so each refusal cost the
+ * router a descriptor, which is the exhaustion the validation exists to
+ * prevent.
+ *
+ * The port keeps fd[0]: it is the port's socket, and the port outlives the
+ * message.  Only fd[1] is the message's to lose.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_queue.h>
+#include <nxt_runtime.h>
+#include <nxt_router.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#if (NXT_HAVE_MEMFD_CREATE)
+#include <linux/memfd.h>
+#include <sys/syscall.h>
+#endif
+
+
+#if (NXT_HAVE_MEMFD_CREATE)
+
+static nxt_bool_t
+nxt_router_new_port_test_fd_is_open(nxt_fd_t fd)
+{
+    return fcntl(fd, F_GETFD) != -1;
+}
+
+#endif
+
+
+nxt_int_t
+nxt_router_new_port_test(nxt_thread_t *thr)
+{
+#if !(NXT_HAVE_MEMFD_CREATE)
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "router new port test skipped: no memfd_create()");
+    return NXT_OK;
+
+#else
+
+    nxt_mp_t                 *mp;
+    nxt_fd_t                 sock, queue;
+    nxt_buf_t                buf;
+    nxt_task_t               *task;
+    nxt_int_t                ret;
+    nxt_port_t               *port;
+    nxt_runtime_t            *rt, *saved_rt;
+    nxt_event_engine_t       engine;
+    nxt_port_recv_msg_t      msg;
+    nxt_port_msg_new_port_t  new_port;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router new port test started");
+
+    ret = NXT_ERROR;
+    sock = -1;
+    queue = -1;
+    port = NULL;
+
+    task = thr->task;
+    task->thread = thr;
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    if (nxt_slow_path(rt == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * The minimal engine nxt_port_write_enable() needs, as
+     * nxt_port_fail_test.c injects one: only fast_work_queue is set up, so
+     * a path that reaches another member would read garbage.  The handler
+     * under test does not get that far.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+
+    saved_rt = thr->runtime;
+    thr->runtime = rt;
+    thr->engine = &engine;
+
+    /*
+     * Releasing the port's last reference reaches nxt_runtime_process_release(),
+     * which frees inline when task->thread->engine is rt->main_engine and
+     * otherwise posts the free to that engine -- NULL here, and a posted work
+     * item would outlive this stack frame anyway.  Pointing it at the fixture's
+     * own engine keeps the teardown synchronous.
+     */
+    rt->main_engine = &engine;
+
+    /*
+     * A short queue: mmap() of the whole object over it would succeed and
+     * fault later, so the size check has to refuse it here.
+     */
+    queue = syscall(SYS_memfd_create, "nxt_router_new_port_test", MFD_CLOEXEC);
+    sock = open("/dev/null", O_RDONLY);
+
+    if (queue == -1 || sock == -1) {
+        nxt_log_alert(thr->log, "router new port test failed to open the "
+                      "descriptors");
+        goto done;
+    }
+
+    if (ftruncate(queue, nxt_pagesize) == -1) {
+        nxt_log_alert(thr->log, "router new port test failed to size the "
+                      "queue");
+        goto done;
+    }
+
+    nxt_memzero(&new_port, sizeof(nxt_port_msg_new_port_t));
+
+    new_port.pid = nxt_pid + 1;
+    new_port.id = 1;
+    new_port.type = NXT_PROCESS_APP;
+    new_port.max_size = 1024;
+    new_port.max_share = 1024;
+
+    nxt_memzero(&buf, sizeof(nxt_buf_t));
+
+    buf.mem.pos = (u_char *) &new_port;
+    buf.mem.free = buf.mem.pos + sizeof(nxt_port_msg_new_port_t);
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    msg.buf = &buf;
+    msg.fd[0] = sock;
+    msg.fd[1] = queue;
+
+    /* stream 0: the handler returns after the refusal, without RPC. */
+    msg.port_msg.stream = 0;
+    msg.port_msg.pid = new_port.pid;
+
+    nxt_router_new_port_handler(task, &msg);
+
+    if (msg.fd[1] != -1 || nxt_router_new_port_test_fd_is_open(queue)) {
+        nxt_log_alert(thr->log, "router new port test: a refused queue "
+                      "leaked its descriptor");
+        goto done;
+    }
+
+    queue = -1;
+
+    if (msg.fd[0] != -1) {
+        nxt_log_alert(thr->log, "router new port test: the port did not take "
+                      "the socket");
+        goto done;
+    }
+
+    /*
+     * The port owns the socket now, so the test must not close it directly
+     * -- but the port itself is the fixture's to release: it is registered
+     * in rt->ports and holds both the descriptor and its own pool, and
+     * destroying only the runtime pool below would leak them for the rest
+     * of the test binary.
+     */
+    sock = -1;
+    port = msg.u.new_port;
+
+    ret = NXT_OK;
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router new port test passed");
+
+done:
+
+    if (queue != -1) {
+        (void) close(queue);
+    }
+
+    if (sock != -1) {
+        (void) close(sock);
+    }
+
+    if (port != NULL) {
+        /*
+         * Through the ownership path, not by destroying the pool directly:
+         * nxt_port_mp_cleanup() asserts that the descriptors are gone and
+         * the use count is zero, so a direct nxt_mp_destroy() aborts a debug
+         * build even though it looks clean in a release one.  close() clears
+         * pair[1]; remove() drops the rt->ports reference, which is the last
+         * one, and the port is freed there.
+         */
+        nxt_port_close(task, port);
+        nxt_runtime_port_remove(task, port);
+    }
+
+    thr->runtime = saved_rt;
+    thr->engine = NULL;
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+
+#endif
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -197,6 +197,9 @@ main(int argc, char **argv)
     if (nxt_port_ready_test(thr) != NXT_OK) {
         return 1;
     }
+    if (nxt_router_new_port_test(thr) != NXT_OK) {
+        return 1;
+    }
 
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -73,6 +73,7 @@ nxt_int_t nxt_http_route_addr_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_mmap_range_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_ready_test(nxt_thread_t *thr);
+nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);


### PR DESCRIPTION
Stacked on #208 — base is `fix/ipc-fd-and-ready-auth`, so the diff here is
this change alone. Retarget to `master` once #208 merges.

`mmap()` succeeds on a descriptor whose object is shorter than the mapped
length, and the first access past its last page raises SIGBUS. Three sites
map a peer-supplied descriptor as a port queue, so a forged message with a
one-page memfd faults the receiver — main, the prototype or the router.

An `fstat()` before the mapping refuses a descriptor that cannot hold the
queue. The three sites now share one helper.

## Short, not different

The check refuses only a **short** object, not a differing one. Both
producers `ftruncate()` the queue to exactly the mapped size, but `fstat()`
does not have to report that back: a POSIX shm object is rounded up to a
page on some systems, and `sizeof(nxt_port_queue_t)` (655380) is not a
whole number of pages. Requiring equality would refuse every legitimate
queue on those platforms — and in `nxt_router_port_queue_map()` that
returns `NXT_ERROR`, so `nxt_router_new_port_handler()` returns early and
the application's port never finishes being set up.

`nxt_port_incoming_port_mmap()` gets away with exact equality because
`PORT_MMAP_SIZE` *is* a page multiple. That does not generalise to this
size.

## What this does and does not buy

It validates; it does not close the hole. The sender keeps the descriptor
and can shrink the object after the check, and the receiver cannot seal
against that — `nxt_shm_open()` creates the memfd without
`MFD_ALLOW_SEALING`, and a forged queue simply omits the flag. Against a
live compromised worker this adds one `ftruncate()` call to the attack.

What it does buy: a queue that cannot work is refused where it is handed
over, with a log line naming the descriptor, instead of faulting at an
arbitrary later access — and parity with the segment check. Actually
closing it needs the senders to seal the object and the receiver to
require the seal, with a compatibility window for older libunit. Not this
commit.

## Scope

Not a regression, not a fix for any published advisory, not
release-blocking for 1.36.1. Reachable only from a peer that is already
compromised.

## Tests

`nxt_port_ready_test_short_queue()` hands the handler a one-page memfd
against a 655380-byte queue and asserts the port keeps its previous queue
and the short descriptor is closed. The SIGBUS was reproduced directly:
mapping 655380 bytes over a 4096-byte memfd succeeds, and writing at
offset 655379 dies with SIGBUS. The committed test asserts before it
probes, so a regression reports cleanly rather than killing the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMTKtFcf3YhmBPvTSKTkfg