### PR TITLE
otel: fix the span lifetime, the exit flush and the reconfigure stall

### DIFF
--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -726,6 +726,63 @@ nxt_otel_parse_tracestate(void *ctx, nxt_http_field_t *field, uintptr_t data)
 }
 
 
+/*
+ * Flush the telemetry pipeline on the way out of the process.
+ *
+ * Called from nxt_runtime_exit(), the single funnel every router exit passes
+ * through (signal handlers, the "quit" port message and internal failures all
+ * converge on nxt_runtime_quit() -> nxt_runtime_exit() -> exit()).  Without
+ * this the batch processor's queue -- up to MAX_QUEUE_SIZE (4096) spans plus
+ * whatever is in the batch being assembled -- is simply discarded.
+ *
+ * The flush is bounded rather than unconditional.  A blocking shutdown waits
+ * for the exporter's own 10s timeout when the collector is unreachable, which
+ * would trade "loses spans on exit" for "takes ten seconds to stop", a far
+ * more visible regression for anything supervising unitd.  The budget below is
+ * comfortably more than a reachable collector needs (a local OTLP endpoint
+ * answers in milliseconds) and short enough that a dead one is not felt.
+ */
+
+#define NXT_OTEL_EXIT_FLUSH_TIMEOUT_MS  2000
+
+void
+nxt_otel_shutdown(nxt_task_t *task)
+{
+    if (!nxt_otel_rs_is_init()) {
+        return;
+    }
+
+    nxt_log(task, NXT_LOG_DEBUG, "otel: flushing spans before exit");
+
+    /*
+     * NXT_OTEL_SHUTDOWN_FLUSHED is not a promise that nothing was lost: the
+     * router's worker engines are still live here, so a span ended after the
+     * flush reaches an already shut down provider and is dropped silently.
+     * That one stays unreportable until producers can be quiesced, which is
+     * the P5 graceful-shutdown work, tracked in issue #219.
+     */
+    switch (nxt_otel_rs_shutdown_bounded(NXT_OTEL_EXIT_FLUSH_TIMEOUT_MS)) {
+
+    case NXT_OTEL_SHUTDOWN_TIMEOUT:
+        nxt_log(task, NXT_LOG_WARN,
+                "otel: the final span flush did not complete within %d ms, "
+                "exiting anyway; the spans it held are lost",
+                NXT_OTEL_EXIT_FLUSH_TIMEOUT_MS);
+        break;
+
+    case NXT_OTEL_SHUTDOWN_FAILED:
+        nxt_log(task, NXT_LOG_WARN,
+                "otel: span export to the collector failed, exiting anyway; "
+                "the spans of at least one batch are lost");
+        break;
+
+    default:
+        nxt_log(task, NXT_LOG_DEBUG, "otel: span flush complete");
+        break;
+    }
+}
+
+
 void
 nxt_otel_log_callback(nxt_uint_t log_level, const char *arg)
 {

--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -354,6 +354,63 @@ nxt_otel_span_collect(nxt_task_t *task, nxt_http_request_t *r)
 }
 
 
