### PR TITLE
docs(openapi): declare the /status counters as 64-bit

### DIFF
--- a/docs/unit-openapi.yaml
+++ b/docs/unit-openapi.yaml
@@ -5051,6 +5051,7 @@ paths:
             application/json:
               schema:
                 type: integer
+                format: int64
 
               examples:
                 Accepted:
@@ -5098,6 +5099,7 @@ paths:
             application/json:
               schema:
                 type: integer
+                format: int64
 
               examples:
                 Idle:
@@ -5122,6 +5124,7 @@ paths:
             application/json:
               schema:
                 type: integer
+                format: int64
 
               examples:
                 Closed:
@@ -5171,6 +5174,7 @@ paths:
             application/json:
               schema:
                 type: integer
+                format: int64
 
               examples:
                 Closed:
@@ -5254,6 +5258,7 @@ paths:
             application/json:
               schema:
                 type: integer
+                format: int64
 
               examples:
                 Exported:
@@ -5282,6 +5287,7 @@ paths:
             application/json:
               schema:
                 type: integer
+                format: int64
 
               examples:
                 Failed:
@@ -7936,6 +7942,7 @@ components:
       properties:
         total:
           type: integer
+          format: int64
           description: "Total non-API requests during the instance’s lifetime."
 
     # /status/telemetry
@@ -7960,10 +7967,12 @@ components:
       properties:
         exported:
           type: integer
+          format: int64
           description: "Spans the collector accepted."
 
         failed:
           type: integer
+          format: int64
           description: "Spans whose export failed."
 
     # /status/connections
@@ -7973,6 +7982,7 @@ components:
       properties:
         accepted:
           type: integer
+          format: int64
           description: "Total accepted connections during the
             instance’s lifetime."
 
@@ -7982,10 +7992,12 @@ components:
 
         idle:
           type: integer
+          format: int64
           description: "Current idle connections for the instance."
 
         closed:
           type: integer
+          format: int64
           description: "Total closed connections during
             the instance’s lifetime."
 


### PR DESCRIPTION
For the 1.36.1 cut (targets `release/1.36.1`). Spec only.

`/status` exposes six 64-bit counters (`src/nxt_status.h`: `accepted_conns`, `idle_conns`, `closed_conns`, `requests`, `otel_spans_exported`, `otel_spans_failed`), but `docs/unit-openapi.yaml` declared them as bare `type: integer`. OpenAPI Generator's Rust template maps that to `i32`, so a generated client (unitctl's `unit-openapi`) fails to deserialise any counter above 2,147,483,647. Found by the Codex review on #237 (review 5056461539) and confirmed by reading the generated `status_telemetry_spans.rs` / `status_connections.rs` (`Option<i32>`).

Fix: `format: int64` on the six schema properties (`statusConnections.accepted/idle/closed`, `statusRequests.total`, `statusTelemetrySpans.exported/failed`) and on the six inline response schemas of the leaf endpoints (`/status/connections/{accepted,idle,closed}`, `/status/requests/total`, `/status/telemetry/spans/{exported,failed}`), which are declared inline rather than by `$ref`. No `minimum: 0`: `openapi-config.json` sets `preferUnsignedInt`, so a minimum would flip the generated types to `u64`; `format: int64` alone yields `i64`. The `uint32_t` fields (`active_requests`, `pending_processes`, `processes`, `idle_processes`) stay as they are.

Validation: YAML parses; example-vs-schema checker unchanged (7 pre-existing `/config` example failures, 0 new). Client-side verification is by regenerating with openapi-generator-cli 7.6.0 (`make -C tools/unitctl openapi-generate`) and reading the models for `i64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
