### PR TITLE
test(port): make the queue-size tests able to fail

### DIFF
--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -99,6 +99,89 @@ fail:
 #if (NXT_HAVE_MEMFD_CREATE)
 
 /*
+ * The size check in nxt_port_queue_mmap() (src/nxt_port.c) refuses only an
+ * object shorter than the queue, and both edges of that rule are load
+ * bearing.
+ *
+ * An object of exactly sizeof(nxt_port_queue_t) is what both producers ask
+ * for -- nxt_shm_open() in the runtime and nxt_unit_shm_open() in libunit
+ * -- so the comparison has to be "<": a "<=" would refuse every queue.
+ *
+ * A longer object is accepted on purpose.  A shm object is rounded up to a
+ * page on some systems and the queue is not a whole number of pages, so
+ * tightening the check to equality would refuse every legitimate queue
+ * there and stall application port setup.  Only the first
+ * sizeof(nxt_port_queue_t) bytes are mapped either way.
+ *
+ * Both cases touch the last item of the mapping the way
+ * nxt_port_queue_send() would.  That probe is not a SIGBUS check: every page
+ * of an accepted mapping is at least partially file-backed here, and a
+ * partial page at EOF is zero-filled, so no size the helper accepts can
+ * fault there.  What it catches is the helper handing back a short or
+ * garbage mapping -- and it fixes the shape of the access, so that a future
+ * change to what gets mapped is exercised rather than merely returned.  The
+ * teeth of these two cases are the NULL checks above it.
+ */
+static nxt_int_t
+nxt_port_ready_test_queue_size(nxt_thread_t *thr, nxt_task_t *task,
+    size_t file_size, const char *name)
+{
+    void                       *mem;
+    nxt_fd_t                   fd;
+    volatile nxt_port_queue_t  *queue;
+
+    fd = syscall(SYS_memfd_create, "nxt_port_ready_test", MFD_CLOEXEC);
+    if (fd == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to create the queue");
+        return NXT_ERROR;
+    }
+
+    if (ftruncate(fd, file_size) == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to size the queue");
+        (void) close(fd);
+        return NXT_ERROR;
+    }
+
+    mem = nxt_port_queue_mmap(task, fd, sizeof(nxt_port_queue_t));
+
+    /* The mapping does not keep the descriptor. */
+    (void) close(fd);
+
+    if (mem == NULL) {
+        nxt_log_alert(thr->log, "port ready test: %s queue was refused", name);
+        return NXT_ERROR;
+    }
+
+    queue = mem;
+    queue->items[NXT_PORT_QUEUE_SIZE - 1].size = 0;
+
+    nxt_mem_munmap(mem, sizeof(nxt_port_queue_t));
+
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_port_ready_test_queue_sizes(nxt_thread_t *thr, nxt_task_t *task)
+{
+    size_t  rounded;
+
+    if (nxt_slow_path(nxt_port_ready_test_queue_size(thr, task,
+                                                     sizeof(nxt_port_queue_t),
+                                                     "an exact-size")
+                      != NXT_OK))
+    {
+        return NXT_ERROR;
+    }
+
+    rounded = nxt_align_size(sizeof(nxt_port_queue_t), nxt_pagesize);
+
+    return nxt_port_ready_test_queue_size(thr, task, rounded,
+                                          "a page-rounded");
+}
+
+
+/*
  * Hand the handler a mappable descriptor and check that the port takes it
  * over: the queue is installed, whatever the port held before is released,
  * and the second descriptor of the message is closed.
@@ -262,6 +345,20 @@ nxt_port_ready_test(nxt_thread_t *thr)
 
     task = thr->task;
     task->thread = thr;
+
+#if (NXT_HAVE_MEMFD_CREATE)
+
+    /*
+     * The two accepted sizes, ahead of the handler fixtures and calling
+     * nxt_port_queue_mmap() directly: nothing is allocated yet, and a
+     * failure here names the rule that broke rather than the handler that
+     * relied on it.
+     */
+    if (nxt_slow_path(nxt_port_ready_test_queue_sizes(thr, task) != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+#endif
 
     /* Defined before the first goto done: the cleanup there releases it. */
     port = NULL;

--- a/src/test/nxt_router_new_port_test.c
+++ b/src/test/nxt_router_new_port_test.c
@@ -21,6 +21,12 @@
  *
  * The port keeps fd[0]: it is the port's socket, and the port outlives the
  * message.  Only fd[1] is the message's to lose.
+ *
+ * The refusal itself is checked here too: the port must come back without a
+ * queue.  A descriptor accounted for proves nothing about the mapping, and
+ * the size check is what keeps a short object off the port -- mmap()
+ * succeeds on one, and the router faults on the first access past its last
+ * page.
  */
 
 #include <nxt_main.h>
@@ -68,7 +74,7 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     nxt_buf_t                buf;
     nxt_task_t               *task;
     nxt_int_t                ret;
-    nxt_port_t               *port;
+    nxt_port_t               *port, *reply_port;
     nxt_runtime_t            *rt, *saved_rt;
     nxt_event_engine_t       engine;
     nxt_port_recv_msg_t      msg;
@@ -81,6 +87,7 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     sock = -1;
     queue = -1;
     port = NULL;
+    reply_port = NULL;
 
     task = thr->task;
     task->thread = thr;
@@ -129,6 +136,33 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     rt->main_engine = &engine;
 
     /*
+     * The port the message arrived on.  An application NEW_PORT that answers
+     * a pending start carries a stream, and the handler dispatches such a
+     * message through nxt_port_rpc_handler(), which reads this port; the
+     * fixture registers no stream, so the dispatch is a lookup that finds
+     * nothing and returns.
+     *
+     * The stream is what keeps the path under test short.  With stream 0 a
+     * handler that took the queue would run on into the main app port lookup
+     * -- an assertion the fixture cannot satisfy -- and then into a PORT_ACK
+     * written through the queue it just took, faulting on the short mapping.
+     * Either would kill the binary instead of failing the checks below.
+     */
+    reply_port = nxt_runtime_process_port_create(task, rt, nxt_pid, 0,
+                                                 NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(reply_port == NULL)) {
+        goto done;
+    }
+
+    /*
+     * nxt_port_new() zeroes the port, and 0 is a descriptor teardown must
+     * not close.
+     */
+    reply_port->pair[0] = -1;
+    reply_port->pair[1] = -1;
+    reply_port->socket.fd = -1;
+
+    /*
      * A short queue: mmap() of the whole object over it would succeed and
      * fault later, so the size check has to refuse it here.
      */
@@ -166,8 +200,8 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     msg.fd[0] = sock;
     msg.fd[1] = queue;
 
-    /* stream 0: the handler returns after the refusal, without RPC. */
-    msg.port_msg.stream = 0;
+    msg.port = reply_port;
+    msg.port_msg.stream = 1;
     msg.port_msg.pid = new_port.pid;
 
     nxt_router_new_port_handler(task, &msg);
@@ -196,6 +230,17 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     sock = -1;
     port = msg.u.new_port;
 
+    /*
+     * The point of the refusal: the short object must not be on the port.
+     * The descriptor checks above say only that nothing leaked, and would
+     * hold just as well for a handler that mapped the object and kept it.
+     */
+    if (port->queue != NULL) {
+        nxt_log_alert(thr->log, "router new port test: a refused queue was "
+                      "installed on the port");
+        goto done;
+    }
+
     ret = NXT_OK;
 
     nxt_log_error(NXT_LOG_NOTICE, thr->log, "router new port test passed");
@@ -221,6 +266,11 @@ done:
          */
         nxt_port_close(task, port);
         nxt_runtime_port_remove(task, port);
+    }
+
+    if (reply_port != NULL) {
+        nxt_port_close(task, reply_port);
+        nxt_runtime_port_remove(task, reply_port);
     }
 
     thr->runtime = saved_rt;


### PR DESCRIPTION
Closes #228. Tests only — no production code changes.

## The problem

The router-side regression test added with the queue-size check asserts only
descriptor ownership, and **that holds with or without the check**. Without
it, `nxt_router_port_queue_map()` maps `sizeof(nxt_port_queue_t)` over a
one-page object and *succeeds* — that is the defect, the fault arrives later
at an access past the object's last page — so the descriptor is closed and
`fd[0]` is taken on that path too. Both assertions pass either way.

This is not a security gap: the property is still guarded on master by
`nxt_port_ready_test`, which keeps the previous queue pointer and fails with
"short queue replaced the installed one". The gap is that the *router* path's
refusal has no test of its own.

## What changed

**A discriminating assertion**: `port->queue == NULL` after the handler. A
refused queue is one that was never installed.

**A fixture that lets that assertion fail.** With `stream = 0` the reverted
handler runs past the refusal into `nxt_assert(main_app_port != NULL)`, and
satisfying that only moves the failure to the `PORT_ACK` write, which
enqueues onto the short mapping and faults — the run dies of the bug under
test rather than of the assertion. The test now supplies a real reply port
and `stream = 1`, so the reverted path leaves through the RPC dispatch before
either hazard. `nxt_port_new()` zeroes the port, so `pair[0]`, `pair[1]` and
`socket.fd` are set to `-1` explicitly; otherwise teardown closes **fd 0**.

**Two boundary cases**, as direct calls to `nxt_port_queue_mmap()`:
- exactly `sizeof(nxt_port_queue_t)` is accepted — pins the comparison as
  `<`, not `<=`;
- a page-rounded object is accepted — pins the deliberate decision *not* to
  require equality. `sizeof(nxt_port_queue_t)` is 160 pages **plus 20 bytes**,
  so a shm object rounded up to a page legitimately reports more than the
  queue needs. "Tightening" the check to `==` would refuse every legitimate
  queue on such a platform and stall application port setup — a
  production-breaking regression with, until now, nothing to catch it.

## Each test was shown to fail, not argued to

| test | revert applied | result |
|---|---|---|
| exact-size | `st_size <` → `<=` | `exit 1`, "an exact-size queue was refused" |
| page-rounded | `st_size <` → `!=` | `exit 1`, "a page-rounded queue was refused" |
| router refusal | size check → `if (0 && ...)` | `exit 1`, "a refused queue was installed on the port" — clean message, no SIGBUS, no abort |

**The third proof is only valid with the ready test's short-queue case
temporarily gated.** Ungated, that test fails first and the router test never
starts, while the non-zero exit makes it look proved. That false positive is
precisely what this PR exists to remove, and it does bite — both an
independent review pass and I reproduced it.

Reviewed by an independent adversarial pass that reproduced all three
revert-proofs from scratch, and by `codex review`. Verified in **both**
`--debug --tests` (the CI leg) and release: these tests fail via
`nxt_log_alert` and return codes, not `nxt_assert`, so their teeth do not
compile out.

## Note on the probe

Both boundary cases touch the last item of the mapping the way
`nxt_port_queue_send()` would. Review corrected an earlier comment claiming
this is a SIGBUS check — it is not. Every page of an accepted mapping is at
least partially file-backed and a partial page at EOF is zero-filled, so no
size the helper accepts can fault there. The probe catches a short or garbage
mapping and fixes the shape of the access; the teeth of those two cases are
the NULL checks.
