### PR TITLE
otel: make export failures continuously observable

### DIFF
--- a/src/nxt_otel.h
+++ b/src/nxt_otel.h
@@ -33,6 +33,13 @@ extern void nxt_otel_rs_set_error(void *trace);
 extern uint8_t nxt_otel_rs_is_init(void);
 extern void nxt_otel_rs_uninit(void);
 extern uint8_t nxt_otel_rs_shutdown_bounded(uint64_t timeout_ms);
+/*
+ * Span export health for the /status API: writes the number of spans the
+ * exporter accepted and the number it rejected since the live provider was
+ * installed, and returns non-zero when a provider is installed at all.  When
+ * it returns 0 the two counters are meaningless and must not be reported.
+ */
+extern uint8_t nxt_otel_rs_export_stats(uint64_t *exported, uint64_t *failed);
 
 /*
  * Return values of nxt_otel_rs_shutdown_bounded().  Defined on the Rust side

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -1001,6 +1001,19 @@ nxt_router_status_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     } nxt_queue_loop;
 
+#if (NXT_HAVE_OTEL)
+    /*
+     * Span export health.  The counters live in the Rust exporter wrapper,
+     * which runs in this process, so the router is the only place they can be
+     * read from.  A build without OTel, or a configuration with no
+     * "settings/telemetry", leaves the memzero'd zeros in place and
+     * nxt_status_get() then omits the "telemetry" object entirely.
+     */
+    report->otel_configured = nxt_otel_rs_export_stats(
+                                  &report->otel_spans_exported,
+                                  &report->otel_spans_failed);
+#endif
+
     report->apps_count = 0;
     app_stat = report->apps;
     p = b->mem.end;

--- a/src/nxt_status.c
+++ b/src/nxt_status.c
@@ -35,11 +35,21 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
     static const nxt_str_t  reqs_str = nxt_string("requests");
     static const nxt_str_t  total_str = nxt_string("total");
     static const nxt_str_t  apps_str = nxt_string("applications");
+    static const nxt_str_t  telemetry_str = nxt_string("telemetry");
+    static const nxt_str_t  spans_str = nxt_string("spans");
+    static const nxt_str_t  exported_str = nxt_string("exported");
+    static const nxt_str_t  failed_str = nxt_string("failed");
     static const nxt_str_t  procs_str = nxt_string("processes");
     static const nxt_str_t  run_str = nxt_string("running");
     static const nxt_str_t  start_str = nxt_string("starting");
 
-    status = nxt_conf_create_object(mp, 4);
+    /*
+     * modules, connections, requests, applications -- plus "telemetry" when
+     * OTel is built in and currently configured.  It is omitted rather than
+     * zeroed otherwise, so a build or a configuration without telemetry
+     * reports exactly what it did before.
+     */
+    status = nxt_conf_create_object(mp, 4 + (report->otel_configured != 0));
     if (nxt_slow_path(status == NULL)) {
         return NULL;
     }
@@ -147,6 +157,36 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
     nxt_conf_set_member(status, &reqs_str, obj, idx++);
 
     nxt_conf_set_member_integer(obj, &total_str, report->requests, 0);
