### PR TITLE
fix(unitctl): stop hiding the server's error message

### DIFF
--- a/tools/unitctl/unit-client-rs/src/unit_client.rs
+++ b/tools/unitctl/unit-client-rs/src/unit_client.rs
@@ -43,7 +43,9 @@ custom_error! {pub UnitClientError
     HttpResponseJsonBodyError { status: http::StatusCode,
                                 path: String,
                                 error: String,
-                                detail: String} = "HTTP response error [path={path}, status={status}]:\n  Error: {error}\n  Detail: {detail}",
+                                detail: String,
+                                location: String,
+                                suggestion: String} = "HTTP response error [path={path}, status={status}]:\n  Error: {error}\n  Detail: {detail}{location}{suggestion}",
     IoError { source: io::Error, socket: String } = "IO error [socket={socket}]",
     UnixSocketAddressError {
         source: io::Error,
@@ -165,6 +167,50 @@ pub struct UnitClient {
     client: Box<RemoteClient>,
 }
 
+/// Pulls the parts of a control API error body out for display: the message, the
+/// detail, where the error is, and the name a typo probably meant.  The last two
+/// come back pre-formatted, empty when they do not apply, so a response carrying
+/// neither renders exactly as it did before they existed.
+fn describe_error_body(body: &serde_json::Value) -> (String, String, String, String) {
+    let member = |name: &str| {
+        body.get(name)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let mut error = member("error");
+    if error.is_empty() {
+        error = "Unknown error".to_string();
+    }
+
+    // A validation error places itself with an RFC 6901 pointer, where the empty
+    // string is the document root; an error found while parsing the request has
+    // no pointer and places itself by position instead.
+    let place = body.get("location").and_then(|location| {
+        let number = |name: &str| location.get(name).and_then(serde_json::Value::as_i64);
+
+        match location.get("path").and_then(serde_json::Value::as_str) {
+            Some("") => Some("the document root".to_string()),
+            Some(pointer) => Some(pointer.to_string()),
+            None => match (number("line"), number("column"), number("offset")) {
+                (Some(line), Some(column), _) => Some(format!("line {}, column {}", line, column)),
+                (_, _, Some(offset)) => Some(format!("byte offset {}", offset)),
+                _ => None,
+            },
+        }
+    });
+
+    let location = place.map(|place| format!("\n  Location: {}", place)).unwrap_or_default();
+
+    let suggestion = match member("suggestion").as_str() {
+        "" => String::new(),
+        name => format!("\n  Did you mean: {}", name),
+    };
+
+    (error, member("detail"), location, suggestion)
+}
+
 impl UnitClient {
     pub fn new(control_socket: ControlSocket) -> Self {
         if control_socket.is_local_socket() {
@@ -228,17 +274,27 @@ impl UnitClient {
 
         let mut reader = body_bytes.reader();
         if !status.is_success() {
-            let error: HashMap<String, String> =
+            // The control API answers an error with "error" and, where they
+            // apply, "detail", a "location" object placing the error, and a
+            // "suggestion" naming the parameter an unknown one was probably a
+            // typo of.  "location" is an object, so the body is not a map of
+            // strings and must not be deserialized as one: that fails the
+            // whole body and hides the message it carries.
+            let body: serde_json::Value =
                 serde_json::from_reader(&mut reader).map_err(|error| UnitClientError::JsonError {
                     source: error,
                     path: path.to_string(),
                 })?;
 
+            let (error, detail, location, suggestion) = describe_error_body(&body);
+
             return Err(UnitClientError::HttpResponseJsonBodyError {
                 status,
                 path: path.to_string(),
-                error: error.get("error").unwrap_or(&"Unknown error".into()).to_string(),
-                detail: error.get("detail").unwrap_or(&"".into()).to_string(),
+                error,
+                detail,
+                location,
+                suggestion,
             });
         }
         serde_json::from_reader(&mut reader).map_err(|error| UnitClientError::JsonError {
@@ -370,6 +426,63 @@ mod tests {
     use crate::unitd_instance::UnitdInstance;
 
     use super::*;
+
+    /// The shapes nxt_controller_response() can send, and how each renders.
+    #[test]
+    fn describes_every_error_body_shape() {
+        let case = |body: serde_json::Value| {
+            let (error, detail, location, suggestion) = describe_error_body(&body);
+            format!("{}|{}|{}|{}", error, detail, location, suggestion)
+        };
+
+        // A plain error, as before location and suggestion existed: both parts
+        // must be empty so the rendered message is unchanged.
+        assert_eq!(
+            case(serde_json::json!({"error": "Value doesn't exist."})),
+            "Value doesn't exist.|||"
+        );
+
+        // A validation error: an RFC 6901 pointer at the member at fault.
+        assert_eq!(
+            case(serde_json::json!({
+                "error": "Invalid configuration.",
+                "detail": "Unknown parameter \"pas\".",
+                "location": {"path": "/routes/0/action"},
+                "suggestion": "pass"
+            })),
+            "Invalid configuration.|Unknown parameter \"pas\".|\n  Location: /routes/0/action|\n  Did you mean: pass"
+        );
+
+        // The empty pointer is the document root, not a missing value.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid configuration.",
+                                    "location": {"path": ""}})),
+            "Invalid configuration.||\n  Location: the document root|"
+        );
+
+        // An error found while parsing places itself by position: no pointer.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid JSON.",
+                                    "location": {"offset": 12, "line": 2, "column": 5}})),
+            "Invalid JSON.||\n  Location: line 2, column 5|"
+        );
+
+        // Offset without line/column, which the controller sends when the
+        // position is known but not the line.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid JSON.", "location": {"offset": 12}})),
+            "Invalid JSON.||\n  Location: byte offset 12|"
+        );
+
+        // Nothing usable in location, and a body that is not an object at all:
+        // neither may panic or invent a location.
+        assert_eq!(
+            case(serde_json::json!({"error": "Invalid JSON.", "location": {}})),
+            "Invalid JSON.|||"
+        );
+        assert_eq!(case(serde_json::json!("not an object")), "Unknown error|||");
+    }
+
     // Integration tests
 
     #[tokio::test]

