### PR TITLE
ci(dependabot): target the default branch, not pre-1.35.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,5 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
-    target-branch: "pre-1.35.6"
     schedule:
       interval: weekly


### PR DESCRIPTION
Points Dependabot at the repository's default branch instead of `pre-1.35.6`.

```diff
   - package-ecosystem: github-actions
     directory: "/"
-    target-branch: "pre-1.35.6"
     schedule:
       interval: weekly
```

## Why

**Version updates branch from the wrong base.** `pre-1.35.6` (`ac866767`) stopped being the integration target long ago, so Dependabot's PRs are built on it and their diffs carry commits `master` already has. #240 arrived with three of them — `setup-python` 6→7, `setup-go` 6→7, `setup-node` 4→7, all present on master under different SHAs — wrapped around the single `setup-java` bump it existed for. It had to be rebuilt onto the release head before it could be merged cleanly.

**Security updates were not being raised at all.** This is the part worth acting on: Dependabot opens security updates only against the repository's default branch, and setting `target-branch` suppresses them for that ecosystem. So the weekly version bumps kept arriving while nothing would have reported a vulnerable action.

## Why remove the key rather than set `master`

With no `target-branch`, Dependabot follows the default branch, which is already `master`. Writing the name explicitly would reintroduce exactly this failure the next time the default changes.

## Expected effects

- New PRs branch from `master`, so their diffs contain only the bump.
- Security updates for `github-actions` start being raised.
- Dependabot re-evaluates on its next run and may close or recreate PRs that targeted `pre-1.35.6`. There are none open right now, so this is a clean moment.
- `pre-1.35.6` itself is untouched and keeps its history.

## Not included

Only `github-actions` is configured, so `src/otel`, `src/wasm-wasi-component` and `tools/unitctl` receive no updates or security alerts at all — that is where `tonic`, `wasmtime` and `bindgen` live. Adding `cargo` ecosystems is a larger change and deliberately left out of this one. For scale: `src/wasm-wasi-component` still pins `bindgen = "0.68.1"` from 2023, which cannot parse headers under clang 22 and currently blocks building that module on Alpine.