+
+    if (report->otel_configured) {
+        nxt_conf_value_t  *spans;
+
+        /*
+         * "is my telemetry reaching the collector?" needs both halves: a
+         * failure count alone cannot tell a healthy pipeline from one that
+         * has never exported anything.  Both are cumulative since the live
+         * tracer provider was installed, so a telemetry reconfiguration
+         * restarts them.
+         */
+        obj = nxt_conf_create_object(mp, 1);
+        if (nxt_slow_path(obj == NULL)) {
+            return NULL;
+        }
+
+        nxt_conf_set_member(status, &telemetry_str, obj, idx++);
+
+        spans = nxt_conf_create_object(mp, 2);
+        if (nxt_slow_path(spans == NULL)) {
+            return NULL;
+        }
+
+        nxt_conf_set_member(obj, &spans_str, spans, 0);
+
+        nxt_conf_set_member_integer(spans, &exported_str,
+                                    report->otel_spans_exported, 0);
+        nxt_conf_set_member_integer(spans, &failed_str,
+                                    report->otel_spans_failed, 1);
+    }
 
     apps = nxt_conf_create_object(mp, report->apps_count);
     if (nxt_slow_path(apps == NULL)) {

--- a/src/nxt_status.h
+++ b/src/nxt_status.h
@@ -22,6 +22,19 @@ typedef struct {
     uint64_t          closed_conns;
     uint64_t          requests;
 
+    /*
+     * OpenTelemetry span export health, filled in by the router.  The two
+     * counters are only meaningful when otel_configured is set: a build
+     * without OTel support, or one where "settings/telemetry" is absent,
+     * leaves them zero and reports no "telemetry" object in /status at all.
+     *
+     * Counted in spans since the live tracer provider was installed, i.e.
+     * reset by a telemetry reconfiguration.
+     */
+    uint64_t          otel_spans_exported;
+    uint64_t          otel_spans_failed;
+    uint8_t           otel_configured;
+
     size_t            apps_count;
     nxt_status_app_t  apps[];
 } nxt_status_report_t;

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -29,7 +29,7 @@ use opentelemetry_sdk::trace::{
 use opentelemetry_sdk::Resource;
 use std::ffi::{c_char, CStr, CString};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -88,6 +88,19 @@ fn runtime_slot() -> &'static Mutex<Option<tokio::runtime::Runtime>> {
 /// before exit would leave nothing at all for the shutdown path to report.
 static EXPORT_FAILED: AtomicBool = AtomicBool::new(false);
 
+/// Spans in batches the exporter accepted, and spans in batches it rejected,
+/// since the live provider was installed.  Read out by
+/// `nxt_otel_rs_export_stats` for the `/status` API, which is the only way an
+/// operator can see export health without waiting for the process to exit.
+///
+/// Counted in spans rather than batches because the number an operator needs
+/// is "how much telemetry did I lose", and a batch is a variable-size unit
+/// that answers that only by accident.  Neither counter includes spans the
+/// processor dropped before an export was attempted (a full queue): that
+/// happens inside the SDK, which reports it nowhere we can observe.
+static SPANS_EXPORTED: AtomicU64 = AtomicU64::new(0);
+static SPANS_FAILED: AtomicU64 = AtomicU64::new(0);
+
 /// Wraps the configured OTLP exporter so a failed export is remembered in
 /// `EXPORT_FAILED` even when the processor discards the result.
 ///
@@ -101,10 +114,20 @@ struct FailureTrackingExporter<E> {
 
 impl<E: SdkSpanExporter> SdkSpanExporter for FailureTrackingExporter<E> {
     async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        // Count before the batch is moved into the inner exporter.
+        let spans = batch.len() as u64;
+
         let res = self.inner.export(batch).await;
 
         if res.is_err() {
+            // The boolean is kept alongside the counter rather than derived
+            // from it: it is the fact the shutdown path asks for ("has any
+            // export failed"), and it stays true even for the degenerate
+            // empty batch that would add nothing to SPANS_FAILED.
             EXPORT_FAILED.store(true, Ordering::Release);
+            SPANS_FAILED.fetch_add(spans, Ordering::Relaxed);
+        } else {
+            SPANS_EXPORTED.fetch_add(spans, Ordering::Relaxed);
         }
 
         res
@@ -196,6 +219,44 @@ pub unsafe extern "C" fn nxt_otel_rs_is_init() -> u8 {
         .unwrap_or(0)
 }
 
+/// Report span export health for the `/status` API.
+///
+/// Writes the number of spans the exporter accepted and the number it
+/// rejected since the live provider was installed, and returns 1 when a
+/// provider is installed at all.
+///
+/// The counters are written whether or not a provider is installed, so on a
+/// 0 return they hold whatever the previous provider left behind -- they are
+/// only zeroed when a new one is installed.  A 0 return therefore means the
+/// values are stale, not absent: the caller must ignore them rather than
+/// report them.
+///
+/// The counters are read with two independent `Relaxed` loads, so a report
+/// taken while an export is completing can be off by one batch.  That is
+/// deliberate: this is a health gauge, not an accounting ledger, and taking a
+/// lock on the export path to make the pair atomic would cost more than the
+/// skew is worth.
+///
+/// # Safety
+///
+/// `exported` and `failed` must each be either null or a valid, aligned,
+/// writable `uint64_t`.
+#[no_mangle]
+pub unsafe extern "C" fn nxt_otel_rs_export_stats(
+    exported: *mut u64,
+    failed: *mut u64,
+) -> u8 {
+    if !exported.is_null() {
+        *exported = SPANS_EXPORTED.load(Ordering::Relaxed);
+    }
+
+    if !failed.is_null() {
+        *failed = SPANS_FAILED.load(Ordering::Relaxed);
+    }
+
+    nxt_otel_rs_is_init()
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn nxt_otel_rs_uninit() {
     nxt_otel_rs_shutdown_tracer();
@@ -254,6 +315,8 @@ pub unsafe extern "C" fn nxt_otel_rs_init(
     // exit, describing a failure that was real but belonged to the old
     // exporter -- not worth a second flag to suppress.
     EXPORT_FAILED.store(false, Ordering::Release);
+    SPANS_EXPORTED.store(0, Ordering::Relaxed);
+    SPANS_FAILED.store(0, Ordering::Relaxed);
 
     let processor = BatchSpanProcessor::builder(FailureTrackingExporter { inner: exporter })
         .with_batch_config(

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -17,7 +17,9 @@ client = ApplicationProto()
 # and OTLP/gRPC, so the transport under test is chosen by config (--protocol),
 # never by how the mock was built. CI installs it via the "Build fake_otlp" step
 # in ci.yml, mirroring fake_upstream. Skip gracefully when it is not built.
-FAKE_OTLP_BIN = '/usr/local/bin/fake_otlp'
+# Overridable so the suite can be run against a locally built fake_otlp
+# without root (installing into /usr/local/bin needs it).
+FAKE_OTLP_BIN = os.environ.get('FAKE_OTLP_BIN', '/usr/local/bin/fake_otlp')
 
 _skipif_no_fake_otlp = pytest.mark.skipif(
     not os.path.exists(FAKE_OTLP_BIN),
@@ -763,3 +765,73 @@ def test_otel_sampling_ratio_nonfinite_rejected():
 
     conf = client.conf(body)
     assert 'error' in conf, f'non-finite sampling_ratio must be rejected: {conf}'
+
+
+def _status_telemetry():
+    """The /status "telemetry" object, or None when it is absent."""
+    return client.conf_get('/status').get('telemetry')
+
+
+def _wait_for_spans(field, timeout=EXPORT_TIMEOUT, delay=0.1):
+    """Poll /status until telemetry/spans/<field> is non-zero; return the object."""
+    deadline = time.time() + timeout
+    telemetry = _status_telemetry()
+    while time.time() < deadline:
+        if telemetry is not None and telemetry['spans'][field] > 0:
+            return telemetry
+        time.sleep(delay)
+        telemetry = _status_telemetry()
+    return telemetry
+
+
+def test_otel_status_absent_without_telemetry():
+    """/status carries no "telemetry" object when telemetry is not configured.
+
+    True of a build without --otel as well, which is why this one does not
+    probe for OTel support first: the absence is the contract in both cases.
+    """
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [{"action": {"return": 200}}],
+            "applications": {},
+        }
+    )
+
+    assert _status_telemetry() is None
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_status_counts_exported_spans(protocol):
+    """A span that reaches the collector is counted in /status (issue #219)."""
+    port = _get_free_port()
+    proc = _run_fake_otlp(port, protocol=protocol)
+    try:
+        _configure_or_skip(port, protocol=protocol)
+
+        assert _get_until_header('traceparent')['status'] == 200
+
+        telemetry = _wait_for_spans('exported')
+        assert telemetry is not None, '/status must report telemetry when configured'
+        assert telemetry['spans']['exported'] > 0, 'exported spans must be counted'
+        assert telemetry['spans']['failed'] == 0, 'a live collector must not fail'
+    finally:
+        _kill(proc)
+
+
+def test_otel_status_counts_failed_spans():
+    """An export the collector refuses is counted as failed, while the process
+    is still running -- the whole point of #219: before this the only signal
+    was a log line at exit.
+    """
+    # Nothing is listening here: the export is refused, not merely slow.
+    port = _get_free_port()
+    _configure_or_skip(port)
+
+    assert _get_until_header('traceparent')['status'] == 200
+
+    telemetry = _wait_for_spans('failed')
+    assert telemetry is not None, '/status must report telemetry when configured'
+    assert telemetry['spans']['failed'] > 0, 'a refused export must be counted'
+    assert telemetry['spans']['exported'] == 0, 'nothing can have been exported'


### PR DESCRIPTION
# otel: make export failures continuously observable

Closes #219. **Stacked on #218** (`fix/otel-span-lifecycle`) — review and merge that
first. This branch is based on its head, and the diff assumes #218's exporter wrapper.

## What #219 asked for

`BatchSpanProcessor` throws away the result of every batch it exports on its own
schedule. A failed batch therefore leaves nothing behind: the spans are gone from the
queue, `force_flush()` at exit finds nothing to do, and the process exits reporting a
clean flush. The issue asked us to record the failure somewhere durable. It left two
questions open: is a boolean the right shape, and should this appear anywhere other than
exit?

## What #218 already delivered

The issue predates #218's fix, so the base branch already contains half of it:

- a `FailureTrackingExporter<E>` wrapping the OTLP exporter at the single
  `BatchSpanProcessor::builder(...)` site, which covers both transports;
- a process-wide sticky `EXPORT_FAILED: AtomicBool`, cleared when a new provider is
  installed;
- that flag folded into `nxt_otel_rs_shutdown_bounded()`, which reports `TIMEOUT`,
  `FLUSHED` or `FAILED`.

That answers "record it durably". This PR answers the two open questions.

## What this PR adds

**1. Spans counted by export outcome.** Two atomics in the exporter wrapper. Each export
adds the batch length to one of them. Both reset with the sticky flag when a new provider
is installed. A boolean fires the same way for one transient blip and for a collector
that has refused everything for hours; a count does not.

**2. Continuous visibility through the existing status API.**
`nxt_otel_rs_export_stats()` reads the pair. The router folds it into the status report —
the exporter runs in the router, so the router is the only process that can read the
counters — and the controller renders it:

```json
"telemetry": {
    "spans": {
        "exported": 4211,
        "failed": 12
    }
}
```

An operator now sees a broken pipeline at 09:00, instead of learning about it when the
process next stops.

## The schema, and why it is this and not more

This is public API surface, so the bias is towards the smallest set that answers *"is my
telemetry reaching the collector?"*.

- **Two counters, not one.** A failure count alone cannot separate a healthy pipeline
  from one that has never exported anything. `exported` is what makes `failed == 0`
  mean something.
- **Spans, not batches.** An operator wants to know how much telemetry was lost. A batch
  is a variable-size unit, so it answers that only by accident.
- **`spans`, not `traces`.** OTel names its signals traces, metrics and logs, so `spans`
  names the counted unit rather than the signal. That is deliberate: a future metrics
  signal would count data points, not "metrics", so unit-named keys stay consistent as
  signals are added. Worth stating plainly, because the choice is hard to reverse.
- **Counters, not timestamps.** We considered a last-success timestamp and dropped it.
  `/status` is polled, and two samples of a monotonic counter give both liveness and
  rate, which is what alerting needs. A timestamp also raises "in which clock, formatted
  how" on a surface that is easy to add to and hard to subtract from. If a timestamp
  turns out to be useful, we can add it next to these. The reverse is not true.
- **No last-error string.** It would be the highest-variance, lowest-value member of the
  set: unbounded, exporter-specific, already in the log, and awkward to keep stable. The
  transport error belongs in the log line, not in a machine-read API.
- **Cumulative since the live provider was installed.** A telemetry reconfiguration
  resets them, so the counters describe the exporter that is running rather than the one
  it replaced. #218 skips the rebuild when the telemetry section is unchanged, so an
  unrelated config apply does not reset them. Note that `connections` and `requests` in
  the same reply reset only when the router restarts, so these counters reset more often
  than their neighbours.
- **Omitted, not zeroed, when telemetry is off.** A build without `--otel`, or a
  configuration without `settings/telemetry`, produces no `"telemetry"` member at all.
  `/status` is therefore byte for byte what it was before on every configuration that
  does not use telemetry.

The report struct fields are **not** build-gated, although the code that fills them is.
The struct crosses the router→controller port message, but that is not the reason: both
processes are `fork()` children of main with no exec, and Unit has no binary-upgrade
path, so a differently-built pair cannot occur. The reason is narrower. `nxt_status.c`
reads `report->otel_configured` unconditionally, so gating the fields would push
`#if (NXT_HAVE_OTEL)` into the controller side as well, for no benefit.

The sticky boolean stays rather than being derived from `spans.failed != 0`. It is
exactly the fact the shutdown path asks for, it survives the degenerate empty batch that
moves no counter, and re-deriving it would risk #218's three shutdown statuses for no
gain. Nothing in #218's shutdown behaviour changes here.

## Out of scope

- **The producer race.** A span that a still-live worker engine ends *after* the exit
  flush reaches a provider that is already shut down, and is dropped silently. Nothing at
  this layer can see it: the engine threads are never joined (`nxt_thread_join` has zero
  call sites in `src/`), so producers cannot be quiesced before `exit()`. That needs the
  P5 router-drain work. It stays noted in the code comments and in #219.
- **Queue-overflow drops.** When the queue is full the SDK discards spans before it
  attempts an export, and reports that nowhere observable. Neither counter includes them,
  and the field docs say so.
- **Partial success.** When a collector accepts a request but rejects some spans, the SDK
  exporter still returns `Ok`, so those spans count as `exported`. This layer cannot see
  the difference.
- **The telemetry config surface** is untouched.
- **Docs.** The new `/status` member needs a companion PR against the docs repo.

## Verification

Run on a Linux box with a real collector. `test/test_otel.py` had never been executed in
this environment before, because port 8080 was occupied on the usual machine. This is
therefore also the first end-to-end exercise of #218's changes.

- `./configure --openssl --otel --tests` + `make` + `./build/tests` — clean.
- `pytest test/test_otel.py` — **36 passed**, including the 4 new cases: `telemetry`
  absent when unconfigured; `exported` moves against a live `fake_otlp` on both `http`
  and `grpc`; `failed` moves against a closed port.
- `pytest test/test_status.py` — 6 passed with the python module built, so the existing
  `/status` shape is unchanged.
- Manual dead-collector run: telemetry pointed at a closed port, three requests, then
  `SIGQUIT`. `/status` reported `{"exported": 0, "failed": 3}` **while the process was
  still running**, and the exit path logged the *failure* warning rather than the timeout
  one. That is the first time that branch has been observed firing rather than reasoned
  about.
- Non-otel build (`./configure` with no `--otel`, `-Werror`) compiles clean, and
  `/status` output is identical to before, with no `telemetry` member.

**Not run:** the sanitizer builds, the full pytest suite, and any non-Linux platform.
Port 8080 is taken by an unrelated service on that box too, so only the two files above
were run, against shifted ports. `cargo fmt` reports diffs in this crate, but all of them
sit on pre-existing lines — the new code introduces none.
