### PR TITLE
router: release the start slot when a start attempt fails early

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -179,6 +179,8 @@ NXT_TEST_SRCS=" \
     src/test/nxt_port_mmap_range_test.c \
     src/test/nxt_port_ready_test.c \
     src/test/nxt_router_new_port_test.c \
+    src/test/nxt_router_start_fail_test.c \
+    src/test/nxt_router_start_fail_soak_test.c \
     src/test/nxt_port_change_file_test.c \
     src/test/nxt_port_fd_test.c \
 "

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -229,6 +229,7 @@ static void nxt_router_app_port_ready(nxt_task_t *task,
     nxt_port_recv_msg_t *msg, void *data);
 static void nxt_router_app_port_error(nxt_task_t *task,
     nxt_port_recv_msg_t *msg, void *data);
+static void nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app);
 
 static void nxt_router_app_use(nxt_task_t *task, nxt_app_t *app, int i);
 static void nxt_router_app_unlink(nxt_task_t *task, nxt_app_t *app);
@@ -395,7 +396,7 @@ nxt_router_greet_controller(nxt_task_t *task, nxt_port_t *controller_port)
 }
 
 
-static void
+void
 nxt_router_start_app_process_handler(nxt_task_t *task, nxt_port_t *port,
     void *data)
 {
@@ -484,11 +485,25 @@ nxt_router_start_app_process_handler(nxt_task_t *task, nxt_port_t *port,
 
     nxt_router_app_joint_use(task, app->joint, 1);
 
+    goto skip;
+
 failed:
+
+    /*
+     * The attempt is over and no handler remains armed for it -- the two
+     * earlier sites never armed one, and the third cancels its registration
+     * with nxt_port_rpc_cancel() -- so nothing will ever report it back.
+     * Release the pending_processes slot the initiator took, exactly as
+     * nxt_router_app_port_error() does for the attempts that do get that far.
+     */
+
+    nxt_alert(task, "app '%V' failed to start a process", &app->name);
 
     if (b != NULL) {
         nxt_mp_free(b->data, b);
     }
+
+    nxt_router_app_start_failed(task, app);
 
 skip:
 
@@ -5041,8 +5056,6 @@ nxt_router_app_port_error(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 {
     nxt_app_t            *app;
     nxt_app_joint_t      *app_joint;
-    nxt_queue_link_t     *link;
-    nxt_http_request_t   *r;
     nxt_app_joint_rpc_t  *app_joint_rpc;
 
     nxt_assert(data != NULL);
@@ -5063,6 +5076,23 @@ nxt_router_app_port_error(nxt_task_t *task, nxt_port_recv_msg_t *msg,
     }
 
     nxt_debug(task, "app '%V' %p start error", &app->name, app);
+
+    nxt_router_app_start_failed(task, app);
+}
+
+
+/*
+ * A start attempt that will never yield a port: give back the
+ * pending_processes slot its initiator took and, if the application is left
+ * with no way to answer at all, fail the requests waiting for an
+ * acknowledgement instead of letting them sit until they time out.
+ */
+
+static void
+nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app)
+{
+    nxt_queue_link_t    *link;
+    nxt_http_request_t  *r;
 
     link = NULL;
 

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -265,6 +265,10 @@ void nxt_router_access_log_release(nxt_task_t *task,
 /* Not static so the descriptor-ownership test can drive it directly. */
 void nxt_router_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 
+/* Not static so the start-failure test can drive it directly. */
+void nxt_router_start_app_process_handler(nxt_task_t *task, nxt_port_t *port,
+    void *data);
+
 void nxt_router_access_log_reopen_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 

--- a/src/test/nxt_router_start_fail_soak_test.c
+++ b/src/test/nxt_router_start_fail_soak_test.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Failure-injection soak for issue #214.  The single-shot test proves that
+ * one early failure gives the pending_processes slot back; this one proves
+ * the accounting is exact under repetition and reaches all three "goto
+ * failed" sites in nxt_router_start_app_process_handler():
+ *
+ *   site 1  the prototype buffer allocation, forced by an app conf length
+ *           no allocator can satisfy;
+ *   site 2  nxt_port_rpc_register_handler_ex(), forced by the NXT_TESTS
+ *           rpc allocation hook;
+ *   site 3  nxt_port_socket_write2(), forced by the NXT_TESTS port message
+ *           allocation hook (the site the single-shot test uses).
+ *
+ * Every iteration seeds the counter at a baseline, adds the one increment
+ * the initiator takes, and requires it back at the baseline afterwards --
+ * a leak leaves baseline+1, a double release leaves baseline-1 (or wraps
+ * to UINT32_MAX at baseline 0).  Both are caught without nxt_assert, so
+ * the check survives a non-debug build.  Baselines alternate between 0 and
+ * a non-zero value so an underflow is caught as an ordinary miscount and
+ * not only as a wrap.
+ *
+ * After the loop the application must still be startable -- that is the
+ * damage #214 does -- and one successful start must still park exactly one
+ * increment on the RPC for nxt_router_app_port_error() to release.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_rpc.h>
+#include <nxt_runtime.h>
+#include <nxt_router.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+
+#define NXT_ROUTER_START_FAIL_SOAK_N  1000
+
+
+/* File scope: the handler hands the application to the router's
+   reference-counting helpers, so its storage must outlive the frame. */
+static nxt_app_t  nxt_router_start_fail_soak_test_app;
+
+
+/*
+ * Mirrors the nxt_inline nxt_router_app_can_start() predicate in
+ * src/nxt_router.c:1218.  Being nxt_inline, the gate #214 wedges is private
+ * to the router's translation unit and cannot be called from here, so this
+ * copy must be kept in sync with it.
+ */
+
+static nxt_bool_t
+nxt_router_start_fail_soak_can_start(nxt_app_t *app)
+{
+    return app->processes + app->pending_processes < app->max_processes
+           && app->pending_processes < app->max_pending_processes;
+}
+
+
+nxt_int_t
+nxt_router_start_fail_soak_test(nxt_thread_t *thr)
+{
+    uint32_t             baseline;
+    nxt_mp_t             *mp;
+    nxt_app_t            *app;
+    nxt_int_t            ret;
+    nxt_bool_t           app_mutex;
+    nxt_uint_t           i, site;
+    nxt_task_t           *task;
+    nxt_port_t           *router_port, *dport;
+    nxt_runtime_t        *rt, *saved_rt;
+    nxt_app_joint_t      *joint;
+    nxt_event_engine_t   engine, *saved_engine;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "router start fail soak test started");
+
+    ret = NXT_ERROR;
+    router_port = NULL;
+    dport = NULL;
+    joint = NULL;
+    app_mutex = 0;
+    app = &nxt_router_start_fail_soak_test_app;
+
+    task = thr->task;
+    task->thread = thr;
+
+    if (nxt_slow_path(nxt_port_rpc_init() != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    joint = nxt_mp_zalloc(mp, sizeof(nxt_app_joint_t));
+    if (nxt_slow_path(rt == NULL || joint == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * Site 1 allocates from task->thread->engine->mem_pool, so unlike the
+     * single-shot fixture this one needs an engine.  Only the members the
+     * reached code touches are set; see src/test/nxt_router_new_port_test.c.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+    thr->runtime = rt;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    /* The port the handler registers its RPC on. */
+
+    router_port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    /*
+     * nxt_port_rpc_register_handler_ex() asserts on a live pair[0]; the
+     * descriptor is never touched here, so borrow the nxt_port_fail_test()
+     * convention of a placeholder that is reset before the port is freed.
+     */
+    router_port->pair[0] = 0;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * The destination port.  No queue and write_ready unset, so
+     * nxt_port_socket_write2() takes the nxt_port_msg_chk_insert() path:
+     * the test hook fails its allocation for site 3, and without the hook
+     * the message is simply queued and the write succeeds.
+     */
+
+    dport = nxt_port_new(task, 1, nxt_pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(dport == NULL)) {
+        goto done;
+    }
+
+    dport->pair[0] = -1;
+    dport->pair[1] = -1;
+    dport->socket.fd = -1;
+
+    nxt_memzero(app, sizeof(nxt_app_t));
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&app->mutex) != NXT_OK)) {
+        goto done;
+    }
+
+    app_mutex = 1;
+
+    nxt_queue_init(&app->ports);
+    nxt_queue_init(&app->spare_ports);
+    nxt_queue_init(&app->idle_ports);
+    nxt_queue_init(&app->ack_waiting_req);
+
+    nxt_str_set(&app->name, "start-fail-soak-test");
+
+    app->joint = joint;
+    joint->app = app;
+    joint->use_count = 1;
+
+    app->max_processes = 8;
+    app->max_pending_processes = 1;
+
+    for (i = 0; i < NXT_ROUTER_START_FAIL_SOAK_N; i++) {
+        site = i % 3;
+        baseline = (i % 2) ? 2 : 0;
+
+        /* What a real initiator leaves behind: the slot and the work's use. */
+        app->pending_processes = baseline + 1;
+        app->use_count = 2;
+
+        /* One process alive, so the failure path has no requests to fail. */
+        app->processes = 1;
+        app->proto_port_requests = 0;
+
+        if (site == 0) {
+            /*
+             * Site 1: no prototype, so the handler builds the START_PROCESS
+             * payload first.  A length no allocator can serve makes
+             * nxt_buf_mem_alloc() return NULL before the buffer is written
+             * to, so app->conf may stay empty.
+             */
+            app->proto_port = NULL;
+            app->conf.length = (size_t) 1 << 46;
+
+        } else {
+            app->proto_port = dport;
+            app->conf.length = 0;
+
+            if (site == 1) {
+                nxt_port_rpc_test_alloc_failures(1);
+
+            } else {
+                nxt_port_test_msg_alloc_failures(1);
+            }
+        }
+
+        nxt_router_start_app_process_handler(task, router_port, app);
+
+        nxt_port_rpc_test_alloc_failures(0);
+        nxt_port_test_msg_alloc_failures(0);
+
+        if (app->pending_processes != baseline) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router start fail soak test: iteration %ui site %ui "
+                          "pending_processes %uD (expected %uD)",
+                          i, site + 1, app->pending_processes, baseline);
+            goto done;
+        }
+
+        if (app->use_count != 1) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router start fail soak test: iteration %ui site %ui "
+                          "app use_count %d (expected 1)",
+                          i, site + 1, (int) app->use_count);
+            goto done;
+        }
+
+        if (joint->use_count != 1) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router start fail soak test: iteration %ui site %ui "
+                          "joint use_count %uD (expected 1)",
+                          i, site + 1, joint->use_count);
+            goto done;
+        }
+    }
+
+    /* The gate #214 wedges: after the failures the app must still start. */
+
+    app->processes = 0;
+    app->pending_processes = 0;
+    app->conf.length = 0;
+    app->proto_port = dport;
+
+    if (!nxt_router_start_fail_soak_can_start(app)) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router start fail soak test: app cannot start after "
+                      "%d failures, processes %uD pending %uD",
+                      NXT_ROUTER_START_FAIL_SOAK_N, app->processes,
+                      app->pending_processes);
+        goto done;
+    }
+
+    /*
+     * A start that succeeds parks the initiator's increment on the armed
+     * RPC and takes a joint reference; nothing is released here.
+     */
+
+    app->pending_processes = 1;
+    app->use_count = 2;
+
+    nxt_router_start_app_process_handler(task, router_port, app);
+
+    if (app->pending_processes != 1 || joint->use_count != 2) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router start fail soak test: successful start left "
+                      "pending %uD joint %uD (expected 1 and 2)",
+                      app->pending_processes, joint->use_count);
+        goto done;
+    }
+
+    /*
+     * Tearing the port's registrations down drives the router's own error
+     * handler for the armed RPC, which is how a start that never answers is
+     * reported; it must give the parked increment back.
+     */
+
+    nxt_port_rpc_close(task, router_port);
+
+    if (app->pending_processes != 0 || joint->use_count != 1) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router start fail soak test: release left pending %uD "
+                      "joint %uD (expected 0 and 1)",
+                      app->pending_processes, joint->use_count);
+        goto done;
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "router start fail soak test passed: %d iterations over "
+                  "failure sites 1-3",
+                  NXT_ROUTER_START_FAIL_SOAK_N);
+
+    ret = NXT_OK;
+
+done:
+
+    if (dport != NULL) {
+        nxt_port_use(task, dport, -1);
+    }
+
+    if (router_port != NULL) {
+        router_port->pair[0] = -1;
+
+        nxt_port_use(task, router_port, -1);
+    }
+
+    thr->engine = saved_engine;
+    thr->runtime = saved_rt;
+
+    if (app_mutex) {
+        nxt_thread_mutex_destroy(&app->mutex);
+    }
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}