--- a/tools/unitctl/unit-openapi/README.md
+++ b/tools/unitctl/unit-openapi/README.md
@@ -364,6 +364,10 @@ Class | Method | HTTP request | Description
 *StatusApi* | [**get_status_modules_lang_version**](docs/StatusApi.md#get_status_modules_lang_version) | **Get** /status/modules/{langMod}/version | Retrieve the language module version object
 *StatusApi* | [**get_status_requests**](docs/StatusApi.md#get_status_requests) | **Get** /status/requests | Retrieve the requests status object
 *StatusApi* | [**get_status_requests_total**](docs/StatusApi.md#get_status_requests_total) | **Get** /status/requests/total | Retrieve the total requests number
+*StatusApi* | [**get_status_telemetry**](docs/StatusApi.md#get_status_telemetry) | **Get** /status/telemetry | Retrieve the telemetry status object
+*StatusApi* | [**get_status_telemetry_spans**](docs/StatusApi.md#get_status_telemetry_spans) | **Get** /status/telemetry/spans | Retrieve the telemetry spans object
+*StatusApi* | [**get_status_telemetry_spans_exported**](docs/StatusApi.md#get_status_telemetry_spans_exported) | **Get** /status/telemetry/spans/exported | Retrieve the exported spans number
+*StatusApi* | [**get_status_telemetry_spans_failed**](docs/StatusApi.md#get_status_telemetry_spans_failed) | **Get** /status/telemetry/spans/failed | Retrieve the failed spans number
 *TlsApi* | [**delete_listener_tls**](docs/TlsApi.md#delete_listener_tls) | **Delete** /config/listeners/{listenerName}/tls | Delete the tls object in a listener
 *TlsApi* | [**delete_listener_tls_certificate**](docs/TlsApi.md#delete_listener_tls_certificate) | **Delete** /config/listeners/{listenerName}/tls/certificate/{arrayIndex} | Delete a certificate array item in a listener
 *TlsApi* | [**delete_listener_tls_certificates**](docs/TlsApi.md#delete_listener_tls_certificates) | **Delete** /config/listeners/{listenerName}/tls/certificate | Delete the certificate option in a listener
@@ -465,6 +469,8 @@ Class | Method | HTTP request | Description
  - [ConfigSettingsHttpStatic](docs/ConfigSettingsHttpStatic.md)
  - [ConfigSettingsHttpStaticMimeType](docs/ConfigSettingsHttpStaticMimeType.md)
  - [ConfigSettingsTelemetry](docs/ConfigSettingsTelemetry.md)
+ - [ErrorLocation](docs/ErrorLocation.md)
+ - [JsonErrorMessage](docs/JsonErrorMessage.md)
  - [Status](docs/Status.md)
  - [StatusApplicationsApp](docs/StatusApplicationsApp.md)
  - [StatusApplicationsAppProcesses](docs/StatusApplicationsAppProcesses.md)
@@ -472,6 +478,8 @@ Class | Method | HTTP request | Description
  - [StatusConnections](docs/StatusConnections.md)
  - [StatusModulesLang](docs/StatusModulesLang.md)
  - [StatusRequests](docs/StatusRequests.md)
+ - [StatusTelemetry](docs/StatusTelemetry.md)
+ - [StatusTelemetrySpans](docs/StatusTelemetrySpans.md)
  - [StringOrStringArray](docs/StringOrStringArray.md)
 
 


### PR DESCRIPTION
Restores the server's error message in `unitctl`, which 1.36.1 would otherwise hide for the most common failure there is — a typo in a configuration.

**Merge after #238** (it branches off it and needs its schema documented alongside). Order: #238 → this → #237 → tag.

## The bug

`unit_client.rs` deserialized every non-2xx control API body into `HashMap<String, String>`:

```rust
let error: HashMap<String, String> = serde_json::from_reader(&mut reader)...
```

The body is not flat. `location` is a nested object (`src/nxt_controller.c:2729-2766`), so serde fails the whole body with "invalid type: map, expected a string" and the branch that reads `error.get("error")` never runs. The user sees a JSON deserialization error instead of what Unit said.

## Why this release makes it matter

At tag `1.36.0` there is no `have_pointer` in `nxt_controller.c`: a validation error set `offset = -1` and emitted no `location` at all, so the flat-map parse succeeded. 1.36.1 emits an RFC 6901 pointer for **every** validation error, so the ordinary case now breaks — and what gets swallowed includes the `suggestion` this release added specifically to help with typos.

## The fix

Deserialize into `serde_json::Value` and pull the parts out in `describe_error_body()`, which handles every shape the controller can send: a pointer at the member at fault, the **empty** pointer that means the document root (`nxt_conf_validation.c:1803-1813`), and the line and column that an error found while parsing places itself by instead of a pointer (`nxt_controller.c:2740-2749`). `HttpResponseJsonBodyError` gains `location` and `suggestion`, appended to its existing display template, so output is unchanged for a body carrying neither:

```
HTTP response error [path=/config, status=400 Bad Request]:
  Error: Invalid configuration.
  Detail: Unknown parameter "pas".
  Location: /routes/0/action
  Did you mean: pass
```

That variant has exactly two sites in the tree — its definition and one construction — so the blast radius is nil.

`unit-openapi/README.md` is regenerated: it lists the endpoints and models the spec gained in this branch.

## Verification

Not left to CI. The client was generated with the **pinned** 7.6.0 generator (`GNUmakefile:26`) in a `--platform linux/amd64` temurin container, the GNUmakefile's post-processing applied, then:

- `cargo check` — `unit-openapi`, `unit-client-rs` and `unitctl` all compile
- `cargo clippy -p unit-client-rs` — no lints in the changed lines
- `cargo test` — 26 passed, 3 failed; the same 3 fail identically on the unmodified base (they require a live control socket)

The extraction is a free function precisely so it can be tested without a live socket, which every existing test in the crate needs. The table test covers all three location shapes, a plain error (asserting the location and suggestion parts come back empty, which is what leaves the rendered message unchanged — the template appends them verbatim), a `location` with nothing usable in it, and a body that is not an object.

That run also confirmed `get_app_restart` still returns `HashMap<String, String>`, i.e. #238 does not disturb it.

