### PR TITLE
docs(openapi): model the control API error response

### DIFF
--- a/docs/unit-openapi.yaml
+++ b/docs/unit-openapi.yaml
@@ -5609,6 +5609,15 @@ components:
           line: 1
           column: 0
 
+    errorUnknownParameter:
+      summary: "400 error response for an unknown parameter"
+      value:
+        error: "Invalid configuration."
+        detail: 'Unknown parameter "pas".'
+        location:
+          path: "/routes/0/action"
+        suggestion: "pass"
+
     errorValueDoesntExist:
       summary: "404 error response"
       value:
@@ -6442,6 +6451,9 @@ components:
             example1:
               $ref: "#/components/examples/errorInvalidJson"
 
+            example2:
+              $ref: "#/components/examples/errorUnknownParameter"
+
     responseNotFound:
       description: "Not Found; the value does not exist in the configuration.
         This may occur if any part of the path is non-existent."
@@ -6493,9 +6505,56 @@ components:
 
     jsonErrorMessage:
       type: object
-      description: "JSON message on error."
+      description: "JSON message on error. Only `error` is always present;
+        each of the others is omitted where it does not apply."
+      properties:
+        error:
+          type: string
+          description: "What went wrong, in a human-readable sentence."
+
+        detail:
+          type: string
+          description: "A longer explanation of the error, where one adds
+            anything to the message."
+
+        location:
+          $ref: "#/components/schemas/errorLocation"
+
+        suggestion:
+          type: string
+          description: "The name the request most likely meant, reported when
+            an unknown parameter is a close and unambiguous typo of a known
+            one."
+
       additionalProperties:
         type: string
+
+    errorLocation:
+      type: object
+      description: "Where in the request the error is. Present when the error
+        can be placed; which members appear depends on how it was found."
+      properties:
+        offset:
+          type: integer
+          description: "Byte offset into the request body, reported only for
+            an error found while parsing it."
+
+        line:
+          type: integer
+          description: "Line number, reported with `column` and only for an
+            error found while parsing."
+
+        column:
+          type: integer
+          description: "Column number, reported with `line`."
+
+        path:
+          type: string
+          description: "An RFC 6901 JSON Pointer to where the error is: the
+            member whose value failed validation, the member a required
+            parameter is missing from, or the containing object when the
+            failure is an unknown parameter, whose name the message itself
+            carries. An empty string is the document root."
 
     # Configuration sections as data types; hugely reliant on each other
 

--- a/docs/unit-openapi.yaml
+++ b/docs/unit-openapi.yaml
@@ -6507,6 +6507,8 @@ components:
       type: object
       description: "JSON message on error. Only `error` is always present;
         each of the others is omitted where it does not apply."
+      required:
+        - error
       properties:
         error:
           type: string
@@ -6531,13 +6533,17 @@ components:
 
     errorLocation:
       type: object
-      description: "Where in the request the error is. Present when the error
-        can be placed; which members appear depends on how it was found."
+      description: "Where the error is. Present when it can be placed. Which
+        members appear depends on how it was found, and they do not index the
+        same document: `offset`, `line` and `column` locate the error in the
+        request body, while `path` locates it in the resulting configuration."
       properties:
         offset:
           type: integer
           description: "Byte offset into the request body, reported only for
-            an error found while parsing it."
+            an error found while parsing it. A leading UTF-8 byte order mark
+            is skipped before parsing, so the offset is relative to the JSON
+            that follows it rather than to the bytes sent."
 
         line:
           type: integer
@@ -6550,11 +6556,15 @@ components:
 
         path:
           type: string
-          description: "An RFC 6901 JSON Pointer to where the error is: the
-            member whose value failed validation, the member a required
-            parameter is missing from, or the containing object when the
-            failure is an unknown parameter, whose name the message itself
-            carries. An empty string is the document root."
+          description: "An RFC 6901 JSON Pointer to the member whose value
+            failed validation, to the member a required parameter is missing
+            from, or to the containing object when the failure is an unknown
+            parameter, whose name the message itself carries. It points into
+            the configuration the request would produce, not into the request
+            body: a request to a path below \"/config\" is validated against a
+            copy of the whole configuration with the change applied, so the
+            pointer is rooted at the configuration and an empty string is the
+            configuration itself."
 
     # Configuration sections as data types; hugely reliant on each other
 