--- a/src/test/nxt_router_start_fail_test.c
+++ b/src/test/nxt_router_start_fail_test.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for issue #214: nxt_router_start_app_process_handler()
+ * is entered owning one app->pending_processes increment (its initiator
+ * took it before posting the work), and its failure paths used to return
+ * without giving it back.  The counter gates every future start
+ * (nxt_router_app_can_start()), so each leak permanently costs the
+ * application one start slot; with the default max_pending_processes of 1
+ * a single failure wedges the application for the router's lifetime.
+ *
+ * The deterministic failure used here is the nxt_port_socket_write2()
+ * site: the NXT_TESTS allocation-failure hook makes the port layer's
+ * message allocation fail, the write returns NXT_ERROR, and the handler
+ * takes "goto failed" after cancelling the RPC registration it had just
+ * made.  On entry the app is set up the way a real start attempt finds
+ * it: pending_processes already counted, one extra app use for the posted
+ * work item.
+ *
+ * This single-shot test reaches that third site only.  All three failure
+ * sites, and the accounting across repeated failures, are covered by
+ * src/test/nxt_router_start_fail_soak_test.c.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_rpc.h>
+#include <nxt_runtime.h>
+#include <nxt_router.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+
+/*
+ * File scope rather than a stack object: the handler hands the application to
+ * the router's reference-counting helpers, so its storage must outlive the
+ * frame even though this test's arrangement never lets it be posted anywhere.
+ */
+static nxt_app_t  nxt_router_start_fail_test_app;
+
+
+nxt_int_t
+nxt_router_start_fail_test(nxt_thread_t *thr)
+{
+    nxt_app_t   *app;
+    nxt_int_t   ret;
+    nxt_bool_t  app_mutex;
+    nxt_task_t  *task;
+    nxt_port_t  *router_port, *dport;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router start fail test started");
+
+    ret = NXT_ERROR;
+    router_port = NULL;
+    dport = NULL;
+    app_mutex = 0;
+    app = &nxt_router_start_fail_test_app;
+
+    task = thr->task;
+    task->thread = thr;
+
+    if (nxt_slow_path(nxt_port_rpc_init() != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    /* The port the handler registers its RPC on. */
+
+    router_port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        return NXT_ERROR;
+    }
+
+    /*
+     * nxt_port_rpc_register_handler_ex() asserts on a live pair[0]; the
+     * descriptor is never touched here, so borrow the nxt_port_fail_test()
+     * convention of a placeholder that is reset before the port is freed.
+     */
+    router_port->pair[0] = 0;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * The destination port the START_PROCESS message is written to.  No
+     * queue and write_ready unset, so nxt_port_socket_write2() takes the
+     * nxt_port_msg_chk_insert() path, whose allocation the test hook
+     * fails.
+     */
+
+    dport = nxt_port_new(task, 1, nxt_pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(dport == NULL)) {
+        goto done;
+    }
+
+    dport->pair[0] = -1;
+    dport->pair[1] = -1;
+    dport->socket.fd = -1;
+
+    nxt_memzero(app, sizeof(nxt_app_t));
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&app->mutex) != NXT_OK)) {
+        goto done;
+    }
+
+    app_mutex = 1;
+
+    nxt_queue_init(&app->ports);
+    nxt_queue_init(&app->spare_ports);
+    nxt_queue_init(&app->idle_ports);
+    nxt_queue_init(&app->ack_waiting_req);
+
+    nxt_str_set(&app->name, "start-fail-test");
+
+    /*
+     * A prototype port makes the handler take the plain app-start branch:
+     * no buffer allocation, straight to the RPC registration and the
+     * write.
+     */
+    app->proto_port = dport;
+
+    /* What a real initiator leaves behind: the slot and the work's use. */
+    app->pending_processes = 1;
+    app->use_count = 2;
+
+    /* One process alive, so the failure path has no requests to fail. */
+    app->processes = 1;
+
+    nxt_port_test_msg_alloc_failures(1);
+
+    nxt_router_start_app_process_handler(task, router_port, app);
+
+    nxt_port_test_msg_alloc_failures(0);
+
+    if (app->pending_processes != 0) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router start fail test: pending_processes %uD leaked "
+                      "(expected 0)", app->pending_processes);
+        goto done;
+    }
+
+    if (app->use_count != 1) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router start fail test: app use_count %d (expected 1)",
+                      (int) app->use_count);
+        goto done;
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router start fail test passed");
+
+    ret = NXT_OK;
+
+done:
+
+    if (dport != NULL) {
+        nxt_port_use(task, dport, -1);
+    }
+
+    if (router_port != NULL) {
+        router_port->pair[0] = -1;
+
+        nxt_port_use(task, router_port, -1);
+    }
+
+    if (app_mutex) {
+        nxt_thread_mutex_destroy(&app->mutex);
+    }
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -201,6 +201,14 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_router_start_fail_test(thr) != NXT_OK) {
+        return 1;
+    }
+
+    if (nxt_router_start_fail_soak_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -74,6 +74,8 @@ nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_mmap_range_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_ready_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);
+nxt_int_t nxt_router_start_fail_test(nxt_thread_t *thr);
+nxt_int_t nxt_router_start_fail_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);


