### PR TITLE
tls: build against OpenSSL 4.0 and drop the deprecated API it removes next

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,10 @@ env:
   # patch level lives here; the 3.6 "slot" (/opt/openssl-3.6, OPENSSL36_* vars)
   # is stable across patch bumps and intentionally not templated.
   OPENSSL_VERSION: 3.6.2
+  # OpenSSL 4.0 for the openssl4 leg below.  No distribution ships 4.0 yet, so
+  # like the 3.6 slot it is built from source; the /opt/openssl-4.0 slot is
+  # stable across patch bumps.
+  OPENSSL4_VERSION: 4.0.2
 
 jobs:
   # Single source of truth for the test matrix. The version-tested language
@@ -534,3 +538,80 @@ jobs:
 
       - name: Run libunit port_recv fd-ownership test
         run: ./build/unit_port_recv_test
+
+  # OpenSSL 4.0 compile gate.  4.0 removed nothing Unit uses, but it deprecated
+  # more of what Unit still calls, and 5.0 is where the deprecated symbols
+  # actually go away -- so the value here is having a leg that fails when a new
+  # deprecation lands, instead of noticing at removal time.  Deliberately cheap:
+  # a build plus the C test suite, no language modules and no pytest run, since
+  # nothing above the TLS layer changes with the OpenSSL version.
+  openssl4:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install build-essential libpcre2-dev
+
+      - name: Cache OpenSSL 4.0
+        id: cache-openssl4
+        uses: actions/cache@v6
+        with:
+          path: /opt/openssl-4.0
+          key: openssl-${{ env.OPENSSL4_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build OpenSSL 4.0
+        if: steps.cache-openssl4.outputs.cache-hit != 'true'
+        run: |
+          cd /tmp
+          wget -q "https://www.openssl.org/source/openssl-${OPENSSL4_VERSION}.tar.gz"
+          tar -xzf "openssl-${OPENSSL4_VERSION}.tar.gz"
+          cd "openssl-${OPENSSL4_VERSION}"
+          ./Configure --prefix=/opt/openssl-4.0 shared no-docs
+          make -j$(nproc)
+          sudo mkdir -p /opt/openssl-4.0
+          sudo make install_sw
+
+      - name: Set OpenSSL 4.0 build environment
+        # Same isolation as the 3.6 slot: never overwrite the system libraries,
+        # because sudo links against them.
+        run: |
+          OSSL=/opt/openssl-4.0
+          LIBDIR=$( [ -d "$OSSL/lib64" ] && echo "$OSSL/lib64" || echo "$OSSL/lib" )
+          echo "OPENSSL4_INCDIR=${OSSL}/include" >> $GITHUB_ENV
+          echo "OPENSSL4_LIBDIR=${LIBDIR}"        >> $GITHUB_ENV
+
+      - name: Configure unit (--openssl --tests)
+        # LD_LIBRARY_PATH is scoped to this step only so that auto/feature test
+        # binaries load OpenSSL 4.0; exporting it globally would break sudo.
+        # The build itself needs no such help -- -Wl,-rpath below is baked into
+        # the binaries, and is honoured under sudo too.
+        env:
+          LD_LIBRARY_PATH: ${{ env.OPENSSL4_LIBDIR }}
+        run: |
+          ./configure \
+            --tests \
+            --openssl \
+            --cc-opt="-I${OPENSSL4_INCDIR} -DOPENSSL_NO_DEPRECATED" \
+            --ld-opt="-L${OPENSSL4_LIBDIR} -Wl,-rpath,${OPENSSL4_LIBDIR}"
+
+      # Assert rather than print: if the include/lib flags ever stop taking
+      # effect, configure falls back to the runner's system OpenSSL 3.x and the
+      # leg would pass while testing nothing it was added for.
+      - name: Assert configure found OpenSSL 4.0
+        run: |
+          grep NXT_HAVE_OPENSSL_VERSION build/include/nxt_auto_config.h
+          grep -q '#define NXT_HAVE_OPENSSL_VERSION  "OpenSSL 4\.' \
+            build/include/nxt_auto_config.h
+
+      - name: Build unit
+        run: make -j4
+
+      - name: Build C tests
+        run: make -j4 tests
+
+      - name: Run C tests
+        run: sudo ./build/tests

--- a/src/nxt_cert.c
+++ b/src/nxt_cert.c
@@ -19,6 +19,26 @@
 #include <openssl/err.h>
 
 
+/* The buffer X509_NAME_get_text_by_NID() used to be given, less the NUL. */
+#define NXT_CERT_NAME_TEXT_MAX  255
+
+/*
+ * The X509 name accessors were constified in stages, and not together:
+ * X509_NAME_get_entry() and X509_NAME_ENTRY_get_data() took const arguments
+ * from 1.1.0, but X509_NAME_get_index_by_NID() only from 3.0, and it is 4.0
+ * that constified the values all three return.  Qualifying from 3.0 is what
+ * satisfies every version at once -- an older header takes these pointers
+ * non-const, and 4.0 hands them back const -- so the boundary is 3.0 rather
+ * than the 1.1.0 the other guards in this file use.
+ */
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define NXT_X509_CONST  const
+#else
+#define NXT_X509_CONST
+#endif
+
+
 struct nxt_cert_s {
     EVP_PKEY          *key;
     nxt_uint_t        count;
@@ -46,6 +66,8 @@ static int nxt_nxt_cert_pem_suffix(char *pem_str, const char *suffix);
 static nxt_conf_value_t *nxt_cert_details(nxt_mp_t *mp, nxt_cert_t *cert);
 static nxt_conf_value_t *nxt_cert_name_details(nxt_mp_t *mp, X509 *x509,
     nxt_bool_t issuer);
+static nxt_int_t nxt_cert_name_text(NXT_X509_CONST X509_NAME *x509_name,
+    int nid, nxt_str_t *str);
 static nxt_conf_value_t *nxt_cert_alt_names_details(nxt_mp_t *mp,
     STACK_OF(GENERAL_NAME) *alt_names);
 static void nxt_cert_buf_completion(nxt_task_t *task, void *obj, void *data);
@@ -536,7 +558,7 @@ nxt_cert_details(nxt_mp_t *mp, nxt_cert_t *cert)
     X509              *x509;
     u_char            *end;
     EVP_PKEY          *key;
-    ASN1_TIME         *asn1_time;
+    const ASN1_TIME   *asn1_time;
     nxt_str_t         str;
     nxt_int_t         ret;
     nxt_uint_t        i;
@@ -631,7 +653,7 @@ nxt_cert_details(nxt_mp_t *mp, nxt_cert_t *cert)
             return NULL;
         }
 
-        asn1_time = X509_get_notBefore(x509);
+        asn1_time = X509_get0_notBefore(x509);
 
         ret = ASN1_TIME_print(bio, asn1_time);
 
@@ -654,7 +676,7 @@ nxt_cert_details(nxt_mp_t *mp, nxt_cert_t *cert)
             return NULL;
         }
 
-        asn1_time = X509_get_notAfter(x509);
+        asn1_time = X509_get0_notAfter(x509);
 
         ret = ASN1_TIME_print(bio, asn1_time);
 
@@ -692,14 +714,12 @@ typedef struct {
 static nxt_conf_value_t *
 nxt_cert_name_details(nxt_mp_t *mp, X509 *x509, nxt_bool_t issuer)
 {
-    int                     len;
-    X509_NAME               *x509_name;
+    NXT_X509_CONST          X509_NAME  *x509_name;
     nxt_str_t               str;
-    nxt_int_t               ret;
+    nxt_int_t               ret, found;
     nxt_uint_t              i, n, count;
     nxt_conf_value_t        *object, *names;
     STACK_OF(GENERAL_NAME)  *alt_names;
-    u_char                  buf[256];
 
     static const nxt_cert_nid_t  nids[] = {
         { NID_commonName, nxt_string("common_name") },
@@ -752,19 +772,25 @@ nxt_cert_name_details(nxt_mp_t *mp, X509 *x509, nxt_bool_t issuer)
 
     for (n = 0, i = 0; n != nxt_nitems(nids) && i != count; n++) {
 
-        len = X509_NAME_get_text_by_NID(x509_name, nids[n].nid,
-                                        (char *) buf, sizeof(buf));
+        found = nxt_cert_name_text(x509_name, nids[n].nid, &str);
 
         if (n == 1 && names != NULL) {
             nxt_conf_set_member(object, &alt_names_str, names, i++);
         }
 
-        if (len < 0) {
+        if (found != NXT_OK) {
             continue;
         }
 
-        str.length = len;
-        str.start = buf;
+        /*
+         * X509_NAME_get_text_by_NID() used to copy into a 256 byte buffer and
+         * report the truncated length.  Keep that cap: it is what the control
+         * API has always reported for pathologically long names.
+         */
+
+        if (str.length > NXT_CERT_NAME_TEXT_MAX) {
+            str.length = NXT_CERT_NAME_TEXT_MAX;
+        }
 
         ret = nxt_conf_set_member_string_dup(object, mp, &nids[n].name,
                                              &str, i++);
@@ -774,6 +800,51 @@ nxt_cert_name_details(nxt_mp_t *mp, X509 *x509, nxt_bool_t issuer)
     }
 
     return object;
+}
+
+
+/*
+ * Return the raw contents of the first entry of x509_name that carries nid,
+ * or NXT_DECLINED if there is none.
+ *
+ * This replaces X509_NAME_get_text_by_NID(), deprecated in OpenSSL 4.0.  The
+ * old function copied the entry verbatim into the caller's buffer; the entry
+ * accessors hand out the same bytes without the copy, pointing into the
+ * certificate, which outlives the returned string here.
+ *
+ * As before the bytes are neither NUL terminated nor guaranteed free of
+ * embedded NULs, so the caller must keep treating them as a counted string.
+ */
+
+static nxt_int_t
+nxt_cert_name_text(NXT_X509_CONST X509_NAME *x509_name, int nid,
+    nxt_str_t *str)
+{
+    int             i, len;
+    NXT_X509_CONST  ASN1_STRING      *data;
+    NXT_X509_CONST  X509_NAME_ENTRY  *entry;
+
+    i = X509_NAME_get_index_by_NID(x509_name, nid, -1);
+    if (i < 0) {
+        return NXT_DECLINED;
+    }
+
+    entry = X509_NAME_get_entry(x509_name, i);
+    if (nxt_slow_path(entry == NULL)) {
+        return NXT_DECLINED;
+    }
+
+    data = X509_NAME_ENTRY_get_data(entry);
+
+    len = ASN1_STRING_length(data);
+    if (nxt_slow_path(len < 0)) {
+        return NXT_DECLINED;
+    }
+
+    str->length = len;
+    str->start = (u_char *) ASN1_STRING_get0_data(data);
+
+    return NXT_OK;
 }
 
 

--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -17,6 +17,22 @@
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 
+/*
+ * The X509 name accessors were constified in stages, and not together:
+ * X509_NAME_get_entry() and X509_NAME_ENTRY_get_data() took const arguments
+ * from 1.1.0, but X509_NAME_get_index_by_NID() only from 3.0, and it is 4.0
+ * that constified the values all three return.  Qualifying from 3.0 is what
+ * satisfies every version at once -- an older header takes these pointers
+ * non-const, and 4.0 hands them back const -- so the boundary is 3.0 rather
+ * than the 1.1.0 the other guards in this file use.
+ */
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define NXT_X509_CONST  const
+#else
+#define NXT_X509_CONST
+#endif
+
 
 typedef struct {
     SSL               *session;
@@ -108,6 +124,8 @@ static void nxt_ssl_session_cache(SSL_CTX *ctx, size_t cache_size,
     time_t timeout);
 static nxt_uint_t nxt_openssl_cert_get_names(nxt_task_t *task, X509 *cert,
     nxt_tls_conf_t *conf, nxt_mp_t *mp);
+static nxt_int_t nxt_openssl_name_text(NXT_X509_CONST X509_NAME *x509_name,
+    int nid, nxt_str_t *str);
 static nxt_int_t nxt_openssl_bundle_hash_test(nxt_lvlhsh_query_t *lhq,
     void *data);
 static nxt_int_t nxt_openssl_bundle_hash_insert(nxt_task_t *task,
@@ -788,9 +806,8 @@ static nxt_uint_t
 nxt_openssl_cert_get_names(nxt_task_t *task, X509 *cert, nxt_tls_conf_t *conf,
     nxt_mp_t *mp)
 {
-    int                         len;
     nxt_str_t                   domain, str;
-    X509_NAME                   *x509_name;
+    NXT_X509_CONST              X509_NAME     *x509_name;
     nxt_uint_t                  i, n;
     GENERAL_NAME                *name;
     nxt_tls_bundle_conf_t       *bundle;
@@ -842,23 +859,22 @@ nxt_openssl_cert_get_names(nxt_task_t *task, X509 *cert, nxt_tls_conf_t *conf,
 
     } else {
         x509_name = X509_get_subject_name(cert);
-        len = X509_NAME_get_text_by_NID(x509_name, NID_commonName,
-                                        NULL, 0);
-        if (len <= 0) {
+
+        if (nxt_openssl_name_text(x509_name, NID_commonName, &str) != NXT_OK
+            || str.length == 0)
+        {
             nxt_log(task, NXT_LOG_WARN, "certificate \"%V\" has neither "
                     "Subject Alternative Name nor Common Name", &bundle->name);
             return NXT_OK;
         }
 
-        domain.start = nxt_mp_nget(mp, len + 1);
+        domain.start = nxt_mp_nget(mp, str.length);
         if (nxt_slow_path(domain.start == NULL)) {
             return NXT_ERROR;
         }
 
-        domain.length = X509_NAME_get_text_by_NID(x509_name, NID_commonName,
-                                                  (char *) domain.start,
-                                                  len + 1);
-        nxt_memcpy_lowcase(domain.start, domain.start, domain.length);
+        domain.length = str.length;
+        nxt_memcpy_lowcase(domain.start, str.start, str.length);
 
         item = nxt_mp_get(mp, sizeof(nxt_tls_bundle_hash_item_t));
         if (nxt_slow_path(item == NULL)) {
@@ -883,6 +899,53 @@ fail:
     sk_GENERAL_NAME_pop_free(alt_names, GENERAL_NAME_free);
 
     return NXT_ERROR;
+}
+
+
+/*
+ * Return the raw contents of the first entry of x509_name that carries nid,
+ * or NXT_DECLINED if there is none.
+ *
+ * This replaces X509_NAME_get_text_by_NID(), deprecated in OpenSSL 4.0.  The
+ * only property of that function the callers ever used was "the bytes of the
+ * first matching entry, verbatim", which is what the entry accessors give
+ * directly and without the copy: the returned string points into the
+ * certificate and stays valid for as long as it does.
+ *
+ * The bytes are not NUL terminated and, exactly as before, may contain
+ * embedded NULs -- the callers must keep handling them with an explicit
+ * length and never as a C string.
+ */
+
+static nxt_int_t
+nxt_openssl_name_text(NXT_X509_CONST X509_NAME *x509_name, int nid,
+    nxt_str_t *str)
+{
+    int             i, len;
+    NXT_X509_CONST  ASN1_STRING      *data;
+    NXT_X509_CONST  X509_NAME_ENTRY  *entry;
+
+    i = X509_NAME_get_index_by_NID(x509_name, nid, -1);
+    if (i < 0) {
+        return NXT_DECLINED;
+    }
+
+    entry = X509_NAME_get_entry(x509_name, i);
+    if (nxt_slow_path(entry == NULL)) {
+        return NXT_DECLINED;
+    }
+
+    data = X509_NAME_ENTRY_get_data(entry);
+
+    len = ASN1_STRING_length(data);
+    if (nxt_slow_path(len < 0)) {
+        return NXT_DECLINED;
+    }
+
+    str->length = len;
+    str->start = (u_char *) ASN1_STRING_get0_data(data);
+
+    return NXT_OK;
 }
 
 

--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1671,6 +1671,53 @@ nxt_openssl_conn_error(nxt_task_t *task, nxt_err_t err, const char *fmt, ...)
 }
 
 
+/*
+ * OpenSSL 4.0 renamed the SSLv3-era alert reason codes to SSL_R_TLS_ALERT_*
+ * and removed the old spellings, so a build against it with deprecated APIs
+ * disabled cannot see SSL_R_SSLV3_ALERT_*.  1.1.1 and 3.x have only the old
+ * names.  Define the new spelling in terms of the old one where it is
+ * missing, so the switch below needs one spelling rather than a version
+ * conditional per label.
+ *
+ * The SSL_R_TLSV1_ALERT_* codes are deliberately not bridged: 4.0 kept those
+ * names, and no SSL_R_TLS_ALERT_ spelling exists for them.
+ */
+
+#ifndef SSL_R_TLS_ALERT_UNEXPECTED_MESSAGE
+#define SSL_R_TLS_ALERT_UNEXPECTED_MESSAGE  SSL_R_SSLV3_ALERT_UNEXPECTED_MESSAGE
+#endif
+#ifndef SSL_R_TLS_ALERT_BAD_RECORD_MAC
+#define SSL_R_TLS_ALERT_BAD_RECORD_MAC  SSL_R_SSLV3_ALERT_BAD_RECORD_MAC
+#endif
+#ifndef SSL_R_TLS_ALERT_DECOMPRESSION_FAILURE
+#define SSL_R_TLS_ALERT_DECOMPRESSION_FAILURE  SSL_R_SSLV3_ALERT_DECOMPRESSION_FAILURE
+#endif
+#ifndef SSL_R_TLS_ALERT_HANDSHAKE_FAILURE
+#define SSL_R_TLS_ALERT_HANDSHAKE_FAILURE  SSL_R_SSLV3_ALERT_HANDSHAKE_FAILURE
+#endif
+#ifndef SSL_R_TLS_ALERT_ILLEGAL_PARAMETER
+#define SSL_R_TLS_ALERT_ILLEGAL_PARAMETER  SSL_R_SSLV3_ALERT_ILLEGAL_PARAMETER
+#endif
+#ifndef SSL_R_TLS_ALERT_NO_CERTIFICATE
+#define SSL_R_TLS_ALERT_NO_CERTIFICATE  SSL_R_SSLV3_ALERT_NO_CERTIFICATE
+#endif
+#ifndef SSL_R_TLS_ALERT_BAD_CERTIFICATE
+#define SSL_R_TLS_ALERT_BAD_CERTIFICATE  SSL_R_SSLV3_ALERT_BAD_CERTIFICATE
+#endif
+#ifndef SSL_R_TLS_ALERT_UNSUPPORTED_CERTIFICATE
+#define SSL_R_TLS_ALERT_UNSUPPORTED_CERTIFICATE  SSL_R_SSLV3_ALERT_UNSUPPORTED_CERTIFICATE
+#endif
+#ifndef SSL_R_TLS_ALERT_CERTIFICATE_REVOKED
+#define SSL_R_TLS_ALERT_CERTIFICATE_REVOKED  SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED
+#endif
+#ifndef SSL_R_TLS_ALERT_CERTIFICATE_EXPIRED
+#define SSL_R_TLS_ALERT_CERTIFICATE_EXPIRED  SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED
+#endif
+#ifndef SSL_R_TLS_ALERT_CERTIFICATE_UNKNOWN
+#define SSL_R_TLS_ALERT_CERTIFICATE_UNKNOWN  SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN
+#endif
+
+
 static nxt_uint_t
 nxt_openssl_log_error_level(nxt_err_t err)
 {
@@ -1728,21 +1775,21 @@ nxt_openssl_log_error_level(nxt_err_t err)
     case SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING:          /*  345 */
 #endif
     case 1000:/* SSL_R_SSLV3_ALERT_CLOSE_NOTIFY */
-    case SSL_R_SSLV3_ALERT_UNEXPECTED_MESSAGE:            /* 1010 */
-    case SSL_R_SSLV3_ALERT_BAD_RECORD_MAC:                /* 1020 */
+    case SSL_R_TLS_ALERT_UNEXPECTED_MESSAGE:            /* 1010 */
+    case SSL_R_TLS_ALERT_BAD_RECORD_MAC:                /* 1020 */
     case SSL_R_TLSV1_ALERT_DECRYPTION_FAILED:             /* 1021 */
     case SSL_R_TLSV1_ALERT_RECORD_OVERFLOW:               /* 1022 */
-    case SSL_R_SSLV3_ALERT_DECOMPRESSION_FAILURE:         /* 1030 */
-    case SSL_R_SSLV3_ALERT_HANDSHAKE_FAILURE:             /* 1040 */
-    case SSL_R_SSLV3_ALERT_ILLEGAL_PARAMETER:             /* 1047 */
+    case SSL_R_TLS_ALERT_DECOMPRESSION_FAILURE:         /* 1030 */
+    case SSL_R_TLS_ALERT_HANDSHAKE_FAILURE:             /* 1040 */
+    case SSL_R_TLS_ALERT_ILLEGAL_PARAMETER:             /* 1047 */
         break;
 
-    case SSL_R_SSLV3_ALERT_NO_CERTIFICATE:                /* 1041 */
-    case SSL_R_SSLV3_ALERT_BAD_CERTIFICATE:               /* 1042 */
-    case SSL_R_SSLV3_ALERT_UNSUPPORTED_CERTIFICATE:       /* 1043 */
-    case SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED:           /* 1044 */
-    case SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED:           /* 1045 */
-    case SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN:           /* 1046 */
+    case SSL_R_TLS_ALERT_NO_CERTIFICATE:                /* 1041 */
+    case SSL_R_TLS_ALERT_BAD_CERTIFICATE:               /* 1042 */
+    case SSL_R_TLS_ALERT_UNSUPPORTED_CERTIFICATE:       /* 1043 */
+    case SSL_R_TLS_ALERT_CERTIFICATE_REVOKED:           /* 1044 */
+    case SSL_R_TLS_ALERT_CERTIFICATE_EXPIRED:           /* 1045 */
+    case SSL_R_TLS_ALERT_CERTIFICATE_UNKNOWN:           /* 1046 */
     case SSL_R_TLSV1_ALERT_UNKNOWN_CA:                    /* 1048 */
     case SSL_R_TLSV1_ALERT_ACCESS_DENIED:                 /* 1049 */
     case SSL_R_TLSV1_ALERT_DECODE_ERROR:                  /* 1050 */

--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -31,6 +31,38 @@ typedef struct {
 } nxt_openssl_conn_t;
 
 
+#if (NXT_HAVE_OPENSSL_TLSEXT)
+
+/*
+ * OpenSSL 3.0 deprecated the HMAC_CTX flavour of the session ticket key
+ * callback in favour of SSL_CTX_set_tlsext_ticket_key_evp_cb(), which hands
+ * the callback an EVP_MAC_CTX instead.  The deprecation covers the
+ * SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB control behind the old registration
+ * macro as well, so the feature guard has to follow the callback flavour:
+ * once OpenSSL 5.0 drops the deprecated symbols, testing for the control
+ * would silently turn Session Tickets off.
+ */
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+
+#define NXT_OPENSSL_TICKET_KEY_CB  1
+typedef EVP_MAC_CTX  nxt_tls_ticket_mac_t;
+
+#elif defined(SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB)
+
+#include <openssl/hmac.h>
+
+#define NXT_OPENSSL_TICKET_KEY_CB  1
+typedef HMAC_CTX     nxt_tls_ticket_mac_t;
+
+#endif
+
+#endif /* NXT_HAVE_OPENSSL_TLSEXT */
+
+
 struct nxt_tls_ticket_s {
     u_char            name[16];
     u_char            hmac_key[32];
@@ -66,8 +98,11 @@ static nxt_int_t nxt_ssl_conf_commands(nxt_task_t *task, SSL_CTX *ctx,
 #if (NXT_HAVE_OPENSSL_TLSEXT)
 static nxt_int_t nxt_tls_ticket_keys(nxt_task_t *task, SSL_CTX *ctx,
     nxt_tls_init_t *tls_init, nxt_mp_t *mp);
+#ifdef NXT_OPENSSL_TICKET_KEY_CB
 static int nxt_tls_ticket_key_callback(SSL *s, unsigned char *name,
-    unsigned char *iv, EVP_CIPHER_CTX *ectx, HMAC_CTX *hctx, int enc);
+    unsigned char *iv, EVP_CIPHER_CTX *ectx, nxt_tls_ticket_mac_t *hctx,
+    int enc);
+#endif
 #endif
 static void nxt_ssl_session_cache(SSL_CTX *ctx, size_t cache_size,
     time_t timeout);
@@ -530,7 +565,7 @@ nxt_tls_ticket_keys(nxt_task_t *task, SSL_CTX *ctx, nxt_tls_init_t *tls_init,
         goto no_ticket;
     }
 
-#ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
+#ifdef NXT_OPENSSL_TICKET_KEY_CB
 
     tickets = nxt_mp_get(mp, sizeof(nxt_tls_tickets_t)
                              + count * sizeof(nxt_tls_ticket_t));
@@ -571,8 +606,13 @@ nxt_tls_ticket_keys(nxt_task_t *task, SSL_CTX *ctx, nxt_tls_init_t *tls_init,
 
     } while (i < count);
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (SSL_CTX_set_tlsext_ticket_key_evp_cb(ctx, nxt_tls_ticket_key_callback)
+        == 0)
+#else
     if (SSL_CTX_set_tlsext_ticket_key_cb(ctx, nxt_tls_ticket_key_callback)
         == 0)
+#endif
     {
         nxt_openssl_log_error(task, NXT_LOG_ALERT,
                       "Unit was built with Session Tickets support, however, "
@@ -601,11 +641,11 @@ no_ticket:
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
+#ifdef NXT_OPENSSL_TICKET_KEY_CB
 
 static int
 nxt_tls_ticket_key_callback(SSL *s, unsigned char *name, unsigned char *iv,
-    EVP_CIPHER_CTX *ectx, HMAC_CTX *hctx, int enc)
+    EVP_CIPHER_CTX *ectx, nxt_tls_ticket_mac_t *hctx, int enc)
 {
     nxt_uint_t          i;
     nxt_conn_t          *c;
@@ -613,6 +653,9 @@ nxt_tls_ticket_key_callback(SSL *s, unsigned char *name, unsigned char *iv,
     const EVP_CIPHER    *cipher;
     nxt_tls_ticket_t    *ticket;
     nxt_openssl_conn_t  *tls;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_PARAM          params[2];
+#endif
 
     c = SSL_get_ex_data(s, nxt_openssl_connection_index);
 
@@ -685,6 +728,28 @@ nxt_tls_ticket_key_callback(SSL *s, unsigned char *name, unsigned char *iv,
     digest = EVP_sha256();
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
+    /*
+     * The EVP_MAC_CTX handed to this callback is an already created HMAC
+     * context; it only needs the digest and the key.  EVP_MAC_init() takes
+     * both, so the key material, its length and the digest are exactly the
+     * ones HMAC_Init_ex() used to be given, and the tag length still follows
+     * from the digest.
+     */
+
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                       (char *) EVP_MD_get0_name(digest), 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (EVP_MAC_init(hctx, ticket[i].hmac_key, ticket[i].size, params) != 1) {
+        nxt_openssl_log_error(c->socket.task, NXT_LOG_ALERT,
+                              "EVP_MAC_init() failed");
+        return -1;
+    }
+
+#else
+
     if (HMAC_Init_ex(hctx, ticket[i].hmac_key, ticket[i].size, digest, NULL)
         != 1)
     {
@@ -693,10 +758,12 @@ nxt_tls_ticket_key_callback(SSL *s, unsigned char *name, unsigned char *iv,
         return -1;
     }
 
+#endif
+
     return enc;
 }
 
-#endif /* SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB */
+#endif /* NXT_OPENSSL_TICKET_KEY_CB */
 
 #endif /* NXT_HAVE_OPENSSL_TLSEXT */
 


### PR DESCRIPTION
Unit did not build against OpenSSL 4.0, and carries deprecated API that OpenSSL 5.0 will remove. This fixes both and adds a CI leg so the claim stops being an inference.

OpenSSL 4.0.0 shipped 2026-04-14. It is non-LTS (EOL 2027-05-14); the distro anchor is 4.2 LTS in April 2027. Separately, 3.0 LTS goes EOL 2026-09-07.

### 1. Session ticket key callback → `EVP_MAC` (`d8f41ef9`)

`HMAC_Init_ex()` has been deprecated since 3.0. On any OpenSSL 3.x build (`OPENSSL_VERSION_NUMBER >= 0x30000000L`), the callback now registers through `SSL_CTX_set_tlsext_ticket_key_evp_cb()` and initialises the `EVP_MAC_CTX` libssl hands it with `EVP_MAC_init()` plus an `OSSL_MAC_PARAM_DIGEST` param, instead of the old `HMAC_CTX` path.

The deprecation was wider than the one call. The old feature guard tested for `SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB`, and that control is itself declared under `OPENSSL_NO_DEPRECATED_3_0`. So on any no-deprecated 3.x build, that guard never fired — Unit silently took the "not supported with this version of OpenSSL library" branch and stopped serving session tickets, with no build failure to flag it. The guard now derives from the callback flavour (`NXT_OPENSSL_TICKET_KEY_CB`) instead of the deprecated control macro, so it fires correctly on 3.x regardless of the deprecation switch.

Key material, key length and digest are passed through unchanged; tag comparison was and remains inside libssl. Return values (0 unknown key name, 1, 2 renew, -1 fail) are unchanged, so key rotation is unaffected. Pre-3.0 keeps the `HMAC_CTX` callback verbatim.

### 2. Certificate names and validity times without deprecated APIs (`59ef69f4`)

`X509_NAME_get_text_by_NID()` is deprecated and copies into a caller buffer — it also cannot express an embedded NUL correctly. The three call sites move to `X509_NAME_get_index_by_NID(x509_name, nid, -1)` / `X509_NAME_get_entry()` / `X509_NAME_ENTRY_get_data()`, taking the value by length from the `ASN1_STRING` instead of by terminator. Passing `-1` as the start index preserves the old function's first-matching-entry semantics. `nxt_cert.c`'s existing 255-byte cap (`NXT_CERT_NAME_TEXT_MAX`) is kept as an explicit truncation instead of a side effect of a fixed buffer.

`X509_get_notBefore()`/`X509_get_notAfter()` move to `X509_get0_notBefore()`/`X509_get0_notAfter()`, available since 1.1.0 and returning `const` — the only thing the call site (`ASN1_TIME_print()`) needs. `const` is applied to the touched locals per-version rather than unconditionally, since `X509_NAME_get_index_by_NID()` only took `const` arguments from 3.0, while the others did from 1.1.0.

### 3. CI: build against OpenSSL 4.0 and run the C tests (`cbfdf683`)

New `openssl4` job builds OpenSSL 4.0.2 from source (no distro ships 4.0 yet) into its own `/opt` prefix, mirroring the existing 3.6 slot's isolation: `LD_LIBRARY_PATH` scoped to the configure step only, `-Wl,-rpath` baked in for everything after. Unit is configured with `-DOPENSSL_NO_DEPRECATED`, so the leg fails on any deprecated-API use it can still see — not only on APIs 4.0 has actually removed. A dedicated step asserts `configure` actually found OpenSSL 4.0 (greps `NXT_HAVE_OPENSSL_VERSION` in `nxt_auto_config.h`), so a silent fallback to the runner's system 3.x can't pass the leg while testing nothing.

Kept cheap: configure, build, build the C tests, run them. No language modules, no pytest — nothing above the TLS layer depends on the OpenSSL version.

### 4. OpenSSL 4.0 alert reason-code names (`b5e0f37b`)

4.0 renamed the 11 SSLv3-era `SSL_R_SSLV3_ALERT_*` codes used in `nxt_openssl_log_error_level()` to `SSL_R_TLS_ALERT_*` and removed the old spellings once deprecated API is disabled (values are unchanged, e.g. 1010, 1020, ...). Each new name is defined in terms of the old one with `#ifndef`, so 1.1.1 and 3.x — which only have the old spelling — still build, and 4.0 uses its own definitions directly.

The 12 `SSL_R_TLSV1_ALERT_*` codes are deliberately left alone: checked name-by-name against 4.0.2's `sslerr.h`, 4.0 kept those spellings as-is and defines no `SSL_R_TLS_ALERT_` alias for them, so bridging them would invent a rename that didn't happen.

## Verification

Built clean (`-Werror`) and passed the C test suite under:

- OpenSSL 4.0.2 with `-DOPENSSL_NO_DEPRECATED`
- OpenSSL 3.5.5 with `-DOPENSSL_NO_DEPRECATED`
- OpenSSL 3.5.5, default build

## Out of scope

`OPENSSL_SUPPRESS_DEPRECATED` is left in place. Pre-1.1.0 conditionals were removed separately in #224 and are not part of this series.