--- a/tools/unitctl/unit-client-rs/src/unit_client.rs
+++ b/tools/unitctl/unit-client-rs/src/unit_client.rs
@@ -43,7 +43,9 @@ custom_error! {pub UnitClientError
     HttpResponseJsonBodyError { status: http::StatusCode,
                                 path: String,
                                 error: String,
-                                detail: String} = "HTTP response error [path={path}, status={status}]:\n  Error: {error}\n  Detail: {detail}",
+                                detail: String,
+                                location: String,
+                                suggestion: String} = "HTTP response error [path={path}, status={status}]:\n  Error: {error}\n  Detail: {detail}{location}{suggestion}",
     IoError { source: io::Error, socket: String } = "IO error [socket={socket}]",
     UnixSocketAddressError {
         source: io::Error,
@@ -165,6 +167,50 @@ pub struct UnitClient {
     client: Box<RemoteClient>,
 }
 
+/// Pulls the parts of a control API error body out for display: the message, the
+/// detail, where the error is, and the name a typo probably meant.  The last two
+/// come back pre-formatted, empty when they do not apply, so a response carrying
+/// neither renders exactly as it did before they existed.
+fn describe_error_body(body: &serde_json::Value) -> (String, String, String, String) {
+    let member = |name: &str| {
+        body.get(name)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let mut error = member("error");
+    if error.is_empty() {
+        error = "Unknown error".to_string();
+    }
+
+    // A validation error places itself with an RFC 6901 pointer, where the empty
+    // string is the document root; an error found while parsing the request has
+    // no pointer and places itself by position instead.
+    let place = body.get("location").and_then(|location| {
+        let number = |name: &str| location.get(name).and_then(serde_json::Value::as_i64);
+
+        match location.get("path").and_then(serde_json::Value::as_str) {
+            Some("") => Some("the document root".to_string()),
+            Some(pointer) => Some(pointer.to_string()),
+            None => match (number("line"), number("column"), number("offset")) {
+                (Some(line), Some(column), _) => Some(format!("line {}, column {}", line, column)),
+                (_, _, Some(offset)) => Some(format!("byte offset {}", offset)),
+                _ => None,
+            },
+        }
+    });
+
+    let location = place.map(|place| format!("\n  Location: {}", place)).unwrap_or_default();
+
+    let suggestion = match member("suggestion").as_str() {
+        "" => String::new(),
+        name => format!("\n  Did you mean: {}", name),
+    };
+
+    (error, member("detail"), location, suggestion)
+}
+
 impl UnitClient {
     pub fn new(control_socket: ControlSocket) -> Self {
         if control_socket.is_local_socket() {
@@ -228,17 +274,27 @@ impl UnitClient {
 
         let mut reader = body_bytes.reader();
         if !status.is_success() {
-            let error: HashMap<String, String> =
+            // The control API answers an error with "error" and, where they
+            // apply, "detail", a "location" object placing the error, and a
+            // "suggestion" naming the parameter an unknown one was probably a
+            // typo of.  "location" is an object, so the body is not a map of
+            // strings and must not be deserialized as one: that fails the
+            // whole body and hides the message it carries.
+            let body: serde_json::Value =
                 serde_json::from_reader(&mut reader).map_err(|error| UnitClientError::JsonError {
                     source: error,
                     path: path.to_string(),
                 })?;
 
+            let (error, detail, location, suggestion) = describe_error_body(&body);
+
             return Err(UnitClientError::HttpResponseJsonBodyError {
                 status,
                 path: path.to_string(),
-                error: error.get("error").unwrap_or(&"Unknown error".into()).to_string(),
-                detail: error.get("detail").unwrap_or(&"".into()).to_string(),
+                error,
+                detail,
+                location,
+                suggestion,
             });
         }
         serde_json::from_reader(&mut reader).map_err(|error| UnitClientError::JsonError {
@@ -370,6 +426,63 @@ mod tests {
     use crate::unitd_instance::UnitdInstance;
 
     use super::*;
+
+    /// The shapes nxt_controller_response() can send, and how each renders.
+    #[test]
+    fn describes_every_error_body_shape() {
+        let case = |body: serde_json::Value| {
+            let (error, detail, location, suggestion) = describe_error_body(&body);
+            format!("{}|{}|{}|{}", error, detail, location, suggestion)
+        };
+
+        // A plain error, as before location and suggestion existed: both parts
+        // must be empty so the rendered message is unchanged.
+        assert_eq!(
+            case(serde_json::json!({"error": "Value doesn't exist."})),
+            "Value doesn't exist.|||"
+        );
+
+        // A validation error: an RFC 6901 pointer at the member at fault.
+        assert_eq!(
+            case(serde_json::json!({
+                "error": "Invalid configuration.",
+                "detail": "Unknown parameter \"pas\".",
+                "location": {"path": "/routes/0/action"},
+                "suggestion": "pass"
+            })),
+            "Invalid configuration.|Unknown parameter \"pas\".|\n  Location: /routes/0/action|\n  Did you mean: pass"
+        );
+
+        // The empty pointer is the document root, not a missing value.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid configuration.",
+                                    "location": {"path": ""}})),
+            "Invalid configuration.||\n  Location: the document root|"
+        );
+
+        // An error found while parsing places itself by position: no pointer.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid JSON.",
+                                    "location": {"offset": 12, "line": 2, "column": 5}})),
+            "Invalid JSON.||\n  Location: line 2, column 5|"
+        );
+
+        // Offset without line/column, which the controller sends when the
+        // position is known but not the line.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid JSON.", "location": {"offset": 12}})),
+            "Invalid JSON.||\n  Location: byte offset 12|"
+        );
+
+        // Nothing usable in location, and a body that is not an object at all:
+        // neither may panic or invent a location.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid JSON.", "location": {}})),
+            "Invalid JSON.|||"
+        );
+        assert_eq!(case(serde_json::json!("not an object")), "Unknown error|||");
+    }
+
     // Integration tests
 
     #[tokio::test]