### PR DESCRIPTION
Closes #214. **Post-tag material** — 1.36.1 is not tagged yet; this should not
go into the cut.

## The bug

`nxt_router_start_app_process_handler()` is entered owning one
`app->pending_processes` increment. Three `goto failed` sites — a buffer
allocation (`nxt_router.c:446`), an RPC registration (`:462`) and a port write
(`:472`) — reach a label that frees the buffer and drops the app reference but
never returns the slot.

**With the default `spare: 0` a single failure is enough**, because
`max_pending_processes = spare_processes ? spare_processes : 1`
(`:2045-2046`). One allocation failure under memory pressure and the
application never starts another worker for the life of the router. Nothing
recovers it: requests never own the counter, so no timeout path returns it,
and it leaks upward rather than underflowing, so the sibling `nxt_assert`s
cannot see it either.

## The fix follows an ownership rule, not the three sites

Every invocation owns exactly one reference and must dispose of it in one of
three ways: transfer it to an armed RPC (released by `app_port_ready` or
`app_port_error`), transfer it to the prototype wait queue (replayed as a
fresh invocation), or release it on failure. Only the third was missing.

Releasing at the `failed:` label puts the fix where the reference goes out of
scope, so it also covers entry paths added later, including prototype replays.
A pre-arm failure is the same event `app_port_error` handles, only earlier, so
the two now share one helper — which also means the waiting requests are
failed rather than left to time out, as `port_error` already did.