+/*
+ * Release the span of a request that is being torn down.
+ *
+ * Registered as an r->mem_pool cleanup at span creation, so it runs from
+ * nxt_mp_destroy() on *every* request exit: the normal completion path, the
+ * client-abort/error path that goes straight to
+ * nxt_http_request_close_handler() without ever reaching COLLECT, and any exit
+ * path added in the future.  Tying the span's lifetime to the pool that holds
+ * it makes the release structural rather than something each new exit path has
+ * to remember.
+ *
+ * nxt_otel_span_collect() NULLs r->otel->trace after handing the span to Rust,
+ * and it is the only other place that does so; that NULL is what keeps this
+ * idempotent, i.e. a no-op for a request that was collected normally.
+ */
+static void
+nxt_otel_span_pool_cleanup(nxt_task_t *task, void *obj, void *data)
+{
+    nxt_thread_t      *thr;
+    nxt_otel_state_t  *state;
+
+    state = obj;
+
+    if (state->trace == NULL) {
+        return;
+    }
+
+    thr = nxt_thread();
+
+    /*
+     * The task recorded at registration belongs to the connection, which may
+     * already have been recycled by the time the pool is destroyed, so log
+     * against the current thread's task instead of the one passed in.
+     */
+    nxt_log(thr->task, NXT_LOG_DEBUG,
+            "otel: releasing the span of an unfinished request");
+
+    /*
+     * The request never produced a response.  Mark the span failed and export
+     * it rather than dropping it silently: an aborted or timed out request is
+     * usually the interesting trace, and a span that simply vanishes is
+     * indistinguishable from telemetry being broken.  Exporting also keeps the
+     * span consistent with the 5xx case, which is already flagged
+     * Status::Error in nxt_otel_span_add_status().
+     *
+     * This cannot stall the engine thread: nxt_otel_rs_send_trace() only ends
+     * the span, which enqueues it on the Rust-side batch processor; the actual
+     * OTLP export runs later on that processor's own thread.
+     */
+    nxt_otel_rs_set_error(state->trace);
+    nxt_otel_rs_send_trace(state->trace);
+
+    state->trace = NULL;
+    state->status = NXT_OTEL_UNINIT_STATE;
+}
+
+
 static void
 nxt_otel_error(nxt_task_t *task, nxt_http_request_t *r)
 {
@@ -424,6 +481,27 @@ nxt_otel_trace_and_span_init(nxt_task_t *task, nxt_http_request_t *r)
                                         &r->otel->trace_state);
     if (r->otel->trace == NULL) {
         nxt_log(task, NXT_LOG_ERR, "error generating otel span");
+        nxt_otel_state_transition(r->otel, NXT_OTEL_ERROR_STATE);
+        return;
+    }
+
+    /*
+     * Bind the span to the request memory pool right away, so that from here
+     * on no exit path can drop the request without releasing the span.
+     */
+    if (nxt_slow_path(nxt_mp_cleanup(r->mem_pool, nxt_otel_span_pool_cleanup,
+                                     task, r->otel, NULL) != NXT_OK))
+    {
+        /*
+         * Without the cleanup nothing guarantees the span is released on an
+         * abort, so end it now instead of tracing this request and risking a
+         * leak.
+         */
+        nxt_log(task, NXT_LOG_ERR, "couldn't register otel span cleanup");
+
+        nxt_otel_rs_send_trace(r->otel->trace);
+        r->otel->trace = NULL;
+
         nxt_otel_state_transition(r->otel, NXT_OTEL_ERROR_STATE);
         return;
     }

--- a/src/nxt_otel.h
+++ b/src/nxt_otel.h
@@ -32,6 +32,23 @@ extern void nxt_otel_rs_add_attr(void *trace, nxt_str_t *key, nxt_str_t *val);
 extern void nxt_otel_rs_set_error(void *trace);
 extern uint8_t nxt_otel_rs_is_init(void);
 extern void nxt_otel_rs_uninit(void);
+extern uint8_t nxt_otel_rs_shutdown_bounded(uint64_t timeout_ms);
+
+/*
+ * Return values of nxt_otel_rs_shutdown_bounded().  Defined on the Rust side
+ * as NXT_OTEL_SHUTDOWN_* in src/otel/src/lib.rs; the two lists must be kept
+ * in step.
+ *
+ * TIMEOUT  the flush did not answer within the caller's budget.
+ * FLUSHED  the flush completed and no export has failed since the provider
+ *          was installed.  Not a promise that no spans were lost: see the
+ *          producer race documented on the Rust side and in issue #219.
+ * FAILED   an export failed -- either the one this call forced, or an earlier
+ *          batch recorded by the sticky failure flag.
+ */
+#define NXT_OTEL_SHUTDOWN_TIMEOUT  0
+#define NXT_OTEL_SHUTDOWN_FLUSHED  1
+#define NXT_OTEL_SHUTDOWN_FAILED   2
 #endif
 
 
@@ -78,6 +95,7 @@ void nxt_otel_log_callback(nxt_uint_t log_level, const char *arg);
 
 void nxt_otel_test_and_call_state(nxt_task_t *task, nxt_http_request_t *r);
 void nxt_otel_request_error_path(nxt_task_t *task, nxt_http_request_t *r);
+void nxt_otel_shutdown(nxt_task_t *task);
 
 
 #endif /* _NXT_OTEL_H_INCLUDED_ */

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -1620,6 +1620,104 @@ static nxt_conf_map_t  nxt_router_websocket_conf[] = {
 };
 
 
