### PR TITLE
otel: assert the attribute struct's layout instead of describing it

### DIFF
--- a/src/nxt_otel.h
+++ b/src/nxt_otel.h
@@ -49,6 +49,26 @@ typedef enum {
 /*
  * One span attribute in a batch.  Mirrored by nxt_otel_attr_t in
  * src/otel/src/lib.rs; the layouts must stay identical.
+ *
+ * The Rust struct is #[repr(C)], so both sides lay their fields out under
+ * the target's C ABI: a change mirrored on both sides, reordering included,
+ * stays in agreement on every target.  What breaks the FFI is editing one
+ * side only, or pairing fields whose types are not the same size and
+ * alignment everywhere we ship -- C long is 4 bytes on ILP32 where Rust i64
+ * is always 8, and C enum sizes are implementation-defined, which is why
+ * key_id and type are uint32_t here rather than nxt_otel_attr_id_t.
+ *
+ * The offsets below are the same on x86-64, armv7 and i386 (the total size
+ * is not: 32 on 64-bit, 24 on 32-bit, where int64_t needs only 4-byte
+ * alignment).  They are asserted rather than described, so that a field
+ * added, reordered or appended here fails the build and prompts the matching
+ * edit on the Rust side, which these assertions cannot see.
+ *
+ * The size assertion is what covers a field appended after sval: the offset
+ * checks alone would all still hold, while the struct grew.  That matters
+ * more than it looks, because these are passed as an array -- a C-side-only
+ * trailing field changes the stride C writes with and not the one Rust reads
+ * with, so every attribute after the first would be misread.
  */
 typedef struct {
     uint32_t   key_id;
@@ -56,6 +76,19 @@ typedef struct {
     int64_t    ival;
     nxt_str_t  sval;
 } nxt_otel_attr_t;
+
+nxt_static_assert(offsetof(nxt_otel_attr_t, key_id) == 0,
+                  "nxt_otel_attr_t layout drifted from src/otel/src/lib.rs");
+nxt_static_assert(offsetof(nxt_otel_attr_t, type) == 4,
+                  "nxt_otel_attr_t layout drifted from src/otel/src/lib.rs");
+nxt_static_assert(offsetof(nxt_otel_attr_t, ival) == 8,
+                  "nxt_otel_attr_t layout drifted from src/otel/src/lib.rs");
+nxt_static_assert(offsetof(nxt_otel_attr_t, sval) == 2 * sizeof(uint32_t)
+                                                     + sizeof(int64_t),
+                  "nxt_otel_attr_t layout drifted from src/otel/src/lib.rs");
+nxt_static_assert(sizeof(nxt_otel_attr_t) == offsetof(nxt_otel_attr_t, sval)
+                                             + sizeof(nxt_str_t),
+                  "nxt_otel_attr_t grew a field Rust does not know about");
 
 
 #if (NXT_HAVE_OTEL)

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -202,9 +202,11 @@ def test_otel_span_exported_with_service_name(tmp_path, protocol):
         with open(dump, 'rb') as f:
             body = f.read()
         assert b'FreeUnit' in body, 'exported span must carry service.name=FreeUnit'
-        # Semconv span attributes (1.35.6): recorded via nxt_otel_rs_add_attr,
-        # not as the old free-form span events. The attribute *keys* travel as
-        # literal strings in the OTLP protobuf payload.
+        # Semconv span attributes: recorded via nxt_otel_rs_add_attrs, not as
+        # the old free-form span events. The attribute *keys* still travel as
+        # literal strings in the OTLP protobuf payload -- keying them by id
+        # across the FFI changed where they live in the process, not the wire
+        # format.
         assert b'http.request.method' in body, 'span must carry semconv method attr'
         assert b'url.path' in body, 'span must carry semconv url.path attr'
         assert b'http.response.status_code' in body, 'span must carry status attr'


### PR DESCRIPTION
Replaces a comment above `nxt_otel_attr_t` with assertions that enforce what it
claimed, and drops one stale symbol reference from the tests. No behaviour
change.

## The comment was wrong twice

**Wrong on the merits.** It said the field order was ABI-significant and that
reordering could put C and Rust out of step on a 32-bit target. Review pushed
back, correctly: the Rust struct is `#[repr(C)]`, so both sides lay out under
the target's C ABI and a change mirrored on both sides — reordering included —
stays in agreement everywhere. Verified rather than argued, on real
cross-compiles of a mirrored `uint32_t` inserted before `ival`:

| target | C `ival` | Rust `ival` |
|---|---|---|
| i686 | 12 | 12 |
| armv7 | 16 | 16 |
| x86-64 | 16 | 16 |

What actually breaks the FFI is editing one side only, or pairing types that
are not the same size and alignment on every target we ship — C `long` is 4
bytes on ILP32 where Rust `i64` is always 8, and C enum sizes are
implementation-defined. That last one is why `key_id` and `type` are `uint32_t`
here rather than `nxt_otel_attr_id_t`; nothing recorded that.

**Wrong about itself.** It claimed the layout was "verified with static
assertions". It had been — in a scratch file, not in the tree. So the
assertions now ship.

## What the assertions cover

Four on the field offsets, and one on `sizeof`. The size assertion is the one
that earns its place: a field appended after `sval` leaves every offset check
passing while the struct grows, and these are passed as an **array** — a
C-side-only trailing field changes the stride C writes with and not the one
Rust reads with, so every attribute after the first in a batch would be
misread. That is silent corruption, not a build failure.

Neither assertion is trusted on inspection. Both were checked by deliberately
breaking the struct:

- mirrored `uint32_t` inserted before `ival` → offset assertion fires
- `uint32_t` appended after `sval` → **only** the size assertion fires, all
  four offset checks still pass

The `sizeof` check is written as `offsetof(sval) + sizeof(nxt_str_t)` rather
than a constant, because the struct is 32 bytes on 64-bit and 24 on 32-bit.

These assertions see only the C side; the Rust side has its own
`[Key; NXT_OTEL_ATTR_MAX]` count check. What they buy is that a one-sided C
edit fails the build and prompts the matching Rust edit.

## The stale symbol

`test/test_otel.py:205` still named `nxt_otel_rs_add_attr`, which #226 deleted
in favour of the batched `nxt_otel_rs_add_attrs`. A repo-wide grep for both
symbols removed in #221 finds no other occurrence.

The rest of that comment was left alone because it is still correct: attribute
*keys* do still travel as literal strings in the OTLP payload. Keying them by
id across the FFI changed where they live in the process, not the wire format.

## Verification

`make -j8` clean, zero warnings. The header also compiles standalone
(`-Isrc -Ibuild/include`), as it does on master. `test_otel.py` was **not**
re-run: this change is comments and `_Static_assert`, which is compile-time
only.

## Not in this PR

`test/test_otel.py` hardcodes `*:8080` in three places, `test/unit/**` in ~17
more, and `test/unit/http.py` defaults to it — so CI cannot run the otel suite
at all, and none of #221 has ever been exercised by CI. Worth fixing, and a
change of its own.