**No double-count is possible:** `nxt_port_rpc_cancel()`
(`nxt_port_rpc.c:515-543`) deletes the registration *without* invoking the
error handler, so no path from `failed:` also reaches `port_error`.

## The test is proven to fail

`src/test/nxt_router_start_fail_test.c` drives the handler directly, using
`nxt_port_test_msg_alloc_failures()` — already in the tree — to fail the next
port-message allocation deterministically, which is site 3.

With the release leg reverted (helper kept, so it still compiles):

```
tests: [notice] router start fail test started
tests: [notice] router start fail test: pending_processes 1 leaked (expected 0)
```
`./build/tests` exit **1**.

With the fix restored: exit **0**, **38 tests pass**, including
`router start fail test passed`.

Both traps this project has been bitten by were checked explicitly: no earlier
test pre-empts it (its own message appears, at the expected position), and the
exit status was read directly rather than through a pipe.

An earlier draft of this test **aborted the suite** rather than running —
`nxt_port_rpc_register_handler_ex()` asserts `port->pair[0] != -1`, and the
draft set it to `-1`, so a `--debug` build died with SIGABRT before the
assertion could be reached. It now follows the existing convention from
`nxt_port_fail_test_rpc_register()`: `pair[0] = 0` for the call, reset to `-1`
before teardown so the port does not close stdin.

