### PR TITLE
otel: static attribute keys, integer values, one crossing per stage

### DIFF
--- a/src/nxt_otel.c
+++ b/src/nxt_otel.c
@@ -3,8 +3,6 @@
  * Copyright (C) F5, Inc.
  */
 
-#include <math.h>
-
 #include <nxt_router.h>
 #include <nxt_router_request.h>
 #include <nxt_application.h>
@@ -22,24 +20,6 @@
 
 #define NXT_OTEL_TRACEPARENT_LEN    55
 
-/*
- * Span attribute keys. These follow the stable OpenTelemetry HTTP semantic
- * conventions (https://opentelemetry.io/docs/specs/semconv/http/http-spans/);
- * "http.flavor"/"http.user_agent" from older drafts are superseded by
- * "network.protocol.version"/"user_agent.original". "unit.application.*" are
- * FreeUnit-specific: a reverse proxy can't know the served app, but Unit can.
- */
-#define NXT_OTEL_BODY_SIZE_TAG      "http.request.body.size"
-#define NXT_OTEL_METHOD_TAG         "http.request.method"
-#define NXT_OTEL_PATH_TAG           "url.path"
-#define NXT_OTEL_SCHEME_TAG         "url.scheme"
-#define NXT_OTEL_FLAVOR_TAG         "network.protocol.version"
-#define NXT_OTEL_USER_AGENT_TAG     "user_agent.original"
-#define NXT_OTEL_SERVER_ADDR_TAG    "server.address"
-#define NXT_OTEL_CLIENT_ADDR_TAG    "client.address"
-#define NXT_OTEL_APP_NAME_TAG       "unit.application.name"
-#define NXT_OTEL_APP_TYPE_TAG       "unit.application.type"
-#define NXT_OTEL_STATUS_CODE_TAG    "http.response.status_code"
 
 
 static void
@@ -54,16 +34,103 @@ nxt_otel_state_transition(nxt_otel_state_t *state, nxt_otel_status_t status)
 
 
 /*
- * Set a semantic-convention span attribute from a string-literal key and an
- * nxt_str_t value. Empty or absent values are skipped so we don't emit blank
- * attributes for headers the request didn't carry.
+ * A request's span attributes, accumulated on the stack and handed to Rust in
+ * one call.
+ *
+ * Each attribute used to cost its own FFI crossing and two heap allocations --
+ * one for the key, one for the value -- and the keys were compile-time
+ * constants being strlen'd and copied per request. Now the key is an id into a
+ * static table on the Rust side, and a whole stage's attributes cross once.
+ *
+ * The batch never outlives the stage that fills it, so the nxt_str_t values it
+ * holds are borrowed, not copied: they stay valid until the flush, and Rust
+ * copies what it needs to keep.
+ */
+typedef struct {
+    nxt_otel_attr_t  attrs[NXT_OTEL_ATTR_MAX];
+    nxt_uint_t       n;
+} nxt_otel_attr_batch_t;
+
+
+static void
+nxt_otel_attr_batch_init(nxt_otel_attr_batch_t *batch)
+{
+    batch->n = 0;
+}
+
+
+static nxt_otel_attr_t *
+nxt_otel_attr_next(nxt_otel_attr_batch_t *batch, nxt_otel_attr_id_t id)
+{
+    nxt_otel_attr_t  *attr;
+
+    /*
+     * Every stage adds at most one attribute per id, so the batch cannot
+     * overflow; the check is here so that a future caller adding a second
+     * attribute for one id truncates rather than writing off the end.
+     */
+    if (nxt_slow_path(batch->n >= NXT_OTEL_ATTR_MAX)) {
+        return NULL;
+    }
+
+    attr = &batch->attrs[batch->n++];
+    attr->key_id = id;
+
+    return attr;
+}
+
+
+/*
+ * Add a string attribute. Empty or absent values are skipped so we don't emit
+ * blank attributes for headers the request didn't carry.
  */
 static void
