### PR TITLE
port: close the descriptors NEW_PORT and MMAP leave behind

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -180,6 +180,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_port_ready_test.c \
     src/test/nxt_router_new_port_test.c \
     src/test/nxt_port_change_file_test.c \
+    src/test/nxt_port_fd_test.c \
 "
 
 

--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -67,6 +67,8 @@ static u_char *nxt_cstr_dup(nxt_mp_t *mp, u_char *dst, u_char *src);
 static void nxt_proto_signal_handler(nxt_task_t *task, void *obj, void *data);
 static void nxt_proto_sigterm_handler(nxt_task_t *task, void *obj, void *data);
 static void nxt_proto_sigchld_handler(nxt_task_t *task, void *obj, void *data);
+static void nxt_app_new_port_handler(nxt_task_t *task,
+    nxt_port_recv_msg_t *msg);
 
 
 nxt_str_t  nxt_server = nxt_string(NXT_SERVER);
@@ -87,7 +89,7 @@ static nxt_common_app_conf_t  *nxt_app_conf;
 
 static const nxt_port_handlers_t  nxt_discovery_process_port_handlers = {
     .quit         = nxt_signal_quit_handler,
-    .new_port     = nxt_port_new_port_handler,
+    .new_port     = nxt_app_new_port_handler,
     .change_file  = nxt_port_change_log_file_handler,
     .mmap         = nxt_port_mmap_handler,
     .data         = nxt_port_data_handler,
@@ -110,7 +112,7 @@ const nxt_sig_event_t  nxt_prototype_signals[] = {
 static const nxt_port_handlers_t  nxt_proto_process_port_handlers = {
     .quit            = nxt_proto_quit_handler,
     .change_file     = nxt_port_change_log_file_handler,
-    .new_port        = nxt_port_new_port_handler,
+    .new_port        = nxt_app_new_port_handler,
     .process_created = nxt_proto_process_created_handler,
     .process_ready   = nxt_port_process_ready_handler,
     .remove_pid      = nxt_port_remove_pid_handler,
@@ -159,6 +161,23 @@ const nxt_process_init_t  nxt_app_process = {
     .port_handlers  = &nxt_app_process_port_handlers,
     .signals        = nxt_process_signals,
 };
+
+
+/*
+ * nxt_port_new_port_handler() hands the queue descriptor of a newly created
+ * port to its caller, because only the caller knows whether this process
+ * maps port queues.  Neither the discovery nor the prototype process does,
+ * so both used the base handler directly and kept every queue descriptor
+ * their peer sent open for the life of the process.
+ */
+
+static void
+nxt_app_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
+{
+    nxt_port_new_port_handler(task, msg);
+
+    nxt_port_recv_msg_close_fds(msg);
+}
 
 
 static nxt_int_t

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -411,9 +411,14 @@ static void
 nxt_controller_process_new_port_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg)
 {
+    nxt_port_t  *port;
+
     nxt_port_new_port_handler(task, msg);
 
-    if (msg->u.new_port->type != NXT_PROCESS_ROUTER
+    port = msg->u.new_port;
+
+    if (port == NULL
+        || port->type != NXT_PROCESS_ROUTER
         || !nxt_controller_router_ready)
     {
         return;

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -417,6 +417,12 @@ nxt_controller_process_new_port_handler(nxt_task_t *task,
 
     port = msg->u.new_port;
 
+    /*
+     * The controller never maps a port queue, so the descriptor
+     * nxt_port_new_port_handler() leaves to its caller has no use here.
+     */
+    nxt_port_recv_msg_close_fds(msg);
+
     if (port == NULL
         || port->type != NXT_PROCESS_ROUTER
         || !nxt_controller_router_ready)

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -430,10 +430,16 @@ nxt_main_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         if (nxt_fast_path(mem != NULL)) {
             port->queue = mem;
         }
-
-        nxt_fd_close(msg->fd[1]);
-        msg->fd[1] = -1;
     }
+
+    /*
+     * nxt_port_new_port_handler() leaves the queue descriptor to its caller,
+     * and only a new application port has a use for it here.  Anything else
+     * -- a port that already existed, a port that could not be created, a
+     * type whose queue main never maps -- used to keep the descriptor open
+     * in the most privileged process of all.
+     */
+    nxt_port_recv_msg_close_fds(msg);
 }
 
 

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -350,6 +350,14 @@ nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     rt = task->thread->runtime;
 
+    /*
+     * The message arrives on the stack of nxt_port_read_handler() with the
+     * union uninitialized, and every caller of this handler reads
+     * msg->u.new_port on return, so a path that creates no port has to say
+     * so rather than leave the garbage the stack happened to hold.
+     */
+    msg->u.new_port = NULL;
+
     new_port_msg = (nxt_port_msg_new_port_t *) msg->buf->mem.pos;
 
     /* TODO check b size and make plain */

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -257,22 +257,37 @@ nxt_port_enable(nxt_task_t *task, nxt_port_t *port,
 static void
 nxt_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 {
-    nxt_port_handler_t  *handlers;
+    nxt_port_handler_t  handler, *handlers;
 
     if (nxt_fast_path(msg->port_msg.type < NXT_PORT_MSG_MAX)) {
 
-        nxt_debug(task, "port %d: message type:%uD fds:%d,%d",
-                  msg->port->socket.fd, msg->port_msg.type,
-                  msg->fd[0], msg->fd[1]);
-
         handlers = msg->port->data;
-        handlers[msg->port_msg.type](task, msg);
+        handler = handlers[msg->port_msg.type];
 
-        return;
+        /*
+         * The tables are designated initializers over a struct of named
+         * slots, and most of them set only a few: an in-range type whose
+         * slot the receiving process never filled is NULL, not a handler.
+         */
+        if (nxt_fast_path(handler != NULL)) {
+            nxt_debug(task, "port %d: message type:%uD fds:%d,%d",
+                      msg->port->socket.fd, msg->port_msg.type,
+                      msg->fd[0], msg->fd[1]);
+
+            handler(task, msg);
+
+            return;
+        }
     }
 
     nxt_alert(task, "port %d: unknown message type:%uD",
               msg->port->socket.fd, msg->port_msg.type);
+
+    /*
+     * The type is a byte off the wire, so any peer can name one that has
+     * no handler.  Nothing runs to take the descriptors it attached.
+     */
+    nxt_port_recv_msg_close_fds(msg);
 }
 
 
@@ -372,8 +387,36 @@ nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
         msg->u.new_port = port;
 
-        nxt_fd_close(msg->fd[0]);
-        msg->fd[0] = -1;
+        /* The socket is refused: the port keeps the pair it was built with. */
+        if (msg->fd[0] != -1) {
+            nxt_fd_close(msg->fd[0]);
+            msg->fd[0] = -1;
+        }
+
+        /*
+         * The queue descriptor is left to the caller unless the port has a
+         * queue already.  An existing port without one is not an anomaly
+         * but the normal path in the main process:
+         * nxt_main_process_whoami_handler() creates every application port
+         * at WHOAMI time, before the NEW_PORT
+         * announcing that same port -- and its queue -- arrives, so this
+         * branch is the only place main can ever be handed the queue of a
+         * worker.  Refusing fd[1] here outright leaves port->queue NULL, and
+         * a queueless sender falls back to a plain socket write that libunit
+         * parks waiting for a READ_SOCKET marker which never comes, stranding
+         * every CHANGE_FILE and QUIT main sends to its workers.
+         *
+         * A port that already has a queue does refuse the descriptor: mapping
+         * it again would re-point a live port's queue at memory this message
+         * chose, dropping the mapping the port was built with.  Every caller
+         * maps fd[1] only while it is still set, so clearing it here
+         * suppresses that without racing them.
+         */
+        if (port->queue != NULL && msg->fd[1] != -1) {
+            nxt_fd_close(msg->fd[1]);
+            msg->fd[1] = -1;
+        }
+
         return;
     }
 
@@ -381,6 +424,7 @@ nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
                                            new_port_msg->id,
                                            new_port_msg->type);
     if (nxt_slow_path(port == NULL)) {
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -400,6 +444,15 @@ nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_port_write_enable(task, port);
 
     msg->u.new_port = port;
+
+    /*
+     * fd[1] is deliberately left in the message: it is the queue of the
+     * port just created, and only the caller knows whether this process
+     * maps port queues at all and with which size.  The same applies on
+     * the branch above when the port exists but has no queue yet.  Every
+     * caller therefore has to close it once it is done -- which is why the
+     * refusing paths clear it instead, so that "still set" means "yours".
+     */
 }
 
 /* TODO move to nxt_main_process.c */
@@ -529,6 +582,11 @@ nxt_port_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     if (nxt_slow_path(msg->fd[0] == -1)) {
         nxt_log(task, NXT_LOG_WARN, "invalid fd passed with mmap message");
 
+        /*
+         * A message can carry two descriptors whichever its type needs, so
+         * a missing fd[0] does not mean the message carried nothing.
+         */
+        nxt_port_recv_msg_close_fds(msg);
         return;
     }
 
@@ -559,7 +617,12 @@ nxt_port_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
 fail_close:
 
-    nxt_fd_close(msg->fd[0]);
+    /*
+     * nxt_port_incoming_port_mmap() maps the segment rather than keeping the
+     * descriptor, so fd[0] is released on the success path too.  fd[1] is
+     * never used by this handler and was leaked on every one of them.
+     */
+    nxt_port_recv_msg_close_fds(msg);
 }
 
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -690,13 +690,24 @@ nxt_router_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         nxt_router_greet_controller(task, msg->u.new_port);
     }
 
+    /*
+     * The router maps a queue for application ports only, so every other
+     * branch below has to release the queue descriptor that
+     * nxt_port_new_port_handler() left behind.  None of the RPC handlers
+     * reachable from here reads msg->fd, so closing before dispatching them
+     * takes nothing away.
+     */
+
     if (port != NULL && port->type == NXT_PROCESS_PROTOTYPE)  {
+        nxt_port_recv_msg_close_fds(msg);
+
         nxt_port_rpc_handler(task, msg);
 
         return;
     }
 
     if (port == NULL || port->type != NXT_PROCESS_APP) {
+        nxt_port_recv_msg_close_fds(msg);
 
         if (msg->port_msg.stream == 0) {
             return;

--- a/src/test/nxt_port_fd_test.c
+++ b/src/test/nxt_port_fd_test.c
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for descriptor ownership in nxt_port_new_port_handler()
+ * and nxt_port_mmap_handler() (src/nxt_port.c).
+ *
+ * A port message can carry two descriptors whatever its type normally uses
+ * -- nxt_socket_msg_oob_get() accepts an SCM_RIGHTS payload of one or two --
+ * and the dispatcher does not reclaim them once the handler returns.  Every
+ * handler therefore has to release what it does not consume, and clear the
+ * slot of what it does.  Both handlers here ignored fd[1] entirely, and
+ * nxt_port_mmap_handler() returned from its "invalid fd" guard without
+ * closing anything at all, so a peer attaching descriptors to forged
+ * messages could exhaust the descriptor table of the router or, through the
+ * NEW_PORT path, of the main process.
+ *
+ * This lives beside nxt_port_ready_test.c rather than inside it: that test
+ * builds a fixture for a single handler and walks its reject paths, while
+ * these two handlers need a port hash and a message body instead.  The
+ * dispatcher (nxt_port_handler()) is covered here too: a type past the
+ * table, and an in-range type whose slot the handler table never filled,
+ * both have to close what the message carried without calling anything.
+ *
+ * The one path this cannot reach is nxt_runtime_process_port_create()
+ * returning NULL, which needs an allocation failure the test harness has no
+ * way to inject.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_queue.h>
+#include <nxt_runtime.h>
+#include "nxt_tests.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+
+
+static nxt_uint_t  nxt_port_fd_test_dispatched;
+
+
+static void
+nxt_port_fd_test_enable_read_stub(nxt_event_engine_t *engine,
+    nxt_fd_event_t *ev)
+{
+    /* The fixture engine polls nothing. */
+}
+
+
+/*
+ * A handler that honours the dispatch contract: consume or close what the
+ * message carries.  Used to pin that the NULL-slot guard does not swallow
+ * types whose slot is set.
+ */
+static void
+nxt_port_fd_test_dispatch_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
+{
+    nxt_port_fd_test_dispatched++;
+
+    nxt_port_recv_msg_close_fds(msg);
+}
+
+
+static const nxt_port_handlers_t  nxt_port_fd_test_handlers = {
+    .quit = nxt_port_fd_test_dispatch_handler,
+};
+
+
+static nxt_bool_t
+nxt_port_fd_test_is_open(nxt_fd_t fd)
+{
+    return fcntl(fd, F_GETFD) != -1;
+}
+
+
+static void
+nxt_port_fd_test_close(nxt_fd_t fd)
+{
+    if (fd != -1 && nxt_port_fd_test_is_open(fd)) {
+        (void) close(fd);
+    }
+}
+
+
+/*
+ * Attach two descriptors to the message, run the handler, and expect it to
+ * have released both: neither of these handlers keeps a descriptor of its
+ * own beyond the call.
+ */
+static nxt_int_t
+nxt_port_fd_test_closed(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg,
+    void (*handler)(nxt_task_t *task, nxt_port_recv_msg_t *msg),
+    nxt_bool_t first_fd, const char *name)
+{
+    nxt_fd_t  fd0, fd1;
+
+    fd0 = first_fd ? open("/dev/null", O_RDONLY) : -1;
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if ((first_fd && fd0 == -1) || fd1 == -1) {
+        nxt_log_alert(thr->log, "port fd test failed to open /dev/null");
+        goto fail;
+    }
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    handler(task, msg);
+
+    if ((first_fd && nxt_port_fd_test_is_open(fd0))
+        || nxt_port_fd_test_is_open(fd1))
+    {
+        nxt_log_alert(thr->log, "port fd test: %s leaked a descriptor", name);
+        goto fail;   /* closes only what is still open */
+    }
+
+    if (msg->fd[0] != -1 || msg->fd[1] != -1) {
+        nxt_log_alert(thr->log, "port fd test: %s left fds in the message",
+                      name);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+
+fail:
+
+    /*
+     * Close only what the handler left open: a descriptor it consumed is
+     * gone already, and closing the number again could reach an unrelated
+     * descriptor that has reused it.
+     */
+    nxt_port_fd_test_close(fd0);
+    nxt_port_fd_test_close(fd1);
+
+    return NXT_ERROR;
+}
+
+
+nxt_int_t
+nxt_port_fd_test(nxt_thread_t *thr)
+{
+    nxt_mp_t                 *mp;
+    nxt_buf_t                *b;
+    nxt_fd_t                 fd0, fd1;
+    nxt_task_t               *task;
+    nxt_int_t                ret;
+    nxt_port_t               *port, *existing;
+    nxt_runtime_t            *rt, *saved_rt;
+    nxt_port_recv_msg_t      msg;
+    nxt_event_engine_t       *engine, *saved_engine;
+    nxt_port_msg_new_port_t  new_port_msg;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "port fd test started");
+
+    task = thr->task;
+    task->thread = thr;
+
+    /* Defined before the first goto done: the cleanup there releases them. */
+    port = NULL;
+    existing = NULL;
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    engine = nxt_mp_zalloc(mp, sizeof(nxt_event_engine_t));
+    b = nxt_mp_zalloc(mp, sizeof(nxt_buf_t));
+
+    if (nxt_slow_path(rt == NULL || engine == NULL || b == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+
+    thr->runtime = rt;
+
+    /*
+     * nxt_port_write_enable() takes the address of a work queue inside the
+     * engine, so a zeroed one is enough to reach the end of the handler.
+     */
+    thr->engine = engine;
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    /*
+     * The mmap handler refuses a message without a segment descriptor.  The
+     * refusal used to return without closing the second descriptor, which
+     * the sender is free to attach regardless of the message type.
+     */
+    ret = nxt_port_fd_test_closed(thr, task, &msg, nxt_port_mmap_handler, 0,
+                                  "mmap without a segment fd");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * A segment announced by a process the runtime does not know: the
+     * handler releases the segment descriptor on that path but used to keep
+     * the second one.
+     */
+    msg.port_msg.pid = nxt_pid + 1;
+
+    ret = nxt_port_fd_test_closed(thr, task, &msg, nxt_port_mmap_handler, 1,
+                                  "mmap from an unknown process");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * NEW_PORT naming a port that exists but has no queue yet.  This is
+     * the normal path in the main process -- WHOAMI creates every
+     * application port before its NEW_PORT arrives -- so the socket is
+     * refused, but the queue descriptor has to reach the caller: closing
+     * it here would leave main's worker ports queueless and strand every
+     * CHANGE_FILE and QUIT main sends through them.
+     */
+    nxt_memzero(&new_port_msg, sizeof(nxt_port_msg_new_port_t));
+
+    new_port_msg.pid = nxt_pid + 2;
+    new_port_msg.id = 7;
+    new_port_msg.type = NXT_PROCESS_APP;
+
+    b->mem.pos = (u_char *) &new_port_msg;
+    msg.buf = b;
+
+    existing = nxt_runtime_process_port_create(task, rt, new_port_msg.pid,
+                                               new_port_msg.id,
+                                               new_port_msg.type);
+    if (nxt_slow_path(existing == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    existing->pair[0] = -1;
+    existing->pair[1] = -1;
+    existing->socket.fd = -1;
+
+    fd0 = open("/dev/null", O_RDONLY);
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (nxt_slow_path(fd0 == -1 || fd1 == -1)) {
+        nxt_log_alert(thr->log, "port fd test failed to open /dev/null");
+        nxt_port_fd_test_close(fd0);
+        nxt_port_fd_test_close(fd1);
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    msg.fd[0] = fd0;
+    msg.fd[1] = fd1;
+    msg.u.new_port = NULL;
+
+    nxt_port_new_port_handler(task, &msg);
+
+    if (nxt_slow_path(msg.u.new_port != existing)) {
+        nxt_log_alert(thr->log, "port fd test: an existing port was not "
+                      "reported back to the caller");
+        nxt_port_fd_test_close(fd0);
+        nxt_port_fd_test_close(fd1);
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    if (nxt_slow_path(msg.fd[0] != -1 || nxt_port_fd_test_is_open(fd0))) {
+        nxt_log_alert(thr->log, "port fd test: an existing port did not "
+                      "refuse the socket");
+        nxt_port_fd_test_close(fd1);
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    if (nxt_slow_path(msg.fd[1] != fd1 || !nxt_port_fd_test_is_open(fd1))) {
+        nxt_log_alert(thr->log, "port fd test: the queue descriptor of a "
+                      "queueless existing port was not left to the caller");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    nxt_port_fd_test_close(fd1);
+    msg.fd[1] = -1;
+
+    /*
+     * NEW_PORT naming a port whose queue is already installed.  Here the
+     * queue descriptor is refused with the socket: a caller that mapped
+     * fd[1] would re-point a live port's queue at memory this message
+     * chose.  The mapping is a real one so that the cleanup below releases
+     * it the same way nxt_port_close() releases any port queue.
+     */
+    existing->queue = mmap(NULL, sizeof(nxt_port_queue_t),
+                           PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (nxt_slow_path(existing->queue == MAP_FAILED)) {
+        existing->queue = NULL;
+        nxt_log_alert(thr->log, "port fd test failed to map a queue");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    msg.u.new_port = NULL;
+
+    ret = nxt_port_fd_test_closed(thr, task, &msg, nxt_port_new_port_handler,
+                                  1, "new port that already has a queue");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    if (nxt_slow_path(msg.u.new_port != existing)) {
+        nxt_log_alert(thr->log, "port fd test: an existing port was not "
+                      "reported back to the caller");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    /*
+     * The one path that keeps a descriptor: a port is created, it adopts
+     * the socket, and the queue descriptor is deliberately left in the
+     * message for the caller to map or discard.  Pinned here because every
+     * caller now treats "fd[1] still set" as "this one is mine".
+     */
+    new_port_msg.id = 8;
+
+    fd0 = open("/dev/null", O_RDONLY);
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (nxt_slow_path(fd0 == -1 || fd1 == -1)) {
+        nxt_log_alert(thr->log, "port fd test failed to open /dev/null");
+        nxt_port_fd_test_close(fd0);
+        nxt_port_fd_test_close(fd1);
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    msg.fd[0] = fd0;
+    msg.fd[1] = fd1;
+    msg.u.new_port = NULL;
+
+    nxt_port_new_port_handler(task, &msg);
+
+    port = msg.u.new_port;
+
+    if (nxt_slow_path(port == NULL || port == existing)) {
+        nxt_log_alert(thr->log, "port fd test: a new port was not created");
+        nxt_port_fd_test_close(fd0);
+        nxt_port_fd_test_close(fd1);
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    if (nxt_slow_path(msg.fd[0] != -1 || port->pair[1] != fd0)) {
+        nxt_log_alert(thr->log, "port fd test: the new port did not take the "
+                      "socket over");
+        nxt_port_fd_test_close(fd1);
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    if (nxt_slow_path(msg.fd[1] != fd1 || !nxt_port_fd_test_is_open(fd1))) {
+        nxt_log_alert(thr->log, "port fd test: the queue descriptor was not "
+                      "left to the caller");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    nxt_port_fd_test_close(fd1);
+    msg.fd[1] = -1;
+
+    /*
+     * The dispatcher itself.  The message type is a byte off the wire, so a
+     * peer can name one past the table -- or, just as easily, an in-range
+     * one whose slot this process never filled: the tables are designated
+     * initializers over a struct of named members, and most set only a few.
+     * Neither may call anything, and both have to close what the message
+     * carried, since no handler runs to take the descriptors.
+     *
+     * nxt_port_enable() installs the (static) dispatcher on the port; the
+     * fixture engine gets a no-op enable_read so that the read side of the
+     * enabling touches nothing real.
+     */
+    engine->event.enable_read = nxt_port_fd_test_enable_read_stub;
+
+    nxt_port_enable(task, port, &nxt_port_fd_test_handlers);
+
+    msg.port = port;
+
+    msg.port_msg.type = NXT_PORT_MSG_MAX;
+
+    ret = nxt_port_fd_test_closed(thr, task, &msg, port->handler, 1,
+                                  "message type past the handler table");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    msg.port_msg.type = _NXT_PORT_MSG_NEW_PORT;    /* slot not set above */
+
+    ret = nxt_port_fd_test_closed(thr, task, &msg, port->handler, 1,
+                                  "message type with an empty handler slot");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_port_fd_test_dispatched != 0)) {
+        nxt_log_alert(thr->log, "port fd test: a refused type reached a "
+                      "handler");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    /* And a slot that is set still dispatches. */
+    msg.port_msg.type = _NXT_PORT_MSG_QUIT;
+
+    ret = nxt_port_fd_test_closed(thr, task, &msg, port->handler, 1,
+                                  "message type with its slot set");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_port_fd_test_dispatched != 1)) {
+        nxt_log_alert(thr->log, "port fd test: a handled type did not reach "
+                      "its handler");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    ret = NXT_OK;
+
+done:
+
+    /*
+     * The ports hold what their handlers adopted -- the new port its socket
+     * descriptor, the existing one its queue mapping -- and nothing else
+     * owns them here: leaving them to the pool teardown would leak both.
+     *
+     * close() releases those, but not the port: each one carries its own
+     * memory pool and a reference held by rt->ports, neither of which the
+     * nxt_mp_destroy() below can reach.  remove() drops that reference,
+     * which is the last one, and frees the port -- so it has to happen
+     * while the fixture runtime is still installed.
+     */
+    if (existing != NULL) {
+        nxt_port_close(task, existing);
+        nxt_runtime_port_remove(task, existing);
+    }
+
+    if (port != NULL) {
+        nxt_port_close(task, port);
+        nxt_runtime_port_remove(task, port);
+    }
+
+    thr->runtime = saved_rt;
+    thr->engine = saved_engine;
+
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    if (nxt_fast_path(ret == NXT_OK)) {
+        nxt_thread_time_update(thr);
+        nxt_log_error(NXT_LOG_NOTICE, thr->log, "port fd test passed");
+    }
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -205,6 +205,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_port_fd_test(thr) != NXT_OK) {
+        return 1;
+    }
+
 #if (NXT_HAVE_CGROUP)
     if (nxt_cgroup_test(thr) != NXT_OK) {
         return 1;

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -75,6 +75,7 @@ nxt_int_t nxt_port_mmap_range_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_ready_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
+nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);
 


### PR DESCRIPTION
Depended on #211, which landed the descriptor close on the router's
queue-map failure path; that branch is deliberately untouched here. #211 is
now merged (`6757ce6b`) and this branch is rebased onto it.

**This previously said "do not merge before 1.36.1 is tagged". That note is
withdrawn, because #211's merge inverted the reasoning behind it.**

With #211 in and this out, master carries a *reachable* queue hijack that
this PR is the fix for. `nxt_router_port_queue_map()` assigns
`port->queue = mem` (`src/nxt_router.c:2780`) with no `munmap()` of a
previous mapping, and it is reachable for a **live** port, because the base
handler's already-exists branch closes only `fd[0]` and leaves `fd[1]` set
for any existing port. So a forged duplicate `NEW_PORT` naming a live
application port re-points its queue and leaks the old mapping. The same
shape exists in main (`src/nxt_main_process.c:425-436`).

This PR closes that upstream of the map site: the exists-branch refuses
`fd[1]` whenever `port->queue != NULL`, and both callers gate their map on
`fd[1] != -1`. `NEW_PORT` is processed on the main thread, so afterwards
neither map site can run against a port that already has a queue.

### Why there is no `munmap()` here

An earlier review suggested adding a `munmap()` before the overwrite in
`nxt_router_port_queue_map()`, "worth fixing regardless". Deliberately not
done, for two reasons. It would be dead code once this lands — the refusal
above means the overwrite is unreachable. And the alternative semantic,
`munmap()` *and accept* the replacement, is worse than the leak: it turns a
mapping leak into a clean re-point of a live port's queue, which is exactly
what needs the port-provenance work tracked in #223 to authorize. The
residue worth having is a `nxt_assert(port->queue == NULL)` in
`nxt_router_port_queue_map()` as documentation of the new invariant, and
that belongs with #223.

### A stale claim in this thread

A force-push comment dated 2026-08-24 says the RPC stranding on the
queue-map failure path was fixed, "it now fails the RPC the way the
port-less branch does". **The final head deliberately reverts that.** A
refused queue still leaves the pending start and its `app_joint` reference
outstanding until the request times out, for the same reason both this PR
and #211 give: the handler cannot distinguish a newly-created port from an
already-live one, so failing the start would damage a working application
port whenever a forged duplicate `NEW_PORT` names it. That needs #223.

## `8ef99c01` — NEW_PORT that creates no port left a stack value behind

`nxt_port_new_port_handler()` assigned `msg->u.new_port` only on the paths
that end with a port. The message lives on the stack of
`nxt_port_read_handler()` and nothing clears it, so when the port already
existed or could not be created, the union held whatever the stack
contained. `nxt_controller_process_new_port_handler()` dereferenced it
unconditionally — a pointer built from stack garbage. Main and the router
check for NULL, which does not help against a non-NULL value that was
never a port, so this affected three processes rather than one.

Separate commit deliberately: it is a wild pointer, not a descriptor leak,
and it has to land first — the new controller wrapper reads the value
before closing anything.

## `227f0ea9` — the descriptor class

A message carries up to two descriptors whatever its type normally uses,
and the dispatcher does not reclaim them after the handler returns.
`nxt_port_mmap_handler()` never closed the second on any path and returned
closing nothing when the first was missing; `nxt_port_new_port_handler()`
closed only the first on the already-exists path and neither on creation
failure; main kept the second for every port that was not a newly created
app port; the router lost it on the branches that map no queue; the
controller never touched it; and the discovery and prototype
processes wired the bare handler, leaving it open for process lifetime.

The invariant is now explicit: **the second descriptor still set on return
means the wrapper owns it**, and it is left set on exactly one path — the
one that creates a port. Every wrapper gates on `!= -1`, and
`nxt_port_recv_msg_close_fds()` clears slots, so no wrapper can close or
map it twice.

The dispatcher now also closes what an unhandled message type brought
along. The type is a byte off the wire, so any peer can name one.

### One behaviour change worth calling out

On the already-exists path the second descriptor is now refused rather
than mapped. Mapping it there installed a queue on a *live* port and
leaked the mapping it replaced — so a repeated NEW_PORT could re-point an
established port at memory of the sender's choosing. One NEW_PORT is sent
per port per peer, and a process never receives one for a port it
inherited across fork, so a second announcement for an existing port is
not a flow this daemon produces. The branch already refused the socket.

Known interaction: #208 deliberately tolerates a repeated PROCESS_READY
(warn and remap), and that path re-broadcasts NEW_PORT. After this change
main remaps its own queue while peers refuse the new descriptor, so the
two diverge on which segment they use. That sequence is already forged or
replayed by #208's own reasoning, but it is a real consequence and not
hidden here.

Codex raised that divergence as a P1. The argument for keeping the refusal
is in the review thread: no legitimate repeated PROCESS_READY carries a
queue (`nxt_unit_ready()` has one call site and the other senders pass -1),
and a worker always reads the queue it mapped itself, so a diverged peer
cannot intercept — only fail to deliver. Accepting the replacement instead
would let a forged direct NEW_PORT re-point any live port. The precondition
is the unauthenticated PROCESS_READY, tracked as its own follow-up.

## Tests

`src/test/nxt_port_fd_test.c`, four cases. Three are regression gates,
each verified to fail against the parent commit hunk-by-hunk: the missing
segment fd, the mmap failure path, and the already-exists path. The fourth
pins the deliberate exception above and **passes with or without the fix**
by design — it is a contract guard, not coverage, and is labelled as such
rather than counted.

Not covered: the `nxt_runtime_process_port_create()` failure path needs an
allocation failure the harness cannot inject, and the three `static`
wrappers are unreachable from it. Those rest on a smoke run — unitd
started, config PUT, `GET :8099` → 204, three reconfigures, descriptor
counts flat, no alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMTKtFcf3YhmBPvTSKTkfg