## Deliberately out of scope

- **#223's window.** A refused port queue strands an *already-armed* start —
  its slot, its `app_joint` reference, and a registered but unreachable port.
  That cannot be fixed at the call site until port provenance is visible. The
  shared helper here is the primitive that work completes into; this change
  does not close that case.
- **A second wedge, found while researching this and not yet filed.** If a
  *prototype* start fails, `app_port_error` decrements the counter but never
  resets `proto_port_requests`, which is reset only in the success branch
  (`:4961`). It then stays non-zero forever and every later attempt parks in
  the wait branch (`:428-435`) for a prototype that is not coming. Distinct
  mechanism, needs proto-awareness in `port_error`, and gets its own change.

## Verification

`./configure --openssl --debug --tests`, `make -j8 tests`: clean, **zero
warnings**. `./build/tests`: exit 0, 38 passed.


## Client-visible consequence

Independent review surfaced a behaviour change worth stating explicitly, since
it is what an operator actually observes.

With `spare: 0`, a transient start failure previously left the request queued
against an app whose `timeout` is 0 — so the request hung, and the leaked slot
wedged the application against all later starts. With this change the waiting
requests are failed at the point the attempt dies, so the client gets **503
immediately** instead of hanging, and the application keeps starting workers.

That is a strict improvement, but it is a change in observable behaviour on a
failure path, not only a counter fix — it belongs in the changelog entry for
whichever release carries this.

