### PR TITLE
comments: drop a stale example call and fix a padding-size claim

### DIFF
--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4728,7 +4728,6 @@ nxt_router_response_error_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
     req_rpc_data->rpc_cancel = 0;
 
     /* TODO cancel message and return if cancelled. */
-    // nxt_router_msg_cancel(task, &req_rpc_data->msg_info, req_rpc_data->stream);
 
     if (req_rpc_data->request != NULL) {
         nxt_http_request_error(task, req_rpc_data->request,

--- a/src/nxt_test_build.h
+++ b/src/nxt_test_build.h
@@ -74,8 +74,12 @@ struct signalfd_siginfo {
     uint64_t           ssi_stime;   /* System CPU time consumed (SIGCHLD) */
     uint64_t           ssi_addr;    /* Address that generated signal
                                        (for hardware-generated signals) */
-    uint8_t            pad[8];      /* Pad size to 128 bytes (allow for
-                                       additional fields in the future) */
+    uint8_t            pad[8];      /* Padding; the real kernel struct pads
+                                       to 128 bytes, but the exact size does
+                                       not matter here since this is a
+                                       syntax-check-only stub for non-Linux
+                                       test builds, never used for a real
+                                       signalfd(2) read */
 };
 
 


### PR DESCRIPTION
Two comments that state things the code does not do. Comment-only changes; no behaviour change.

**`src/nxt_router.c`** — removed a commented-out three-argument call to `nxt_router_msg_cancel(task, &req_rpc_data->msg_info, req_rpc_data->stream)`. The live function takes two arguments (`task, req_rpc_data`) and derives `msg_info` itself; `rg -n 'nxt_router_msg_cancel' src` returns only the two-argument definition, one two-argument call site, and this stale line. The `TODO cancel message and return if cancelled.` above it is left in place — that work is still open.

**`src/nxt_test_build.h`** — the stub `struct signalfd_siginfo`'s `pad[8]` carried a comment claiming it pads the struct to 128 bytes. The preceding fields sum to 80, so `pad[8]` reaches 88. Reworded the comment rather than resizing the array: this struct is a syntax-check-only stand-in for non-Linux `NXT_TEST_BUILD_EPOLL` builds and is never used for a real `signalfd(2)` read, so the byte count is inert — only the arithmetic claim was wrong.

## Checked and deliberately not changed

The `/* 1 bit */` comments on `uint8_t` fields in `nxt_port.h` look wrong but are not. The convention appears **92 times across 28 files** and documents a field's *semantic* width, not its storage. `src/nxt_http.h:165` has `nxt_http_protocol_t protocol:8; /* 2 bits */` — a real bitfield stored in 8 bits because the enum has 3 values — and `src/nxt_http.h:259` has `uint8_t pass_count; /* 8 bits */`. Changing only the six `nxt_port.h` instances would break a consistent, nginx-derived house style.

Also swept and found correct: every `TODO`/`FIXME`/`XXX` (all still open), every `nxt_*()` function name referenced in a comment (all exist), and `nxt_random.c`'s reseed arithmetic.

No cases were found where a comment was right and the code was wrong.

## Verification

`./configure --openssl --tests` + `make` clean with default flags including `-Werror`; `./build/tests` exits 0. No line exceeds 80 columns; `git log --check` clean. The Python suite was not run (port contention in the dev environment); these are comment-only changes in a header used solely by non-Linux test builds and one deleted comment line.