### PR TITLE
port: stop describing a queueless port as a socket fallback

### DIFF
--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -429,6 +429,19 @@ nxt_main_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
         if (nxt_fast_path(mem != NULL)) {
             port->queue = mem;
+
+        } else {
+            /*
+             * Not a fallback to the socket: a libunit process delivers a
+             * socket message only after dequeuing the READ_SOCKET marker
+             * that only a queue-holding sender emits, so everything main
+             * sends on this port -- CHANGE_FILE on log rotation, QUIT on
+             * shutdown -- would be suspended undelivered, and the second
+             * message fails the worker's context.  See issue #231.
+             */
+            nxt_alert(task, "cannot map the queue of port %PI:%d; the "
+                      "process cannot be reached on this port from main",
+                      port->pid, (int) port->id);
         }
 
         nxt_fd_close(msg->fd[1]);

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -489,14 +489,40 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
         } else {
             /*
-             * A refused queue leaves the port as it was, as a failed
-             * mapping always did -- on the socket if it had no queue yet,
-             * on the one it already has otherwise.  Refusing the message
-             * outright would let a forged PROCESS_READY carrying a bad
-             * descriptor keep the process from ever being marked ready.
+             * A refused queue leaves the port as it was.  For a repeated
+             * PROCESS_READY that is the queue it already has, and the port
+             * keeps working.  For the first one it is no queue at all, and
+             * that is not a fallback to the socket: only libunit attaches
+             * a queue descriptor to PROCESS_READY, and a libunit process
+             * delivers a socket message only after dequeuing the
+             * READ_SOCKET marker that nxt_port_socket_write2() emits under
+             * port->queue != NULL.  A queueless sender cannot emit the
+             * marker, so its messages are suspended undelivered on the
+             * worker side, and the second one fails the worker's context
+             * ("too many port socket messages").  The broadcast below
+             * forwards queue_fd == -1, so every peer holds the same
+             * unreachable copy; a QUIT can never arrive, while requests
+             * still flow through the shared app queue.  See issue #231.
+             *
+             * The message is still not refused outright: it is not
+             * authenticated, and refusing it would let a forged
+             * PROCESS_READY carrying a bad descriptor keep the process
+             * from ever being marked ready.  Failing the start is the
+             * honest reaction to a genuine mmap failure, but it hands the
+             * same forgery a way to kill a legitimate start, so it has to
+             * wait for sender authentication (see the lookup comment
+             * above).
              */
-            nxt_log(task, NXT_LOG_WARN, "process %PI ready: cannot map the "
-                    "queue, leaving the port as it was", msg->port_msg.pid);
+            if (port->queue == NULL) {
+                nxt_alert(task, "process %PI ready: cannot map the queue; "
+                          "the process cannot be reached on this port",
+                          msg->port_msg.pid);
+
+            } else {
+                nxt_log(task, NXT_LOG_WARN, "process %PI ready: cannot map "
+                        "the replacement queue, keeping the current one",
+                        msg->port_msg.pid);
+            }
         }
     }
 


### PR DESCRIPTION
Closes nothing by itself; documentation half of #231.

Three places have now stated that a port without a mapped queue "falls back to the socket" and keeps working: the log e8b7f644 added to `nxt_port_process_ready_handler()`, the comment that survived its rewording ("on the socket if it had no queue yet"), and a justification offered during the #212 review. #231 traces why this is false for every libunit application — the READ_SOCKET marker that gates socket delivery is only ever emitted by a queue-holding sender — and #212's own discussion reproduced the consequence: one log rotation wedged a worker with `too many port socket messages`.

This PR only makes the code tell the truth:

- `nxt_port_process_ready_handler()`: the comment now states the real property (with the mechanism and the reason the message is still absorbed rather than refused), and the log splits into an alert for the case that leaves the port with **no** queue — the process is unreachable on that port — and the existing mild warning for a repeated `PROCESS_READY` that keeps the working queue it already has.
- `nxt_main_new_port_handler()`: a failed mapping now logs the consequence (main cannot deliver `CHANGE_FILE`/`QUIT` on that port) instead of continuing silently.

No behaviour changes. Failing the start on a genuine mmap failure is the honest end state, but `PROCESS_READY` is unauthenticated and refusing it hands a forged message a kill-the-start primitive — the same trade-off already documented at the router's `NEW_PORT` site and deferred to #223. #231 keeps that follow-up.

Verified: `./configure --tests --debug && make -j8` exit 0, `./build/tests` exit 0 (all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Asbr2xiUkx9axPtYy9Km2c