--- a/tools/unitctl/unit-openapi/README.md
+++ b/tools/unitctl/unit-openapi/README.md
@@ -364,6 +364,10 @@ Class | Method | HTTP request | Description
 *StatusApi* | [**get_status_modules_lang_version**](docs/StatusApi.md#get_status_modules_lang_version) | **Get** /status/modules/{langMod}/version | Retrieve the language module version object
 *StatusApi* | [**get_status_requests**](docs/StatusApi.md#get_status_requests) | **Get** /status/requests | Retrieve the requests status object
 *StatusApi* | [**get_status_requests_total**](docs/StatusApi.md#get_status_requests_total) | **Get** /status/requests/total | Retrieve the total requests number
+*StatusApi* | [**get_status_telemetry**](docs/StatusApi.md#get_status_telemetry) | **Get** /status/telemetry | Retrieve the telemetry status object
+*StatusApi* | [**get_status_telemetry_spans**](docs/StatusApi.md#get_status_telemetry_spans) | **Get** /status/telemetry/spans | Retrieve the telemetry spans object
+*StatusApi* | [**get_status_telemetry_spans_exported**](docs/StatusApi.md#get_status_telemetry_spans_exported) | **Get** /status/telemetry/spans/exported | Retrieve the exported spans number
+*StatusApi* | [**get_status_telemetry_spans_failed**](docs/StatusApi.md#get_status_telemetry_spans_failed) | **Get** /status/telemetry/spans/failed | Retrieve the failed spans number
 *TlsApi* | [**delete_listener_tls**](docs/TlsApi.md#delete_listener_tls) | **Delete** /config/listeners/{listenerName}/tls | Delete the tls object in a listener
 *TlsApi* | [**delete_listener_tls_certificate**](docs/TlsApi.md#delete_listener_tls_certificate) | **Delete** /config/listeners/{listenerName}/tls/certificate/{arrayIndex} | Delete a certificate array item in a listener
 *TlsApi* | [**delete_listener_tls_certificates**](docs/TlsApi.md#delete_listener_tls_certificates) | **Delete** /config/listeners/{listenerName}/tls/certificate | Delete the certificate option in a listener
@@ -465,6 +469,8 @@ Class | Method | HTTP request | Description
  - [ConfigSettingsHttpStatic](docs/ConfigSettingsHttpStatic.md)
  - [ConfigSettingsHttpStaticMimeType](docs/ConfigSettingsHttpStaticMimeType.md)
  - [ConfigSettingsTelemetry](docs/ConfigSettingsTelemetry.md)
+ - [ErrorLocation](docs/ErrorLocation.md)
+ - [JsonErrorMessage](docs/JsonErrorMessage.md)
  - [Status](docs/Status.md)
  - [StatusApplicationsApp](docs/StatusApplicationsApp.md)
  - [StatusApplicationsAppProcesses](docs/StatusApplicationsAppProcesses.md)
@@ -472,6 +478,8 @@ Class | Method | HTTP request | Description
  - [StatusConnections](docs/StatusConnections.md)
  - [StatusModulesLang](docs/StatusModulesLang.md)
  - [StatusRequests](docs/StatusRequests.md)
+ - [StatusTelemetry](docs/StatusTelemetry.md)
+ - [StatusTelemetrySpans](docs/StatusTelemetrySpans.md)
  - [StringOrStringArray](docs/StringOrStringArray.md)
 
 


### PR DESCRIPTION
Documents the control API error response, which the spec has never described correctly and which 1.36.1 extended.

**Do not merge before #237** — this branches off that PR's head (`8410a3c4`) and targets `release/1.36.1` so it ships in the 1.36.1 tag.

## The problem

Every error response in the spec points at one schema:

```yaml
jsonErrorMessage:
  type: object
  additionalProperties:
    type: string
```

The server has never sent only that. `location` is a nested object with integer `offset`, `line` and `column` (`src/nxt_controller.c:2729-2755`), and 1.36.1 added an RFC 6901 JSON Pointer in `location.path` plus a top-level `suggestion` naming the parameter an unknown one was probably a typo of — the release's headline changelog entry. `suggestion` appeared **zero** times in the spec.

The spec already contradicted itself: its own `errorInvalidJson` example shows a `location` object, which the schema it is attached to forbids.

## The change

Spec only, no code. `jsonErrorMessage` gains the members the controller actually sets — `error`, `detail`, `location`, `suggestion` — keeping `additionalProperties` so anything unmodelled stays legal; a new `errorLocation` documents the nested object, recording for each member the condition under which the server emits it. A new `errorUnknownParameter` example carries the pointer and the suggestion, offered on 400 beside the existing parse-error example, with wording taken verbatim from the server (`nxt_controller.c:1653`, `nxt_conf_validation.c:2064`).

`jsonSuccessMessage` is deliberately **not** touched: a pure-`additionalProperties` named schema generates as `HashMap<String, String>`, and `unit_client.rs:308` hard-codes that type for the restart endpoint. Error bodies never reach a generated model — the client templates turn a non-2xx into an error carrying raw bytes — so this change cannot affect the generated client.

## Validation

Every committed example was checked against the schema it is attached to:

| | example sites failing |
|---|---|
| before (`8410a3c4`) | 60 |
| after | 6 |

Zero sites fail that did not fail before; the 6 that remain are unrelated `/config` application and settings examples. YAML parses, every `$ref` resolves, no added line over 80 columns. An adversarial review pass verified the member inventory, presence conditions and example wording against `nxt_controller.c` and `nxt_conf_validation.c`.

## Found while doing this, not fixed here

`unit_client.rs:231` deserializes every error body as `HashMap<String, String>`, so any response carrying `location` fails serde and surfaces `JsonError` instead of the server's actual message. Filed as #239 — and it is worse than "pre-existing": at tag `1.36.0` a validation error carried no `location` at all, so the map deserialization succeeded. 1.36.1 emits a pointer for every validation error, so the common case of a configuration typo now loses the server's explanation, including the `suggestion` this release added to help with exactly that.