+#if (NXT_HAVE_OTEL)
+
+/*
+ * The telemetry settings currently applied to the Rust exporter.
+ *
+ * nxt_otel_rs_init() flushes the live provider and builds a new one, which
+ * blocks the router's control thread for as long as the export of the pending
+ * batch takes -- up to the exporter's 10s timeout against an unreachable
+ * collector -- and drops whatever is in flight across the swap.  Every config
+ * apply used to pay that, including applies that do not touch
+ * /settings/telemetry at all (adding a route, changing an app).  Caching what
+ * was applied lets an unchanged telemetry section be a no-op.
+ *
+ * Only exact equality is treated as unchanged; anything the comparison cannot
+ * establish falls through to the rebuild, which is the old behaviour.
+ */
+typedef struct {
+    nxt_bool_t  configured;
+    nxt_str_t   endpoint;
+    nxt_str_t   protocol;
+    double      sample_fraction;
+    double      batch_size;
+} nxt_otel_applied_conf_t;
+
+
+static nxt_otel_applied_conf_t  nxt_otel_applied_conf;
+
+
+static nxt_bool_t
+nxt_router_otel_conf_unchanged(nxt_str_t *endpoint, nxt_str_t *protocol,
+    double sample_fraction, double batch_size)
+{
+    /*
+     * The doubles are re-parsed from the same JSON text on every apply, so an
+     * unchanged section reproduces them bit for bit; an exact comparison is
+     * therefore the right test here, and any inequality only costs a rebuild.
+     */
+    return nxt_otel_applied_conf.configured
+           && nxt_strstr_eq(&nxt_otel_applied_conf.endpoint, endpoint)
+           && nxt_strstr_eq(&nxt_otel_applied_conf.protocol, protocol)
+           && nxt_otel_applied_conf.sample_fraction == sample_fraction
+           && nxt_otel_applied_conf.batch_size == batch_size;
+}
+
+
+static nxt_int_t
+nxt_router_otel_conf_store_str(nxt_str_t *dst, const nxt_str_t *src)
+{
+    u_char  *p;
+
+    p = NULL;
+
+    if (src->length != 0) {
+        p = nxt_malloc(src->length);
+        if (nxt_slow_path(p == NULL)) {
+            return NXT_ERROR;
+        }
+
+        memcpy(p, src->start, src->length);
+    }
+
+    nxt_free(dst->start);
+
+    dst->start = p;
+    dst->length = src->length;
+
+    return NXT_OK;
+}
+
+
+/*
+ * Remember what was just handed to nxt_otel_rs_init().  The strings point into
+ * the configuration memory pool, which is released once this apply completes,
+ * so they have to be copied.  On any failure the cache is invalidated, which
+ * only means the next apply rebuilds unconditionally.
+ */
+static void
+nxt_router_otel_conf_remember(nxt_str_t *endpoint, nxt_str_t *protocol,
+    double sample_fraction, double batch_size)
+{
+    if (nxt_slow_path(nxt_router_otel_conf_store_str(
+                          &nxt_otel_applied_conf.endpoint, endpoint) != NXT_OK
+                      || nxt_router_otel_conf_store_str(
+                          &nxt_otel_applied_conf.protocol,
+                          protocol) != NXT_OK))
+    {
+        nxt_otel_applied_conf.configured = 0;
+        return;
+    }
+
+    nxt_otel_applied_conf.sample_fraction = sample_fraction;
+    nxt_otel_applied_conf.batch_size = batch_size;
+    nxt_otel_applied_conf.configured = 1;
+}
+
+#endif
+
+
 static nxt_int_t
 nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     u_char *start, u_char *end)
@@ -2225,11 +2323,33 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
             ? nxt_conf_get_number(otel_sampling)
             : NXT_OTEL_SAMPLING_DEFAULT;
 
