### PR TITLE
ci: cancel superseded PR runs, and bound every job

### DIFF
--- a/.github/workflows/analysis-clang-ast.yml
+++ b/.github/workflows/analysis-clang-ast.yml
@@ -20,9 +20,18 @@ on:
       - 'pkg/contrib/**'
       - '.github/workflows/analysis-clang-ast.yml'
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   clang-ast:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     container:
       image: debian:testing

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -69,6 +69,7 @@ env:
 jobs:
   build-trixie:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container:
       image: debian:trixie
 
@@ -160,6 +161,7 @@ jobs:
   smoke-test:
     needs: build-trixie
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container:
       image: debian:trixie
     strategy:
@@ -298,6 +300,7 @@ jobs:
   package-qa:
     needs: build-trixie
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container:
       image: debian:trixie
     strategy:
@@ -355,6 +358,7 @@ jobs:
     needs: [build-trixie, smoke-test, package-qa]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write   # required to upload assets to the release
     steps:

--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -23,6 +23,7 @@ jobs:
 
   fedora-rawhide:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -130,6 +131,7 @@ jobs:
 
   alpine-edge:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,6 +33,14 @@ env:
   # stable across patch bumps.
   OPENSSL4_VERSION: 4.0.2
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Single source of truth for the test matrix. The version-tested language
   # modules (go/java/node/php/python/ruby) are derived from pkg/eol.json; the
@@ -41,6 +49,7 @@ jobs:
   # and the "minimal" image — those are Docker packaging flavors, not test axes.
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       builds: ${{ steps.list.outputs.builds }}
     steps:
@@ -60,6 +69,7 @@ jobs:
   test:
     needs: prepare
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -530,6 +540,7 @@ jobs:
   # privilege-sensitive cases (clone creds) work.
   c-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v5
@@ -562,6 +573,7 @@ jobs:
   # nothing above the TLS layer changes with the OpenSSL version.
   openssl4:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,7 @@ jobs:
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -86,6 +87,7 @@ jobs:
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/eol-check.yml
+++ b/.github/workflows/eol-check.yml
@@ -27,9 +27,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   eol-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       issues: write   # scheduled run may open/update a tracking issue

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/lint-whitespace.yml
+++ b/.github/workflows/lint-whitespace.yml
@@ -7,9 +7,18 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-whitespace:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -51,6 +51,7 @@ jobs:
   # consumed by both `build` and `merge` via fromJSON().
   setup:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.meta.outputs.version }}
       variants: ${{ steps.meta.outputs.variants }}