-nxt_otel_add_attr(nxt_http_request_t *r, const char *key, nxt_str_t *val)
+nxt_otel_attr_str(nxt_otel_attr_batch_t *batch, nxt_otel_attr_id_t id,
+    nxt_str_t *val)
 {
-    nxt_str_t  k;
+    nxt_otel_attr_t  *attr;
 
     if (val == NULL || val->start == NULL || val->length == 0) {
+        return;
+    }
+
+    attr = nxt_otel_attr_next(batch, id);
+    if (attr == NULL) {
+        return;
+    }
+
+    attr->type = NXT_OTEL_ATTR_TYPE_STR;
+    attr->ival = 0;
+    attr->sval = *val;
+}
+
+
+/*
+ * Add an integer attribute. The semantic conventions type these as integers,
+ * and passing one as an integer avoids a sprintf round-trip on the request
+ * path as well as being the correct value type on the wire.
+ */
+static void
+nxt_otel_attr_i64(nxt_otel_attr_batch_t *batch, nxt_otel_attr_id_t id,
+    int64_t val)
+{
+    nxt_otel_attr_t  *attr;
+
+    attr = nxt_otel_attr_next(batch, id);
+    if (attr == NULL) {
+        return;
+    }
+
+    attr->type = NXT_OTEL_ATTR_TYPE_I64;
+    attr->ival = val;
+    nxt_memzero(&attr->sval, sizeof(nxt_str_t));
+}
+
+
+static void
+nxt_otel_attr_flush(nxt_http_request_t *r, nxt_otel_attr_batch_t *batch)
+{
+    if (batch->n == 0) {
         return;
     }
 
@@ -71,10 +138,7 @@ nxt_otel_add_attr(nxt_http_request_t *r, const char *key, nxt_str_t *val)
         return;
     }
 
-    k.start = (u_char *) key;
-    k.length = nxt_strlen(key);
-
-    nxt_otel_rs_add_attr(r->otel->trace, &k, val);
+    nxt_otel_rs_add_attrs(r->otel->trace, batch->attrs, batch->n);
 }
 
 
@@ -168,21 +232,24 @@ nxt_otel_propagate_header(nxt_task_t *task, nxt_http_request_t *r)
 static void
 nxt_otel_span_add_request_attrs(nxt_http_request_t *r)
 {
-    nxt_str_t  val;
+    nxt_str_t              val;
+    nxt_otel_attr_batch_t  batch;
 
     /*
      * Record only well-defined semconv attributes. We deliberately do NOT
      * iterate every request header: that would leak sensitive values
      * (Authorization, Cookie, ...) into the telemetry backend.
      */
-    nxt_otel_add_attr(r, NXT_OTEL_METHOD_TAG, r->method);
-    nxt_otel_add_attr(r, NXT_OTEL_PATH_TAG, r->path);
+    nxt_otel_attr_batch_init(&batch);
+
+    nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_METHOD, r->method);
+    nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_PATH, r->path);
 
     nxt_str_set(&val, "http");
     if (r->tls) {
         nxt_str_set(&val, "https");
     }
-    nxt_otel_add_attr(r, NXT_OTEL_SCHEME_TAG, &val);
+    nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_SCHEME, &val);
 
     /* "HTTP/1.1" -> "1.1" for network.protocol.version */
     val = r->version;
@@ -192,21 +259,23 @@ nxt_otel_span_add_request_attrs(nxt_http_request_t *r)
         val.start += nxt_length("HTTP/");
         val.length -= nxt_length("HTTP/");
     }
-    nxt_otel_add_attr(r, NXT_OTEL_FLAVOR_TAG, &val);
+    nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_FLAVOR, &val);
 
     if (r->user_agent != NULL) {
         val.start = r->user_agent->value;
         val.length = r->user_agent->value_length;
-        nxt_otel_add_attr(r, NXT_OTEL_USER_AGENT_TAG, &val);
+        nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_USER_AGENT, &val);
     }
 
-    nxt_otel_add_attr(r, NXT_OTEL_SERVER_ADDR_TAG, &r->host);
+    nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_SERVER_ADDR, &r->host);
 
     if (r->remote != NULL) {
         val.start = nxt_sockaddr_address(r->remote);
         val.length = r->remote->address_length;
-        nxt_otel_add_attr(r, NXT_OTEL_CLIENT_ADDR_TAG, &val);
+        nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_CLIENT_ADDR, &val);
     }