-        nxt_otel_rs_init(&nxt_otel_log_callback, &telemetry_endpoint,
-                         &telemetry_proto, telemetry_sample_fraction,
-                         telemetry_batching);
-    } else {
+        /*
+         * Rebuild the exporter only when the telemetry settings actually
+         * differ.  nxt_otel_rs_is_init() is required as well so that a
+         * previous init that failed inside the Rust side (an exporter that
+         * could not be built) is retried rather than remembered as applied.
+         */
+        if (!nxt_router_otel_conf_unchanged(&telemetry_endpoint,
+                                            &telemetry_proto,
+                                            telemetry_sample_fraction,
+                                            telemetry_batching)
+            || !nxt_otel_rs_is_init())
+        {
+            nxt_otel_rs_init(&nxt_otel_log_callback, &telemetry_endpoint,
+                             &telemetry_proto, telemetry_sample_fraction,
+                             telemetry_batching);
+
+            nxt_router_otel_conf_remember(&telemetry_endpoint, &telemetry_proto,
+                                          telemetry_sample_fraction,
+                                          telemetry_batching);
+        }
+
+    } else if (nxt_otel_applied_conf.configured || nxt_otel_rs_is_init()) {
         nxt_otel_rs_uninit();
+
+        nxt_free(nxt_otel_applied_conf.endpoint.start);
+        nxt_free(nxt_otel_applied_conf.protocol.start);
+        nxt_memzero(&nxt_otel_applied_conf, sizeof(nxt_otel_applied_conf));
     }
 #endif
 

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -11,6 +11,9 @@
 #include <nxt_main_process.h>
 #include <nxt_router.h>
 #include <nxt_regex.h>
+#if (NXT_HAVE_OTEL)
+#include <nxt_otel.h>
+#endif
 
 
 static nxt_int_t nxt_runtime_inherited_listen_sockets(nxt_task_t *task,
@@ -613,6 +616,16 @@ nxt_runtime_exit(nxt_task_t *task, void *obj, void *data)
     if (!nxt_array_is_empty(rt->thread_pools)) {
         return;
     }
+
+#if (NXT_HAVE_OTEL)
+    /*
+     * Only the router builds spans, and this is the last point before exit()
+     * at which the batch processor can still be flushed.
+     */
+    if (rt->type == NXT_PROCESS_ROUTER) {
+        nxt_otel_shutdown(task);
+    }
+#endif
 
     if (rt->type == NXT_PROCESS_MAIN) {
         if (rt->pid_file != NULL) {

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -21,12 +21,16 @@ use opentelemetry::trace::{
 };
 use opentelemetry::{Context, KeyValue};
 use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{
-    BatchConfigBuilder, BatchSpanProcessor, Sampler, SdkTracerProvider,
+    BatchConfigBuilder, BatchSpanProcessor, Sampler, SdkTracerProvider, SpanData,
+    SpanExporter as SdkSpanExporter,
 };
 use opentelemetry_sdk::Resource;
 use std::ffi::{c_char, CStr, CString};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::{ptr, slice};
@@ -39,6 +43,14 @@ const TRACER_NAME: &str = "FreeUnit";
 const SPAN_NAME: &str = "request";
 
 const NXT_LOG_ERR: nxt_uint_t = 1;
+
+/// Return values of `nxt_otel_rs_shutdown_bounded`.
+///
+/// These are mirrored as `NXT_OTEL_SHUTDOWN_*` in `src/nxt_otel.h`, which is
+/// the only consumer; the two lists must be kept in step.
+const NXT_OTEL_SHUTDOWN_TIMEOUT: u8 = 0;
+const NXT_OTEL_SHUTDOWN_FLUSHED: u8 = 1;
+const NXT_OTEL_SHUTDOWN_FAILED: u8 = 2;
 
 #[repr(C)]
 pub struct nxt_str_t {
@@ -67,6 +79,52 @@ fn provider_slot() -> &'static Mutex<Option<SdkTracerProvider>> {
 fn runtime_slot() -> &'static Mutex<Option<tokio::runtime::Runtime>> {
     static RT: Mutex<Option<tokio::runtime::Runtime>> = Mutex::new(None);
     &RT
+}
+
+/// Set whenever an export returns `Err`, and cleared when a new provider is
+/// installed. Sticky because the `BatchSpanProcessor` throws away the result
+/// of every batch it exports on its own schedule (it only propagates the one
+/// forced by `force_flush`), so without this a batch that failed minutes
+/// before exit would leave nothing at all for the shutdown path to report.
+static EXPORT_FAILED: AtomicBool = AtomicBool::new(false);
+
+/// Wraps the configured OTLP exporter so a failed export is remembered in
+/// `EXPORT_FAILED` even when the processor discards the result.
+///
+/// Everything other than `export` is delegated verbatim to the inner
+/// exporter: taking the trait's defaults here would silently turn shutdown,
+/// force-flush and resource propagation into no-ops.
+#[derive(Debug)]
+struct FailureTrackingExporter<E> {
+    inner: E,
+}
+
+impl<E: SdkSpanExporter> SdkSpanExporter for FailureTrackingExporter<E> {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        let res = self.inner.export(batch).await;
+
+        if res.is_err() {
+            EXPORT_FAILED.store(true, Ordering::Release);
+        }
+
+        res
+    }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        self.inner.shutdown()
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        self.inner.set_resource(resource);
+    }
 }
 
 /// Build the OTLP/HTTP exporter: the blocking reqwest client, no async runtime.
@@ -187,7 +245,17 @@ pub unsafe extern "C" fn nxt_otel_rs_init(
         }
     };
 
