### PR TITLE
ci(build-test): refresh the apt index before installing libperl-dev

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -308,7 +308,8 @@ jobs:
 
       - name: Install libperl-dev
         run: |
-          sudo apt-get install libperl-dev
+          sudo apt-get -y update
+          sudo apt-get -y install libperl-dev
         if: steps.metadata.outputs.module == 'perl'
 
       - name: Configure perl


### PR DESCRIPTION
The perl leg of build-test fails in "Install libperl-dev" with:

    E: Failed to fetch .../libperl-dev_5.38.2-3.2ubuntu0.3_amd64.deb  404  Not Found

Run 33183190831, job 98894408092; attempt 2 failed identically, so the runner image ships a stale package index rather than hitting a flaky mirror. The step installed without refreshing the index; it now runs `apt-get update` first.

Scoped to the one step that has actually failed. The other install steps in this workflow are left as they are and get the same treatment only if one of them 404s — keeps the fix evidence-based and the added pipeline cost to a single leg.

Unblocks the perl leg on #227 and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iXrca5JtVfrv6nMdnSQMa