### PR TITLE
otel: take the avoidable work off the request path (#221 fixes 1-3)

### DIFF
--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -107,7 +107,6 @@ static void
 nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
 {
     u_char            *traceval;
-    nxt_str_t         traceparent_name, traceparent;
     nxt_http_field_t  *f;
 
     traceval = nxt_mp_zalloc(r->mem_pool, NXT_OTEL_TRACEPARENT_LEN + 1);
@@ -151,19 +150,6 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
         nxt_http_field_name_set(f, "traceparent");
         f->value = traceval;
         f->value_length = nxt_strlen(traceval);
-
-        traceparent_name = (nxt_str_t) {
-            .start  = f->name,
-            .length = f->name_length,
-        };
-
-        traceparent = (nxt_str_t) {
-            .start  = f->value,
-            .length = f->value_length,
-        };
-
-        nxt_otel_rs_add_event_to_trace(r->otel->trace,
-                                       &traceparent_name, &traceparent);
     }
 
     f = nxt_http_resp_field_zero_add(&r->resp, r->mem_pool);
@@ -180,17 +166,9 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
 
 
 static void
-nxt_otel_span_add_headers(nxt_task_t *task, nxt_http_request_t *r)
+nxt_otel_span_add_request_attrs(nxt_http_request_t *r)
 {
     nxt_str_t  val;
-
-    nxt_log(task, NXT_LOG_DEBUG, "adding attributes to trace");
-
-    if (r->otel == NULL || r->otel->trace == NULL) {
-        nxt_log(task, NXT_LOG_ERR, "no trace to add attributes to!");
-        nxt_otel_state_transition(r->otel, NXT_OTEL_ERROR_STATE);
-        return;
-    }
 
     /*
      * Record only well-defined semconv attributes. We deliberately do NOT
@@ -229,6 +207,33 @@ nxt_otel_span_add_headers(nxt_task_t *task, nxt_http_request_t *r)
         val.length = r->remote->address_length;
         nxt_otel_add_attr(r, NXT_OTEL_CLIENT_ADDR_TAG, &val);
     }
+}
+
+
+static void
+nxt_otel_span_add_headers(nxt_task_t *task, nxt_http_request_t *r)
+{
+    nxt_log(task, NXT_LOG_DEBUG, "adding attributes to trace");
+
+    if (r->otel == NULL || r->otel->trace == NULL) {
+        nxt_log(task, NXT_LOG_ERR, "no trace to add attributes to!");
+        nxt_otel_state_transition(r->otel, NXT_OTEL_ERROR_STATE);
+        return;
+    }
+
+    /*
+     * A span the sampler dropped records nothing, yet every attribute value
+     * is still assembled before the call that discards it.  Skip that work.
+     *
+     * Propagation below is not part of the bargain: the traceparent must
+     * reach the peer and the application whatever the sampling decision was,
+     * so that a downstream service can continue -- or deliberately not
+     * continue -- the same trace.
+     */
+
+    if (r->otel->recording) {
+        nxt_otel_span_add_request_attrs(r);
+    }
 
     nxt_otel_propagate_header(task, r);
 
@@ -244,6 +249,11 @@ nxt_otel_span_add_body(nxt_http_request_t *r)
     u_char     *body_buf, *body_size_buf;
     nxt_int_t  cur;
     nxt_str_t  body_val;
+
+    if (!r->otel->recording) {
+        nxt_otel_state_transition(r->otel, NXT_OTEL_COLLECT_STATE);
+        return;
+    }
 
     if (r->body != NULL) {
         body_size = nxt_buf_used_size(r->body);
@@ -291,7 +301,7 @@ nxt_otel_span_add_status(nxt_task_t *task, nxt_http_request_t *r)
     nxt_app_t               *app;
     nxt_request_rpc_data_t  *rpc;
 
-    if (r->otel == NULL || r->otel->trace == NULL) {
+    if (r->otel == NULL || r->otel->trace == NULL || !r->otel->recording) {
         return;
     }
 
@@ -505,6 +515,8 @@ nxt_otel_trace_and_span_init(nxt_task_t *task, nxt_http_request_t *r)
         nxt_otel_state_transition(r->otel, NXT_OTEL_ERROR_STATE);
         return;
     }
+
+    r->otel->recording = nxt_otel_rs_is_recording(r->otel->trace);
 
     nxt_otel_state_transition(r->otel, NXT_OTEL_HEADER_STATE);
 }

--- a/src/nxt_otel.h
+++ b/src/nxt_otel.h
@@ -26,10 +26,9 @@ extern void nxt_otel_rs_init(
     const nxt_str_t *endpoint, const nxt_str_t *protocol,
     double sample_fraction, double batch_size);
 extern void nxt_otel_rs_copy_traceparent(u_char *buffer, void *span);
-extern void nxt_otel_rs_add_event_to_trace(void *trace, nxt_str_t *key,
-    nxt_str_t *val);
 extern void nxt_otel_rs_add_attr(void *trace, nxt_str_t *key, nxt_str_t *val);
 extern void nxt_otel_rs_set_error(void *trace);
+extern uint8_t nxt_otel_rs_is_recording(void *trace);
 extern uint8_t nxt_otel_rs_is_init(void);
 extern void nxt_otel_rs_uninit(void);
 extern uint8_t nxt_otel_rs_shutdown_bounded(uint64_t timeout_ms);
@@ -90,6 +89,8 @@ struct nxt_otel_state_s {
     void               *trace;
     nxt_otel_status_t  status;
     nxt_str_t          trace_state;
+    /* The sampler's verdict on this span, cached at creation. */
+    uint8_t            recording;
 };
 
 

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -14,7 +14,7 @@
 //! which exports it from its own background thread.
 
 use opentelemetry::global;
-use opentelemetry::global::BoxedSpan;
+use opentelemetry::global::{BoxedSpan, BoxedTracer};
 use opentelemetry::trace::{
     Span, SpanContext, SpanId, SpanKind, Status, TraceContextExt, TraceFlags,
     TraceId, TraceState, Tracer, TracerProvider,
@@ -31,7 +31,7 @@ use std::ffi::{c_char, CStr, CString};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 use std::time::Duration;
 use std::{ptr, slice};
 
@@ -71,6 +71,19 @@ type nxt_otel_log_cb = unsafe extern "C" fn(log_level: nxt_uint_t, msg: *const c
 fn provider_slot() -> &'static Mutex<Option<SdkTracerProvider>> {
     static PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);
     &PROVIDER
+}
+
+/// The tracer built from the live provider.
+///
+/// `global::tracer_provider().tracer()` takes the global provider's lock,
+/// clones the provider and heap-allocates a fresh tracer on every call, but a
+/// tracer is meant to be built once. Caching it leaves the request path with
+/// one uncontended read lock instead. `None` means no provider is installed;
+/// the request path then falls back to the global one, so behaviour is
+/// unchanged either way.
+fn tracer_slot() -> &'static RwLock<Option<BoxedTracer>> {
+    static TRACER: RwLock<Option<BoxedTracer>> = RwLock::new(None);
+    &TRACER
 }
 
 /// The tokio runtime owning the gRPC exporter's tonic channel. The blocking
@@ -341,6 +354,10 @@ pub unsafe extern "C" fn nxt_otel_rs_init(
 
     global::set_tracer_provider(provider.clone());
 
+    if let Ok(mut slot) = tracer_slot().write() {
+        *slot = Some(global::tracer_provider().tracer(TRACER_NAME));
+    }
+
     if let Ok(mut slot) = provider_slot().lock() {
         *slot = Some(provider);
     }
@@ -372,25 +389,8 @@ pub unsafe extern "C" fn nxt_otel_rs_copy_traceparent(buf: *mut c_char, span: *c
     *buf.add(TRACEPARENT_HEADER_LEN as usize) = 0;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn nxt_otel_rs_add_event_to_trace(
-    trace: *mut BoxedSpan,
-    key: *const nxt_str_t,
-    val: *const nxt_str_t,
-) {
-    if trace.is_null() || key.is_null() || val.is_null() {
-        return;
-    }
-
-    let key = nxt_str_to_string(&*key);
-    let val = nxt_str_to_string(&*val);
-
-    (*trace).add_event("Unit Attribute".to_string(), vec![KeyValue::new(key, val)]);
-}
-
 /// Set a semantic-convention span attribute (e.g. `http.request.method`).
-/// Unlike `add_event_to_trace`, this records structured span attributes the
-/// collector can index and query, not timestamped events.
+/// These are structured span attributes the collector can index and query.
 #[no_mangle]
 pub unsafe extern "C" fn nxt_otel_rs_add_attr(
     trace: *mut BoxedSpan,
@@ -405,6 +405,22 @@ pub unsafe extern "C" fn nxt_otel_rs_add_attr(
     let val = nxt_str_to_string(&*val);
 
     (*trace).set_attribute(KeyValue::new(key, val));
+}
+
+/// Whether the sampler kept this span.
+///
+/// C asks once, right after the span is built, and skips the attribute work
+/// for a span that is not recording. `set_attribute` on such a span is
+/// already a no-op, but its arguments are built before the call that throws
+/// them away -- so without this gate, lowering `sampling_ratio` buys back the
+/// exporter and nothing on the request path.
+#[no_mangle]
+pub unsafe extern "C" fn nxt_otel_rs_is_recording(trace: *mut BoxedSpan) -> u8 {
+    if trace.is_null() {
+        return 0;
+    }
+
+    (*trace).is_recording() as u8
 }
 
 /// Mark the span as errored. Called by C for 5xx responses so the trace is
@@ -457,6 +473,12 @@ unsafe fn nxt_otel_parent_context(
     Some(Context::new().with_remote_span_context(sc))
 }
 
+fn nxt_otel_build_span(tracer: &BoxedTracer, parent: &Context) -> BoxedSpan {
+    let builder = tracer.span_builder(SPAN_NAME).with_kind(SpanKind::Server);
+
+    tracer.build_with_context(builder, parent)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn nxt_otel_rs_get_or_create_trace(
     trace_id: *const c_char,
@@ -464,12 +486,23 @@ pub unsafe extern "C" fn nxt_otel_rs_get_or_create_trace(
     trace_flags: *const c_char,
     trace_state: *const nxt_str_t,
 ) -> *mut BoxedSpan {
-    let tracer = global::tracer_provider().tracer(TRACER_NAME);
-    let builder = tracer.span_builder(SPAN_NAME).with_kind(SpanKind::Server);
-
     let parent = nxt_otel_parent_context(trace_id, parent_id, trace_flags, trace_state)
         .unwrap_or_else(Context::new);
-    let span = tracer.build_with_context(builder, &parent);
+
+    // The read guard is held across the build so the cached tracer cannot be
+    // dropped by a concurrent reconfigure while a span is being made from it.
+    let cached = tracer_slot().read().ok();
+
+    let span = match cached.as_ref().and_then(|slot| slot.as_ref()) {
+        Some(tracer) => nxt_otel_build_span(tracer, &parent),
+        None => {
+            // No provider installed, or the lock is poisoned: fall back to the
+            // global provider, which hands out a no-op tracer in that case.
+            let tracer = global::tracer_provider().tracer(TRACER_NAME);
+
+            nxt_otel_build_span(&tracer, &parent)
+        }
+    };
 
     Box::into_raw(Box::new(span))
 }
@@ -524,6 +557,14 @@ pub unsafe extern "C" fn nxt_otel_rs_send_trace(trace: *mut BoxedSpan) {
 /// export has failed", not "no spans were lost".
 #[no_mangle]
 pub unsafe extern "C" fn nxt_otel_rs_shutdown_bounded(timeout_ms: u64) -> u8 {
+    // This path takes the provider without going through
+    // nxt_otel_rs_shutdown_tracer(), so the cached tracer has to be dropped
+    // here too: leaving it would hand out a tracer whose provider has
+    // already been shut down.
+    if let Ok(mut slot) = tracer_slot().write() {
+        *slot = None;
+    }
+
     let provider = provider_slot().lock().ok().and_then(|mut g| g.take());
     let rt = runtime_slot().lock().ok().and_then(|mut g| g.take());
 
@@ -582,6 +623,12 @@ pub unsafe extern "C" fn nxt_otel_rs_shutdown_bounded(timeout_ms: u64) -> u8 {
 /// Flush and tear down the live tracer provider, if any.
 #[no_mangle]
 pub unsafe extern "C" fn nxt_otel_rs_shutdown_tracer() {
+    // Dropped first: a tracer handed out after this point would belong to a
+    // provider that is already being torn down.
+    if let Ok(mut slot) = tracer_slot().write() {
+        *slot = None;
+    }
+
     let provider = provider_slot().lock().ok().and_then(|mut g| g.take());
     if let Some(provider) = provider {
         // Flushes pending spans; on a grpc build this still needs the runtime,

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -314,6 +314,31 @@ def test_otel_sampling_zero_exports_nothing(protocol):
 
 @_skipif_no_fake_otlp
 @pytest.mark.parametrize('protocol', ['http', 'grpc'])
+def test_otel_sampling_zero_still_propagates(protocol):
+    """sampling_ratio=0 → nothing is exported, but context still propagates.
+
+    The request path skips the attribute work for a span the sampler dropped
+    (nxt_otel_span_add_headers, src/nxt_otel.c). Propagation sits outside that
+    gate on purpose: W3C Trace Context requires the traceparent to reach the
+    peer and the application whatever the sampling decision was, so a
+    downstream service can join -- or knowingly decline to join -- the trace.
+    """
+    port = _get_free_port()
+    proc = _run_fake_otlp(port, protocol=protocol)  # run forever, absorb exports
+    try:
+        _configure_or_skip(port, sampling_ratio=0.0, protocol=protocol)
+
+        resp = _get_until_header('traceparent')
+        assert resp['status'] == 200
+        assert 'traceparent' in _response_headers_lower(resp), (
+            'an unsampled request must still carry a traceparent header'
+        )
+    finally:
+        _kill(proc)
+
+
+@_skipif_no_fake_otlp
+@pytest.mark.parametrize('protocol', ['http', 'grpc'])
 def test_otel_traceparent_malformed(protocol):
     """A malformed inbound traceparent is ignored and the trace restarted.
 


### PR DESCRIPTION
Addresses the cheap tier of #221 — fixes 1-3. Fixes 4-6 (static attribute
keys, i64 attributes, one-shot span assembly) are being prepared separately
and stack on this branch.

## What changed

**Cache the tracer at init.** `nxt_otel_rs_get_or_create_trace()` called
`global::tracer_provider().tracer()` per request — a global lock, a provider
clone and a fresh `Box` every time, for an object meant to be built once. It
now lives in an `RwLock<Option<BoxedTracer>>` beside the provider.
`BoxedTracer` rather than `SdkTracer` deliberately: `SdkTracer` returns a
different span type than the `*mut BoxedSpan` the FFI contract is built on.

**Drop the "Unit Attribute" event.** It carried the traceparent that the
span context already holds, and nothing consumes it. It was also being added
*twice* on errored requests: it lived in `nxt_otel_propagate_header()`, and
`nxt_otel_request_error_path()` runs that a second time, so a self-started
trace attached the event and the traceparent request field once per pass.

**Skip the attribute work for spans the sampler dropped.** `set_attribute()`
on a non-recording span is a no-op, but its arguments are built first — the
sprintf round-trips, the pool allocations, two owned Strings per attribute.
Nothing asked whether the span was recording. It now asks once at span
creation and caches the answer in `nxt_otel_state_t`.

Propagation stays *outside* the gate: W3C Trace Context requires the
traceparent to reach the peer and the application whatever the sampling
decision was. `test_otel_sampling_zero_still_propagates` pins that.

## Measured

Idle 8-core box, `listen_threads: 1`, 100k requests per cell rate-limited
below saturation, six interleaved repetitions with rotated cell order,
router **request-thread** CPU only (`comm` = `unitd`, so the Rust exporter
threads are excluded), paired per-repetition differences.

| | otel tax at `ratio 1.0` | at `ratio 0.1` |
|---|---|---|
| before | 18.55 µs | 15.45 µs |
| after | 18.52 µs | **7.10 µs** |

**Only the gate earns a number.** The tracer cache and the event deletion are
measured *free*, not measured wins: at `ratio 1.0`, where they are the only
changes that can help, the paired difference is −0.55 ± 2.28 µs. They stand
on mechanism — one fewer allocation and one fewer global lock per request,
and redundant data removed — not on a measurement. That is stated in the
commit message so nobody later cites them as perf wins.

The gate removes **54%** of otel's request-path cost at 10% sampling, and
fixes the complaint in #221: before, dropping `sampling_ratio` from 1.0 to
0.1 cut the tax by 17%; after, by 62%. `sampling_ratio` now means what an
operator expects.

The full table and the correction to #221's ranking are posted on the issue.

## Why one commit

The three share a single measurement and only one earns a number. Splitting
them would imply three independent wins, which the data does not support.

The one real cost of that: the event deletion is a **bug fix** (the double
add on the error path) that a 1.34 LTS backport might want without the perf
work attached. It is separable — the hunks are `nxt_otel_propagate_header()`
in `src/nxt_otel.c`, `nxt_otel_rs_add_event_to_trace()` in
`src/otel/src/lib.rs`, and its declaration in `src/nxt_otel.h` — so it can be
extracted without reverse-engineering the diff. Say the word if the split is
wanted here instead.

## Tests

`test_otel.py` passes 38/38 with this branch and the stacked 4-6 work
applied — verified by the session preparing those fixes; the suite needs a
port other than 8080 to run at all here, which is a separate problem.
`./build/tests` passes. The new propagation test is the one that would catch
a future gate change swallowing propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Asbr2xiUkx9axPtYy9Km2c