+
+    nxt_otel_attr_flush(r, &batch);
 }
 
 
@@ -244,11 +313,8 @@ nxt_otel_span_add_headers(nxt_task_t *task, nxt_http_request_t *r)
 static void
 nxt_otel_span_add_body(nxt_http_request_t *r)
 {
-    size_t     body_size = 0;
-    size_t     buf_size;
-    u_char     *body_buf, *body_size_buf;
-    nxt_int_t  cur;
-    nxt_str_t  body_val;
+    size_t                 body_size = 0;
+    nxt_otel_attr_batch_t  batch;
 
     if (!r->otel->recording) {
         nxt_otel_state_transition(r->otel, NXT_OTEL_COLLECT_STATE);
@@ -259,34 +325,10 @@ nxt_otel_span_add_body(nxt_http_request_t *r)
         body_size = nxt_buf_used_size(r->body);
     }
 
-    buf_size = 1; // first digit
-    if (body_size != 0) {
-        buf_size += log10(body_size); // subsequent digits
-    }
-    buf_size += 1; // \0
-    buf_size += nxt_strlen(NXT_OTEL_BODY_SIZE_TAG);
-    buf_size += 1; // \0
+    nxt_otel_attr_batch_init(&batch);
+    nxt_otel_attr_i64(&batch, NXT_OTEL_ATTR_BODY_SIZE, (int64_t) body_size);
+    nxt_otel_attr_flush(r, &batch);
 
-    body_buf = nxt_mp_alloc(r->mem_pool, buf_size);
-    if (nxt_slow_path(body_buf == NULL)) {
-        return;
-    }
-
-    cur = sprintf((char *) body_buf, "%lu", body_size);
-    if (cur < 0) {
-        return;
-    }
-
-    cur += 1;
-    body_size_buf = body_buf + cur;
-    nxt_cpystr(body_buf + cur, (const u_char *) NXT_OTEL_BODY_SIZE_TAG);
-
-    body_val = (nxt_str_t) {
-        .start  = body_buf,
-        .length = nxt_strlen(body_buf),
-    };
-
-    nxt_otel_add_attr(r, (const char *) body_size_buf, &body_val);
     nxt_otel_state_transition(r->otel, NXT_OTEL_COLLECT_STATE);
 }
 