@@ -84,6 +85,7 @@ jobs:
   build:
     needs: setup
     runs-on: ${{ matrix.arch.runner }}
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -146,6 +148,7 @@ jobs:
   merge:
     needs: [setup, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -53,10 +53,19 @@ on:
       - '.github/scripts/check-sanitizer-reports.sh'
       - '.github/sanitizer-allowlist.txt'
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   sanitize:
     name: "sanitize (${{ matrix.runtime }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     # NOTE: `continue-on-error` is deliberately NOT set at job level here.
     # It is set on every step an experimental leg can fail in: the

--- a/.github/workflows/security-seccomp.yml
+++ b/.github/workflows/security-seccomp.yml
@@ -18,10 +18,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   seccomp-af-alg:
     name: Verify AF_ALG seccomp mitigation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/unitctl.yml
+++ b/.github/workflows/unitctl.yml
@@ -21,9 +21,18 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a push is never grouped with another:
+  # Actions keeps only one PENDING run per group and would drop a queued commit
+  # even with cancel-in-progress false, which would break bisectability.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: tools/unitctl
@@ -74,6 +83,7 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: tools/unitctl
@@ -177,6 +187,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     needs: [build]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Adds a concurrency group to every pull-request-triggered workflow, and a `timeout-minutes` to every job.

## The problem, measured

No workflow declared a `concurrency:` group, so pushing to a PR left its predecessor running. On this repo:

- **PR #243 ran Build & Test five times between 01:39 and 02:23 and cancelled none** — four superseded 26-job matrices, ~450 job-minutes, inside 45 minutes
- Build & Test is **14–17 min unloaded** but ran **44–57 min** repeatedly during last night's release
- One run sat **1h48m in queue** before starting
- Across a week: ~98 runs of this workflow, ~11,000 job-minutes, of which an estimated **2,500–3,500 are superseded**

**This is not about billing.** The repo is public and runs on standard runners, so the minutes are free — `/actions/runs/<id>/timing` reports `billable.UBUNTU.total_ms: 0` and the same for macOS. The cost is the runner pool: those superseded matrices are what slowed everyone else's PRs down, including the ones nobody had superseded.

## What it does

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Applied to the seven PR-triggered workflows: `build-test`, `sanitize`, `analysis-clang-ast`, `unitctl`, `security-seccomp`, `eol-check`, `lint-whitespace`.

**Only PR runs are cancelled**, and non-PR events fall back to `github.run_id` — unique per run — so a push, tag, schedule or dispatch is never grouped with anything.

That fallback matters more than it looks, and the first version of this PR got it wrong by using `github.ref`. Actions keeps only **one pending run per group** and replaces it when another arrives — *even with `cancel-in-progress: false`*. A shared `refs/heads/master` group would therefore have silently dropped an intermediate commit's queued run during a burst of pushes, destroying the very bisectability it was meant to protect, and a queued `unitctl` release dispatch could have been displaced by an unrelated push to master. Caught in review; fixed before merge.

The tag-driven workflows — `build-deb`, `release-docker`, `build-distros` — get no group at all: cancelling a release build because another tag arrived is not a saving.

## Timeouts

Nothing in the repo set `timeout-minutes`, so a hung job held a runner for the **360-minute default** and fed the same saturation. All 24 jobs now have one: 30 for the build-test matrix (12.7-min worst case), 40 for sanitize, 90 for the docker image builds, 10 for the small checks.

For the 22 jobs with run history each value is **at least 2x the slowest observed execution**, verified per job over recent runs. `timeout-minutes` bounds execution, not queue time, so the 44–57 minute runs cited above — which were queue-dominated, with a 20.6-minute wall clock and a 12-minute longest job — cannot trip one. Two values are honest guesses with nothing to measure against: `claude.yml` (only skipped runs) and `fuzzing.yml` (never run; `workflow_dispatch`-only).

## Deliberately not included

Investigated and rejected, with reasons:

- **Tighter path filters** — `build-test.yml`'s filters are already correct. #243 triggered it via `auto/ssltls` (a build script; the filter cannot know the edit was comment-only) and #245 via `pkg/eol.json`, which *is* the matrix source of truth — the `prepare` job derives all 23 legs from it. Narrowing further would let build-affecting changes skip their tests.
- **More caching** — the caches already hit: OpenSSL 3.6 restores in 2s, njs and ccache hit, `Make unit` takes 54s. Only crumbs remain.
- **Self-hosted runners** — on a public repo this means running fork-PR code on private hardware, and since hosted minutes are free the only gain would be storm-time latency.
- **`fail-fast: true`** — would save minutes on red runs but destroy the per-leg failure picture the sanitize and experimental legs depend on; the existing `fail-fast: false` is deliberate.

## Follow-ups, not in this PR

The long pole is the python legs at ~12.7 min, of which 10.6 min is the full pytest suite — run in triplicate across three python versions plus once more on the `unit` leg. Deduplicating or sharding it would cut time-to-green further, but both trade coverage or add pool pressure and deserve their own discussion.



## Follow-up found in review, not fixed here

`security-seccomp.yml` has a `push:` trigger with no `branches:` filter, so a same-repo PR branch fires both a push run and a PR run of the same commit — observed live on this very branch (runs 33230817337 and 33230833595). With the `run_id` fallback the push twin is never cancelled even when its PR twin is superseded. A `branches: master` filter there is a small separate saving.
