### PR TITLE
ci(build-test): configure python and java against the toolchain the matrix installed

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -271,7 +271,7 @@ jobs:
 
       - name: Configure java
         run: |
-          sudo ./configure java
+          sudo ./configure java --home="$(readlink -f "${JAVA_HOME}")"
         if: steps.metadata.outputs.module == 'java'
 
       - name: Make java
@@ -357,9 +357,19 @@ jobs:
           python-version: '${{ steps.metadata.outputs.version }}'
         if: steps.metadata.outputs.module == 'python'
 
+      # A second setup-python below installs python-version '3' for pytest and
+      # overwrites pythonLocation with whatever the newest 3.x is.  Record the
+      # matrix interpreter's prefix while it is still the current one.
+      - name: Record python prefix
+        run: |
+          echo "UNIT_PYTHON_PREFIX=${pythonLocation}" >> "$GITHUB_ENV"
+        if: steps.metadata.outputs.module == 'python'
+
       - name: Configure python3
         run: |
-          sudo ./configure python --config=python3-config
+          sudo ./configure python \
+            --config="${UNIT_PYTHON_PREFIX}/bin/python3-config" \
+            --lib-path="${UNIT_PYTHON_PREFIX}/lib"
         if: steps.metadata.outputs.module == 'python'
 
       - name: Make python3
@@ -501,6 +511,11 @@ jobs:
 
       - name: Run ${{ steps.metadata.outputs.module }} tests
         run: |
+          # Pin unitd's embedded interpreter to the toolcache prefix it was
+          # built against; conftest turns this into PYTHONHOME for unitd only.
+          if [ "${{ steps.metadata.outputs.module }}" == "python" ]; then
+            export UNIT_PYTHONHOME="${UNIT_PYTHON_PREFIX}"
+          fi
           if [ "${{ matrix.build }}" == "wasm-wasi-component" ]; then
             pytest-3 --print-log ${{ steps.metadata.outputs.testpath }}
           else

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -521,7 +521,22 @@ def unit_run(state_dir=None):
         # router, app workers) shares one group we can signal as a unit — and
         # which can never be confused with the pytest runner's own group or an
         # unrelated unitd already running on the box.
-        p = subprocess.Popen(unitd_args, stderr=log, start_new_session=True)
+        # UNIT_PYTHONHOME pins the embedded interpreter's stdlib to the
+        # prefix unit's python module was built against.  It cannot be passed
+        # as PYTHONHOME from outside: unitd inherits this process's
+        # environment, and PYTHONHOME here would also rebind pytest's own
+        # interpreter, dropping dist-packages (where pytest itself lives) from
+        # its sys.path.  Needed when unit is built against a non-system
+        # interpreter whose minor version matches the system one, because
+        # CPython then resolves its prefix by finding "python3" on PATH.
+        unitd_env = os.environ.copy()
+        pythonhome = unitd_env.pop('UNIT_PYTHONHOME', None)
+        if pythonhome:
+            unitd_env['PYTHONHOME'] = pythonhome
+
+        p = subprocess.Popen(
+            unitd_args, stderr=log, start_new_session=True, env=unitd_env
+        )
         unit_instance['process'] = p
 
     # Record the group id (== leader pid) immediately, on disk and in-memory,

--- a/test/test_python_isolation.py
+++ b/test/test_python_isolation.py
@@ -8,8 +8,6 @@ import pytest
 from unit.applications.lang.python import ApplicationPython
 from unit.option import option
 from unit.utils import findmnt
-from unit.utils import waitformount
-from unit.utils import waitforunmount
 
 prerequisites = {'modules': {'python': 'any'}, 'features': {'isolation': True}}
 
@@ -78,29 +76,55 @@ def test_python_isolation_rootfs(is_su, require, temp_dir):
     assert ret['body']['FileExists'], 'application exists in rootfs'
 
 
+def language_deps_mounts(temp_dir):
+    # The stdlib bind mount lands at <rootfs><stdlib dir>, and auto/modules/
+    # python picks that directory as the sys.path entry whose basename is
+    # "pythonX.Y".  It is /usr/lib/pythonX.Y only when unit was built against
+    # the system interpreter; a toolcache, venv or /usr/local build mounts a
+    # different prefix, so match the stdlib directory rather than assuming one.
+    return [
+        line
+        for line in findmnt().splitlines()
+        if line.startswith(f'{temp_dir}/')
+        and re.search(r'/python\d+\.\d+', line.split(' ')[0])
+    ]
+
+
+def waitfor(predicate, timeout=50):
+    for _ in range(timeout):
+        if predicate():
+            return True
+
+        time.sleep(0.1)
+
+    return False
+
+
 def test_python_isolation_rootfs_no_language_deps(require, temp_dir):
     require({'privileged_user': True})
 
     isolation = {'rootfs': temp_dir, 'automount': {'language_deps': False}}
     client.load('empty', isolation=isolation)
 
-    python_path = f'{temp_dir}/usr'
-
-    assert findmnt().find(python_path) == -1
+    assert not language_deps_mounts(temp_dir)
     assert client.get()['status'] != 200, 'disabled language_deps'
-    assert findmnt().find(python_path) == -1
+    assert not language_deps_mounts(temp_dir)
 
     isolation['automount']['language_deps'] = True
 
     client.load('empty', isolation=isolation)
 
-    assert findmnt().find(python_path) == -1
+    assert not language_deps_mounts(temp_dir)
     assert client.get()['status'] == 200, 'enabled language_deps'
-    assert waitformount(python_path), 'language_deps mount'
+    assert waitfor(
+        lambda: bool(language_deps_mounts(temp_dir))
+    ), 'language_deps mount'
 
     client.conf({"listeners": {}, "applications": {}})
 
-    assert waitforunmount(python_path), 'language_deps unmount'
+    assert waitfor(
+        lambda: not language_deps_mounts(temp_dir)
+    ), 'language_deps unmount'
 
 
 def test_python_isolation_procfs(require, temp_dir):

--- a/test/unit/applications/lang/java.py
+++ b/test/unit/applications/lang/java.py
@@ -63,8 +63,19 @@ class ApplicationJava(ApplicationProto):
             if not ws_jars:
                 pytest.fail('websocket api jar not found.')
 
+            # The suite runs under sudo, whose secure_path drops the
+            # toolcache directory that actions/setup-java prepends, so a bare
+            # "javac" resolves to the system JDK rather than the one this
+            # matrix leg installed and built the jars with.
+            javac_bin = 'javac'
+            java_home = os.environ.get('JAVA_HOME')
+            if java_home:
+                javac_home = os.path.join(java_home, 'bin', 'javac')
+                if os.path.isfile(javac_home):
+                    javac_bin = javac_home
+
             javac = [
-                'javac',
+                javac_bin,
                 '-target',
                 '8',
                 '-source',


### PR DESCRIPTION
@pr.md