## Soak

`src/test/nxt_router_start_fail_soak_test.c` covers what the single-shot test
cannot: **all three** `goto failed` sites (buffer allocation, RPC registration,
port write), cycled over **N = 1000** iterations, requiring
`app->pending_processes` back at its baseline after every one. Baselines
alternate 0 and 2, so an underflow shows as a miscount and not only as a
`uint32` wrap — the check still works in a build with `nxt_assert` compiled
out. Afterwards the application must still pass the start gate, and one
*successful* start must park exactly one increment on the armed RPC.

It is cheap: **~0.8 ms** measured for the whole 1000-iteration loop (three runs:
792 / 917 / 701 µs), so it costs nothing in the suite.

Both tests are proven to fail with the release leg reverted (helper kept, so it
still compiles). Negative control 1, the single-shot test:

```
tests: [notice] router start fail test started
tests: [notice] router start fail test: pending_processes 1 leaked (expected 0)
```

Negative control 2, the soak (single-shot test skipped so the suite reaches it —
`nxt_tests.c` stops at the first failure):

```
tests: [notice] router start fail soak test started
tests: [notice] router start fail soak test: iteration 0 site 1 pending_processes 1 (expected 0)
```

`./build/tests` exit **1** in both; nothing earlier failed, the leak line is the
last line of the run. With the fix restored, exit **0** and both
`router start fail test passed` and
`router start fail soak test passed: 1000 iterations over failure sites 1-3`.
Verified in a `--debug --tests` build and again in a non-debug `--tests` build,
both exit 0, zero warnings.

The soak's `can_start()` copy mirrors the `nxt_inline`
`nxt_router_app_can_start()` in `src/nxt_router.c`; the comment above it says so
and asks for the two to be kept in sync.

## Why it hid for years — now fixed

All three `goto failed` sites were silent outside `--debug`: the counter leaks
upward rather than underflowing, so the sibling `nxt_assert`s cannot fire, and
nothing logged. The label now logs:

```
nxt_alert(task, "app '%V' failed to start a process", &app->name);
```

so a wedged application is distinguishable from a busy one in a production log.
(The soak consequently emits 1000 of these alert lines when the test suite runs —
expected, and the price of the label no longer being silent.)