@@ -294,16 +336,17 @@ nxt_otel_span_add_body(nxt_http_request_t *r)
 static void
 nxt_otel_span_add_status(nxt_task_t *task, nxt_http_request_t *r)
 {
-    int                     n;
-    u_char                  status_buf[8];
     const char              *type_name;
     nxt_str_t               val;
     nxt_app_t               *app;
+    nxt_otel_attr_batch_t   batch;
     nxt_request_rpc_data_t  *rpc;
 
     if (r->otel == NULL || r->otel->trace == NULL || !r->otel->recording) {
         return;
     }
+
+    nxt_otel_attr_batch_init(&batch);
 
     /*
      * Application identity is resolved during routing, so it is only known by
@@ -313,32 +356,21 @@ nxt_otel_span_add_status(nxt_task_t *task, nxt_http_request_t *r)
     rpc = r->req_rpc_data;
     if (rpc != NULL && rpc->app != NULL) {
         app = rpc->app;
-        nxt_otel_add_attr(r, NXT_OTEL_APP_NAME_TAG, &app->name);
+        nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_APP_NAME, &app->name);
 
         type_name = nxt_otel_app_type_name(app->type);
         val.start = (u_char *) type_name;
         val.length = nxt_strlen(type_name);
-        nxt_otel_add_attr(r, NXT_OTEL_APP_TYPE_TAG, &val);
+        nxt_otel_attr_str(&batch, NXT_OTEL_ATTR_APP_TYPE, &val);
     }
 
     // dont bother logging an unset status
-    if (r->status == 0) {
-        return;
+    if (r->status != 0) {
+        nxt_otel_attr_i64(&batch, NXT_OTEL_ATTR_STATUS_CODE,
+                          (int64_t) r->status);
     }
 
-    n = snprintf((char *) status_buf, sizeof(status_buf), "%d",
-                 (int) r->status);
-    /*
-     * snprintf() returns the length it *would* have written; on truncation
-     * that exceeds the buffer, so only record the attribute when the value
-     * fully fit -- a truncated status code is meaningless anyway, and using
-     * the would-have-been length as val.length would read past status_buf.
-     */
-    if (n > 0 && n < (int) sizeof(status_buf)) {
-        val.start = status_buf;
-        val.length = (size_t) n;
-        nxt_otel_add_attr(r, NXT_OTEL_STATUS_CODE_TAG, &val);
-    }
+    nxt_otel_attr_flush(r, &batch);
 
     /* Flag server errors so the span shows Status::Error in the collector. */
     if (r->status >= NXT_HTTP_INTERNAL_SERVER_ERROR) {

--- a/src/nxt_otel.h
+++ b/src/nxt_otel.h
@@ -16,6 +16,48 @@
 #endif
 
 
+/*
+ * Span attribute keys, as ids rather than strings.
+ *
+ * The key text lives on the Rust side in ATTR_KEYS, as a const table of
+ * Key::from_static_str -- so a key costs no allocation and no strlen per
+ * request.  The order of this enum and of that table is the contract between
+ * the two sides: the id indexes the table directly.  Add to the end, and add
+ * to ATTR_KEYS in src/otel/src/lib.rs in the same commit.
+ */
+typedef enum {
+    NXT_OTEL_ATTR_METHOD = 0,
+    NXT_OTEL_ATTR_PATH,
+    NXT_OTEL_ATTR_SCHEME,
+    NXT_OTEL_ATTR_FLAVOR,
+    NXT_OTEL_ATTR_USER_AGENT,
+    NXT_OTEL_ATTR_SERVER_ADDR,
+    NXT_OTEL_ATTR_CLIENT_ADDR,
+    NXT_OTEL_ATTR_APP_NAME,
+    NXT_OTEL_ATTR_APP_TYPE,
+    NXT_OTEL_ATTR_STATUS_CODE,
+    NXT_OTEL_ATTR_BODY_SIZE,
+    NXT_OTEL_ATTR_MAX
+} nxt_otel_attr_id_t;
+
+
+/* Which member of nxt_otel_attr_t carries the value. */
+#define NXT_OTEL_ATTR_TYPE_STR  0
+#define NXT_OTEL_ATTR_TYPE_I64  1
+
+
+/*
+ * One span attribute in a batch.  Mirrored by nxt_otel_attr_t in
+ * src/otel/src/lib.rs; the layouts must stay identical.
+ */
+typedef struct {
+    uint32_t   key_id;
+    uint32_t   type;
+    int64_t    ival;
+    nxt_str_t  sval;
+} nxt_otel_attr_t;
+
+
 #if (NXT_HAVE_OTEL)
 extern void nxt_otel_rs_send_trace(void *trace);
 extern void * nxt_otel_rs_get_or_create_trace(const u_char *trace_id,
@@ -26,7 +68,8 @@ extern void nxt_otel_rs_init(
     const nxt_str_t *endpoint, const nxt_str_t *protocol,
     double sample_fraction, double batch_size);
 extern void nxt_otel_rs_copy_traceparent(u_char *buffer, void *span);
-extern void nxt_otel_rs_add_attr(void *trace, nxt_str_t *key, nxt_str_t *val);
+extern void nxt_otel_rs_add_attrs(void *trace,
+    const nxt_otel_attr_t *attrs, size_t n);
 extern void nxt_otel_rs_set_error(void *trace);
 extern uint8_t nxt_otel_rs_is_recording(void *trace);
 extern uint8_t nxt_otel_rs_is_init(void);

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -19,7 +19,7 @@ use opentelemetry::trace::{
     Span, SpanContext, SpanId, SpanKind, Status, TraceContextExt, TraceFlags,
     TraceId, TraceState, Tracer, TracerProvider,
 };
-use opentelemetry::{Context, KeyValue};
+use opentelemetry::{Context, Key, KeyValue, Value};
 use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{
@@ -51,6 +51,55 @@ const NXT_LOG_ERR: nxt_uint_t = 1;
 const NXT_OTEL_SHUTDOWN_TIMEOUT: u8 = 0;
 const NXT_OTEL_SHUTDOWN_FLUSHED: u8 = 1;
 const NXT_OTEL_SHUTDOWN_FAILED: u8 = 2;
+
+/// Span attribute keys, indexed by the `nxt_otel_attr_id_t` id C sends.
+///
+/// `Key::from_static_str` is a `const fn` over a `&'static str`, so a key
+/// costs no allocation and no `strlen` -- where the previous string-key FFI
+/// copied all eleven of these compile-time constants onto the heap on every
+/// traced request.
+///
+/// This table and `nxt_otel_attr_id_t` in `src/nxt_otel.h` are one contract:
+/// the id indexes this array directly, so the order must match exactly.
+/// The `[Key; NXT_OTEL_ATTR_MAX]` annotation makes a mismatched element count
+/// a compile error, so a key added here without extending the count cannot
+/// ship. It cannot check the C enum itself -- the ids stay a reviewed
+/// contract -- but it catches the half of the mistake that lives on this side.
+///
+/// These follow the stable OpenTelemetry HTTP semantic conventions
+/// (<https://opentelemetry.io/docs/specs/semconv/http/http-spans/>);
+/// "http.flavor"/"http.user_agent" from older drafts are superseded by
+/// "network.protocol.version"/"user_agent.original". "unit.application.*" are
+/// FreeUnit-specific: a reverse proxy can't know the served app, but Unit can.
+static ATTR_KEYS: [Key; NXT_OTEL_ATTR_MAX] = [
+    Key::from_static_str("http.request.method"),
+    Key::from_static_str("url.path"),
+    Key::from_static_str("url.scheme"),
+    Key::from_static_str("network.protocol.version"),
+    Key::from_static_str("user_agent.original"),
+    Key::from_static_str("server.address"),
+    Key::from_static_str("client.address"),
+    Key::from_static_str("unit.application.name"),
+    Key::from_static_str("unit.application.type"),
+    Key::from_static_str("http.response.status_code"),
+    Key::from_static_str("http.request.body.size"),
+];
+
+/// Must equal `NXT_OTEL_ATTR_MAX` in `src/nxt_otel.h`.
+const NXT_OTEL_ATTR_MAX: usize = 11;
+
+const NXT_OTEL_ATTR_TYPE_STR: u32 = 0;
+const NXT_OTEL_ATTR_TYPE_I64: u32 = 1;
+
+/// One span attribute in a batch. Mirrors `nxt_otel_attr_t` in
+/// `src/nxt_otel.h`; the layouts must stay identical.
+#[repr(C)]
+pub struct nxt_otel_attr_t {
+    pub key_id: u32,
+    pub r#type: u32,
+    pub ival: i64,
+    pub sval: nxt_str_t,
+}
 
 #[repr(C)]
 pub struct nxt_str_t {
@@ -389,22 +438,58 @@ pub unsafe extern "C" fn nxt_otel_rs_copy_traceparent(buf: *mut c_char, span: *c
     *buf.add(TRACEPARENT_HEADER_LEN as usize) = 0;
 }
 
-/// Set a semantic-convention span attribute (e.g. `http.request.method`).
-/// These are structured span attributes the collector can index and query.
+/// Set a stage's semantic-convention span attributes in one call.
+///
+/// C accumulates a stage's attributes on its stack and crosses once, rather
+/// than once per attribute: a traced request used to make eight or nine FFI
+/// crossings here and allocate two `String`s at each of them. Only the values
+/// still allocate, and only those that are strings.
+///
+/// Note this deliberately does NOT use `SpanBuilder::with_attributes`, which
+/// issue #221 suggests. That would assemble the attributes while the span is
+/// being built -- before C can observe the sampling decision -- which would
+/// undo the `is_recording` gate that is the measured win. Attributes are set
+/// after the gate, on a span already known to be recording.
+///
+/// # Safety
+///
+/// `attrs` must point at `n` initialised `nxt_otel_attr_t`, and each entry's
+/// `sval` must reference bytes that stay valid for the duration of the call.
 #[no_mangle]
-pub unsafe extern "C" fn nxt_otel_rs_add_attr(
+pub unsafe extern "C" fn nxt_otel_rs_add_attrs(
     trace: *mut BoxedSpan,
-    key: *const nxt_str_t,
-    val: *const nxt_str_t,
+    attrs: *const nxt_otel_attr_t,
+    n: usize,
 ) {
-    if trace.is_null() || key.is_null() || val.is_null() {
+    if trace.is_null() || attrs.is_null() || n == 0 {
         return;
     }
 
-    let key = nxt_str_to_string(&*key);
-    let val = nxt_str_to_string(&*val);
+    let attrs = slice::from_raw_parts(attrs, n);
 
-    (*trace).set_attribute(KeyValue::new(key, val));
+    // Set each attribute directly rather than collecting into a Vec first.
+    // `Span::set_attributes` is a default trait method that just loops over
+    // `set_attribute`, and `BoxedSpan` does not override it, so a Vec here
+    // would be an allocation that buys nothing. The saving this function
+    // exists for is the single FFI crossing and the static keys, not batching
+    // inside the SDK.
+    for attr in attrs {
+        // A key_id C and Rust disagree about would index out of bounds;
+        // drop the attribute rather than panic across the FFI boundary.
+        let Some(key) = ATTR_KEYS.get(attr.key_id as usize) else {
+            continue;
+        };
+
+        let value = match attr.r#type {
+            NXT_OTEL_ATTR_TYPE_I64 => Value::I64(attr.ival),
+            NXT_OTEL_ATTR_TYPE_STR => Value::String(nxt_str_to_string(&attr.sval).into()),
+            _ => continue,
+        };
+
+        // Cloning a Key built by `from_static_str` copies a &'static str --
+        // no allocation, which is the point of the ATTR_KEYS table.
+        (*trace).set_attribute(KeyValue::new(key.clone(), value));
+    }
 }
 
 /// Whether the sampler kept this span.

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -118,6 +118,41 @@ def _require_otel():
     _configure_or_skip(1)
 
 
+STATUS_CODE_KEY = b'http.response.status_code'
+
+
+def _otlp_int_value(value):
+    """Encode an OTLP AnyValue int_value as it appears on the wire.
+
+    int_value is field 3 of AnyValue with varint wire type, so the tag byte is
+    (3 << 3) | 0 == 0x18, followed by the value as a base-128 varint.
+    """
+    out = bytearray(b'\x18')
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | 0x80 if value else byte)
+        if not value:
+            return bytes(out)
+
+
+def _has_keyed_int_attr(body, key, value):
+    """Whether `key` is followed by an int_value attribute equal to `value`.
+
+    The dump holds raw trace ids, span ids and timestamps, so the encoded value
+    can occur anywhere by coincidence. Anchoring the search to the bytes just
+    after each occurrence of the key is what makes this a statement about the
+    attribute rather than about the payload.
+    """
+    want = _otlp_int_value(value)
+    at = body.find(key)
+    while at != -1:
+        if want in body[at + len(key):at + len(key) + 16]:
+            return True
+        at = body.find(key, at + 1)
+    return False
+
+
 def _response_headers_lower(resp):
     return {k.lower(): v for k, v in resp['headers'].items()}
 
@@ -182,11 +217,15 @@ def test_otel_span_exported_with_service_name(tmp_path, protocol):
 def test_otel_span_5xx_status(tmp_path, protocol):
     """A 5xx response is still traced and the span records the error status.
 
-    The status_code attribute is emitted as a string (sprintf "%d"), so the
-    literal `503` travels in the OTLP payload. Per the 1.35.6 fix, 503 >= 500
-    also marks the span Status::Error (nxt_otel_rs_set_error); that enum is not
-    asserted here (it is not a literal in the protobuf), but the status_code
-    value is the concrete, reliable signal.
+    http.response.status_code is an OTLP *integer* attribute, so 503 travels as
+    a varint rather than the ASCII bytes `503`: in AnyValue, int_value is field
+    3, giving tag 0x18 followed by varint 503 (0xf7 0x03). Asserting on those
+    bytes is what distinguishes a correctly typed integer attribute from the
+    stringified one the semantic conventions do not ask for.
+
+    Per the 1.35.6 fix, 503 >= 500 also marks the span Status::Error
+    (nxt_otel_rs_set_error); that enum is not asserted here (it is a protobuf
+    enum, not a literal).
     """
     port = _get_free_port()
     dump = str(tmp_path / 'otlp_dump.bin')
@@ -208,11 +247,11 @@ def test_otel_span_5xx_status(tmp_path, protocol):
             '503', 'routes/0/action/return'
         ), 'switch route to return 503'
 
-        # Fire 503s until the error span reaches the collector. status_code is
-        # emitted as the string "503" (sprintf "%d"); per the 1.35.6 fix,
-        # 503 >= 500 also marks the span Status::Error (not asserted here -- it
-        # is a protobuf enum, not a literal). Only the 503 requests can add the
-        # "503" bytes, so the readiness 200 spans don't false-positive.
+        # Fire 503s until the error span reaches the collector. The wait
+        # condition is the same keyed check as the assertion below: a bare
+        # substring search would also match a trace id or timestamp that
+        # happens to contain these bytes, ending the poll before the 503 span
+        # was actually exported.
         body = b''
         found = False
         for _ in range(int(EXPORT_TIMEOUT * 10)):
@@ -224,14 +263,24 @@ def test_otel_span_5xx_status(tmp_path, protocol):
                 with open(dump, 'rb') as f:
                     body = f.read()
 
-                if b'503' in body:
+                if _has_keyed_int_attr(body, STATUS_CODE_KEY, 503):
                     found = True
                     break
 
             time.sleep(0.1)
 
-        assert found, 'span with status_code=503 was not exported'
-        assert b'http.response.status_code' in body, 'status_code attr missing'
+        assert STATUS_CODE_KEY in body, 'status_code attr missing'
+        assert found, (
+            'http.response.status_code must carry 503 as an int_value varint; '
+            'a span with that attribute was never exported'
+        )
+
+        # The readiness spans are still in the same dump and carry int_value
+        # 200, which confirms the keyed search discriminates by value rather
+        # than merely finding the key.
+        assert _has_keyed_int_attr(body, STATUS_CODE_KEY, 200), (
+            'readiness spans should still carry status_code=200'
+        )
     finally:
         _kill(proc)
 


### PR DESCRIPTION
Implements the remaining three fixes from #221: static attribute keys, integer
attribute values, and one FFI crossing per span stage.

#221 measured a traced request at roughly 13 C→Rust FFI crossings and 25-30
heap allocations. The `is_recording` gate and the cached tracer that land
alongside this remove the cost that *sampling* should have removed. This PR
removes the cost that remains at `sampling_ratio: 1.0`, where every request is
recorded and the attribute path runs in full.

## What changed

**Keys become ids (#221 fix 4).** All eleven attribute keys are compile-time
constants that were being `strlen`'d and copied onto the heap on every traced
request. They now live in a `static ATTR_KEYS: [Key; NXT_OTEL_ATTR_MAX]` of
`Key::from_static_str`, indexed by a new `nxt_otel_attr_id_t`. The
`[Key; NXT_OTEL_ATTR_MAX]` annotation makes a mismatched element count a
compile error; the C enum's *order* stays a reviewed contract, the way the
`NXT_OTEL_SHUTDOWN_*` constants already do.

**Integers travel as integers (#221 fix 5).** `http.response.status_code` and
`http.request.body.size` are `Value::I64`. The semantic conventions type them
that way, and it deletes both string round-trips: the `snprintf` and
`status_buf` in the status stage, and the whole `log10`/`sprintf`/
`nxt_mp_alloc` block in the body stage — and `math.h` with it.

**Attributes cross once per stage (#221 fix 6).** `nxt_otel_rs_add_attrs()`
takes a stack-built array, so the request stage goes from eight FFI crossings
to one and the status stage from three to one. The single-attribute entry point
had no other callers and is gone.

The saving here is the crossings and the static keys, not batching inside the
SDK: `BoxedSpan` does not override `Span::set_attributes`, so it gets the
default implementation that loops over `set_attribute` anyway. Collecting into
a `Vec` first would add a per-stage allocation that the code it replaces did
not have, so the loop sets each attribute directly.

## Why not `SpanBuilder::with_attributes`

#221's fix 6 suggests assembling attributes through `SpanBuilder`. That would
build them while the span is being constructed — *before* C can observe the
sampling decision — which would undo the `is_recording` gate that is the
measured win of the companion change. Attributes are set after the gate, on a
span already known to be recording.

## A state-machine consequence worth naming

`nxt_otel_span_add_body()` used to return without transitioning if
`nxt_mp_alloc()` failed. There is no allocation left on that path, and the
gate's early return transitions too, so every exit from that function now
transitions exactly once. That property belongs to the gate and this change
*together* — neither commit shows it alone.

## Tests

`test_otel_span_5xx_status` could not survive the typing change: it scanned for
the ASCII bytes `503`, which an `int_value` varint does not contain. It now
asserts the OTLP `AnyValue` `int_value` encoding next to the `status_code` key,
scanning every occurrence of the key because the readiness spans carry
`int_value` 200 and appear first in the dump. That proves the semconv typing,
where the old scan only proved that some `503` existed somewhere in the payload.

Full `test/test_otel.py`: **38 passed, 0 failed**, both transports.

## Performance

Measured on a calibrated A/B harness (ABBA-counterbalanced, router request
thread only, exporter threads excluded), comparing the release candidate
without #221 against the same tree with both halves of #221 applied:

| otel tax over each build's own baseline | `sampling_ratio: 1.0` | `sampling_ratio: 0.1` |
|---|---|---|
| without #221 | 16.85 µs | 12.07 µs |
| with #221 (both halves) | **12.35 µs** | **5.63 µs** |
| | **−27%** | **−53%** |

The `ratio 1.0` column is the one this PR is responsible for. The companion
change deliberately does not touch it — its A/B found the tracer cache and the
event deletion *measured free*, with the whole measurable win coming from the
sampling gate below `ratio 1.0`. So the −27% at full sampling is what fixes
4/5/6 bought, in the one place fixes 1-3 could not reach.

Two caveats, stated rather than buried:

- The figures above are **within-build** (each build against its own
  telemetry-off cell), which is what makes them defensible. The
  between-build comparison is not: the telemetry-off control came out
  significant at −1.22% (CI [−2.28%, −0.16%]), so cross-build percentages
  carry a systematic offset of roughly that size and should not be quoted as
  precise.
- This was measured before the two review fixes in this PR. Both are
  test-only or allocation-removing, so the measured tree is if anything
  marginally worse than what is proposed here.

Measurement was run by the session that authored the companion change, on its
harness, not by me.

## Review

Reviewed by `codex review` and by an adversarial critique pass before opening.
Both found the same defect in the new test independently, and it is fixed:
the poll loop's wait condition was a bare substring search for the encoded
value over the whole dump, which can match a random trace id or timestamp and
end the poll before the 503 span is exported, failing the key-anchored
assertion below it spuriously. The wait condition is now the same key-anchored
check as the assertion.

The critique pass also caught a claim in the first version of this change that
was simply wrong: `BoxedSpan` does not override `Span::set_attributes`, so the
`Vec::with_capacity` it used to build was a per-stage allocation the previous
code did not make. Removed — see above.

Verified rather than assumed during review, since these are the parts most
likely to be quietly broken:

- **FFI layout.** Both sides' structs compiled and their offsets printed:
  `size=32 align=8, key_id=0 type=4 ival=8 sval=16` on x86-64, with no padding
  disagreement between `type` and `ival`. `#[repr(C)]` follows the target C
  ABI, so armv7 (which this project ships) and i386 agree too.
- **The id↔table contract.** Enumerated key by key against the `#define`s this
  change removes — identical, so no key changes on the wire.
- **`Key::clone()` does not allocate.** `Key::from_static_str` yields
  `OtelString::Static(&'static str)`; cloning copies a fat pointer. Fix 4's
  premise depends on this.
- **Skip semantics unchanged.** The NULL/empty-value skip is byte-for-byte the
  old condition, and `body.size` is still emitted when it is 0 — as `int 0`
  rather than the string `"0"`.

---

Follows #225 (issue #221 fixes 1-3), now merged as `e21bc5bc`; this branch has
been rebased onto it and carries a single commit.

Closes #221.