-    let processor = BatchSpanProcessor::builder(exporter)
+    // A new provider starts with a clean slate, so the shutdown path does not
+    // normally report a failure that belonged to the exporter we replaced:
+    // nxt_otel_rs_shutdown_tracer() above joins the old worker thread before
+    // this runs.  It joins on a 5s budget though, and an export gets 10s, so
+    // a worker still blocked on a dead collector can outlive the join and set
+    // the flag after this store.  The cost is one spurious FAILED at the next
+    // exit, describing a failure that was real but belonged to the old
+    // exporter -- not worth a second flag to suppress.
+    EXPORT_FAILED.store(false, Ordering::Release);
+
+    let processor = BatchSpanProcessor::builder(FailureTrackingExporter { inner: exporter })
         .with_batch_config(
             BatchConfigBuilder::default()
                 .with_max_export_batch_size(batch_size as usize)
@@ -354,6 +422,98 @@ pub unsafe extern "C" fn nxt_otel_rs_send_trace(trace: *mut BoxedSpan) {
     // exports it from its own background thread; the Box is then dropped here.
     let mut span = Box::from_raw(trace);
     span.end();
+}
+
+/// Flush and tear down the live tracer provider with a caller-supplied bound,
+/// for use on the process exit path.
+///
+/// `nxt_otel_rs_shutdown_tracer` can block for as long as the exporter's own
+/// `EXPORT_TIMEOUT` (10s) when the collector is unreachable, which is far too
+/// long to sit in front of `exit()`. The provider and runtime are taken out of
+/// their slots here and *moved* into a helper thread, so the statics are left
+/// empty and unlocked whatever happens; we then wait up to `timeout_ms` for
+/// that thread to finish flushing. On timeout we give up and return: the
+/// helper thread is left running and dies with the process. Best effort by
+/// construction — spans that could not be flushed in the budget are lost,
+/// exactly as they are today, but a dead collector can no longer delay exit.
+///
+/// Returns one of three statuses, mirrored in `src/nxt_otel.h`:
+///
+/// * `NXT_OTEL_SHUTDOWN_FLUSHED` (1) — the flush completed within the budget
+///   and no export has failed since this provider was installed.
+/// * `NXT_OTEL_SHUTDOWN_FAILED` (2) — an export failed. Either the flush this
+///   call forced failed, or `EXPORT_FAILED` records an earlier batch that did:
+///   the processor exports on its own schedule and discards the result, so the
+///   only way that failure is visible at all is the sticky flag. The helper
+///   thread failing to spawn reports here too; it is a failure, not a timeout.
+/// * `NXT_OTEL_SHUTDOWN_TIMEOUT` (0) — the helper thread did not answer inside
+///   `timeout_ms`. Kept distinct from the above because a rejected export
+///   fails in milliseconds, and calling that a timeout sends an operator
+///   looking for latency that is not there.
+///
+/// One loss remains unreportable from here: the router's worker engines are
+/// still live when `nxt_runtime_exit` calls this, so a span they end after the
+/// flush reaches a provider that is already shut down and is dropped without a
+/// word. Nothing at this layer can see it — the engine threads are never
+/// joined (`nxt_thread_join` has no call sites), so producers cannot be
+/// quiesced first. That needs the P5 graceful-shutdown work and is tracked in
+/// issue #219. A `FLUSHED` return therefore means "this flush succeeded and no
+/// export has failed", not "no spans were lost".
+#[no_mangle]
+pub unsafe extern "C" fn nxt_otel_rs_shutdown_bounded(timeout_ms: u64) -> u8 {
+    let provider = provider_slot().lock().ok().and_then(|mut g| g.take());
+    let rt = runtime_slot().lock().ok().and_then(|mut g| g.take());
+
+    if provider.is_none() && rt.is_none() {
+        return if EXPORT_FAILED.load(Ordering::Acquire) {
+            NXT_OTEL_SHUTDOWN_FAILED
+        } else {
+            NXT_OTEL_SHUTDOWN_FLUSHED
+        };
+    }
+
+    let (tx, rx) = mpsc::channel::<bool>();
+
+    let spawned = std::thread::Builder::new()
+        .name("otel-shutdown".to_string())
+        .spawn(move || {
+            let mut flushed = true;
+
+            if let Some(provider) = provider {
+                // Needs the runtime alive on a grpc build, hence the ordering.
+                //
+                // force_flush() first, because it is the only one of the two
+                // that reports whether the spans actually left: the batch
+                // processor hands shutdown() the export result and shutdown()
+                // throws it away, reporting only that the worker answered.  A
+                // collector that refuses the connection fails in milliseconds,
+                // so shutdown() alone would call that a clean flush and exit
+                // without a word.  Both run whatever the first one says.
+                let exported = provider.force_flush().is_ok();
+                let stopped = provider.shutdown().is_ok();
+
+                flushed = exported && stopped;
+            }
+            if let Some(rt) = rt {
+                rt.shutdown_background();
+            }
+            // Read the sticky flag only after the flush above, so a batch the
+            // flush itself pushed out and failed on is counted here too.
+            let _ = tx.send(flushed && !EXPORT_FAILED.load(Ordering::Acquire));
+        });
+
+    // The caller logs these, so they must not be conflated: a collector that
+    // rejects the export fails in milliseconds, and reporting that as a
+    // timeout sends an operator looking for latency that is not there.
+    match spawned {
+        Ok(_) => match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+            Ok(true) => NXT_OTEL_SHUTDOWN_FLUSHED,
+            Ok(false) => NXT_OTEL_SHUTDOWN_FAILED,
+            Err(_) => NXT_OTEL_SHUTDOWN_TIMEOUT,
+        },
+        // Nothing flushed at all, and no time was spent trying.
+        Err(_) => NXT_OTEL_SHUTDOWN_FAILED,
+    }
 }
 
 /// Flush and tear down the live tracer provider, if any.


