### PR TITLE
docs(eol): flag Go 1.25, Perl 5.38 and Debian 12 as past upstream EOL

### DIFF
--- a/EOL.md
+++ b/EOL.md
@@ -11,7 +11,7 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
 | Runtime | Version | Upstream EOL | FreeUnit Drops |
 |---------|---------|--------------|----------------|
 | Go | 1.24 (EOL) † | Feb 2026 | Feb 2027 |
-| Go | 1.25 | Aug 2026 | Aug 2027 |
+| Go | 1.25 (EOL) † | Aug 2026 | Aug 2027 |
 | Go | 1.26 | Feb 2027 | Feb 2028 |
 | Java (JSC) | 17 (LTS) | Oct 2027 | Oct 2028 |
 | Java (JSC) | 21 (LTS) | Dec 2029 | Dec 2030 |
@@ -21,7 +21,7 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
 | Node.js | 22 (LTS) | Apr 2027 | Apr 2028 |
 | Node.js | 24 (LTS) | Apr 2028 | Apr 2029 |
 | Node.js | 26 (LTS) | Apr 2029 | Apr 2030 |
-| Perl | 5.38 | Jul 2026 | Jul 2027 |
+| Perl | 5.38 (EOL) † | Jul 2026 | Jul 2027 |
 | Perl | 5.40 | Jun 2027 | Jun 2028 |
 | Perl | 5.42 | Jul 2028 | Jul 2029 |
 | PHP | 8.3 | Dec 2027 | Dec 2028 |
@@ -52,7 +52,7 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
 | Ubuntu (LTS) | 24.04 | 2029-05 | 2032-05 | 3.12 |
 | Ubuntu (LTS) | 26.04 | 2031-04 | 2034-04 | 3.13 |
 | Debian | 11 (bullseye) (EOL) † | 2024-08 | 2027-08 | 3.9 |
-| Debian | 12 (bookworm) | 2026-07 | 2029-07 | 3.11 |
+| Debian | 12 (bookworm) (EOL) † | 2026-07 | 2029-07 | 3.11 |
 | Debian | 13 (trixie) | 2028-08 | 2031-08 | 3.13 |
 | RHEL | 8 | 2029-05 | 2032-05 | 3.8 ‡ |
 | RHEL | 9 | 2032-05 | 2035-05 | 3.11 |

--- a/pkg/eol.json
+++ b/pkg/eol.json
@@ -28,7 +28,7 @@
     ],
     "debian": [
       {"version": "11", "eol": "2024-08", "supported_until": "2027-08", "default_python": "3.9",  "codename": "bullseye", "note": "EOL"},
-      {"version": "12", "eol": "2026-07", "supported_until": "2029-07", "default_python": "3.11", "codename": "bookworm"},
+      {"version": "12", "eol": "2026-07", "supported_until": "2029-07", "default_python": "3.11", "codename": "bookworm", "note": "EOL"},
       {"version": "13", "eol": "2028-08", "supported_until": "2031-08", "default_python": "3.13", "codename": "trixie"}
     ],
     "rhel": [
@@ -46,7 +46,7 @@
   },
   "runtimes": {
     "go": [
-      {"version": "1.25", "eol": "2026-08", "supported_until": "2027-08"},
+      {"version": "1.25", "eol": "2026-08", "supported_until": "2027-08", "note": "EOL"},
       {"version": "1.26", "eol": "2027-02", "supported_until": "2028-02"}
     ],
     "java": [
@@ -62,7 +62,7 @@
       {"version": "26", "eol": "2029-04", "supported_until": "2030-04", "lts": true}
     ],
     "perl": [
-      {"version": "5.38", "eol": "2026-07", "supported_until": "2027-07"},
+      {"version": "5.38", "eol": "2026-07", "supported_until": "2027-07", "note": "EOL"},
       {"version": "5.40", "eol": "2027-06", "supported_until": "2028-06"},
       {"version": "5.42", "eol": "2028-07", "supported_until": "2029-07"}
     ],


### PR DESCRIPTION
Marks three rows that are past their upstream EOL date but carry no `(EOL) †`, so the tables currently read as if the versions were still upstream-supported.

| | upstream EOL | in matrix until (grace) |
|---|---|---|
| Go 1.25 | **2026-08-19** | 2027-08 |
| Perl 5.38 | 2026-07-02 | 2027-07 |
| Debian 12 | 2026-07-11 (LTS to 2028-06-30) | 2029-07 |

Dates confirmed against endoflife.date, not inferred from the file. All three stay in the matrix on FreeUnit's three-year grace window — the marker records that *upstream* stopped, not that FreeUnit has.

## Go 1.25 is the one worth noticing

It went EOL **ten days ago** and the checker has not reported it. `pkg/eol.json` stores month granularity (`"2026-08"`) and the comparison only fires once the month is fully past, so this would have surfaced in September. CI still builds `go-1.25` and `pkg/docker/Dockerfile.go-1.25` still ships it. That is consistent with the grace window, but it should be a deliberate choice rather than an unflagged one — worth a decision separate from this PR.

## Checker

```
before: 14 warnings, 0 errors
after:  13 warnings, 0 errors
```

Only Perl 5.38 produced an `add (EOL) flag` warning, now gone. The Debian and Go rows never raised that class and still don't — an OS past its date takes the "plan migration" path instead, and Go 1.25's month has not fully elapsed. The flag does not change either, which is why the count drops by one rather than three.

## Deliberately not changed

`Go 1.24` has a marked row in `EOL.md` and none in `pkg/eol.json`. That asymmetry is intentional: the version is not built (`.github/workflows/release-docker.yml:23` says so explicitly) and `pkg/eol.json` tracks what is, while `EOL.md` keeps the record.

Follow-up to the review of #243, which surfaced the marker inconsistency. Documentation and metadata only; no build behaviour changes.