### PR DESCRIPTION
Three lifecycle defects in the OpenTelemetry support: a span leak on aborted requests, no flush at exit, and a reconfiguration stall. Found while auditing the subsystem against the original author's account of it in #65, where he confirms it shipped as an MVP intended for immediate iteration that never happened.

### 1. A request's span now belongs to the memory pool that holds it (`498caae4`)

`nxt_otel_span_collect()` is reachable only through `NXT_OTEL_COLLECT_STATE`. But `init_state` and `body_state` set `.error_handler = nxt_http_request_close_handler` directly (`src/nxt_http_request.c:307`, `:545`), and that handler releases the request pool with no otel hook. A request aborted before response headers therefore never reached COLLECT, and the `Box<BoxedSpan>` allocated on the Rust heap at header parse was never freed — unbounded growth under client aborts with telemetry enabled.

The fix registers an `nxt_mp_cleanup()` handler on `r->mem_pool` when the span is created (`src/nxt_otel.c:485-505`), the same idiom `src/nxt_http_static.c:801` uses to tie an fd to a request. **Every exit path releases the pool, so every exit path now releases the span — including exits not yet written.** A hook on the error handler would only have covered the two exits that exist today.

Idempotency rests on `nxt_otel_span_collect()` NULLing `r->otel->trace` after it sends (`src/nxt_otel.c:353`); the cleanup early-returns on NULL. That is the only other site calling `nxt_otel_rs_send_trace()` on the request path, so no path ends a span without clearing the pointer.

**The aborted span is ended and exported with `Status::Error`, not dropped.** An aborted or timed-out request is usually the interesting trace, and a span that simply vanishes is indistinguishable from broken telemetry. This cannot stall the engine thread: `nxt_otel_rs_send_trace()` only calls `span.end()`, which enqueues onto the batch processor — the OTLP export runs later on that processor's own thread.

Exercised, not only reasoned about: against a `--debug --otel` unitd, a `POST` announcing `Content-Length: 100` that sends 5 bytes and closes logs `otel: releasing the span of an unfinished request`. A normal request does not.

### 2. Flush the span pipeline before the router exits (`2923825b`)

Nothing called `nxt_otel_rs_uninit` at exit — the only lifecycle callers were the reconfigure path — so up to 4096 queued spans plus the current batch were discarded when the router exited.

New `nxt_otel_rs_shutdown_bounded(timeout_ms)` in `src/otel/src/lib.rs` takes the provider and tokio runtime *out* of their static slots first, then moves them into a helper thread and waits with `mpsc::recv_timeout`, so the statics are left empty and unlocked however the wait ends. Called from `nxt_runtime_exit()` gated on `rt->type == NXT_PROCESS_ROUTER` (`src/nxt_runtime.c:625`) — the single funnel that the quit port message, SIGTERM/SIGQUIT and internal failures all converge on.

**What the warning does and does not cover.** The helper runs `force_flush()` before `shutdown()` and folds both results in. That matters because `shutdown()` alone reports only that the batch worker *answered*: `shutdown_with_timeout()` receives the worker's export result and discards it (`opentelemetry_sdk-0.32.1/src/trace/span_processor.rs:703-710`), so a collector that refuses the connection fails in milliseconds and would look like a clean flush. `force_flush()` propagates the export result (`:658-666`), so the exit path now reports a failing final export as well as a stalled one.

It still does **not** report a batch that failed *earlier* and was already discarded: a size-triggered export drops its spans before exporting and throws the result away (`:394`, `:562`), so a later `force_flush()` legitimately sees an empty queue. That is pre-existing batch-processor behaviour rather than something these commits change, and it is tracked separately in #219.

**Budget is 2s, best-effort, with a `[warn]` on timeout.** A reachable collector needs milliseconds; ten seconds of silence in front of `exit()` is the more visible regression. Spans not flushed inside the budget are lost exactly as they are today — the difference is that the log now says so.

Measured both directions: with `batch_size` above the pending span count, a local collector received the OTLP POST only after SIGTERM (shutdown 0.12s). Against a blackholed address, shutdown took 2.03s plus the warning, versus the 10s an unbounded flush would take.

### 3. Rebuild the exporter only when telemetry changed (`19b6f28b`)

Every config apply with telemetry present — even an unrelated app or route change — synchronously flushed and rebuilt the exporter on the router control thread, blocking up to the hardcoded 10s export timeout against a dead collector and dropping in-flight spans across the swap.

`src/nxt_router.c` now keeps the applied telemetry config (endpoint and protocol copied out of the conf pool, plus the two doubles) and skips `nxt_otel_rs_init()` when it is unchanged. It also consults `nxt_otel_rs_is_init()` so a Rust-side init failure is retried rather than remembered as applied, and removing the section still tears down and clears the cache.

Kept deliberately narrow: only exact equality counts as unchanged and anything else falls through to the previous behaviour. The doubles are compared exactly — the same JSON text reparsed each apply reproduces them bit-for-bit, and an unexpected inequality costs one rebuild, not a bug.

Measured against a blackholed collector with spans queued: two route-only applies at 11ms each, while changing the endpoint still pays 5s. Previously all three paid it.

## Verification

- `--openssl --otel --tests`: `make` exit 0, zero warnings, `./build/tests` exit 0.
- `--openssl --tests` (no otel): configure reports `otel support: NO`, `make` exit 0, `./build/tests` exit 0.
- A third `--debug --otel` build was used for the runtime checks above.

## Not verified

- **The Python suite was not run** (port contention in the dev environment).
- **The gRPC transport path of `shutdown_bounded` was not exercised** — only OTLP/HTTP. The code path is shared apart from `rt.shutdown_background()`.
- The two intermediate commits were not separately compiled, though commit 1 was checked to reference nothing from commit 2.

## Out of scope

The crate still links no TLS stack, so `https://` collectors remain unreachable and the endpoint must be plain `http://` — a sidecar collector on localhost is the working posture. That is a separate question from these three defects; there is reason to think it may cost only a Cargo feature rather than a redesign, but that experiment is unfinished and deliberately not part of this PR.

