### PR TITLE
test(port): iterate control messages through NXT_CMSG_NXTHDR

### DIFF
--- a/src/test/nxt_unit_port_recv_test.c
+++ b/src/test/nxt_unit_port_recv_test.c
@@ -31,6 +31,7 @@
  */
 
 #include "nxt_main.h"
+#include "nxt_socket_msg.h"
 #include "nxt_port.h"
 #include "nxt_port_queue.h"
 #include "nxt_app_queue.h"
@@ -104,7 +105,7 @@ nxt_port_recv_test_send(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
 
     for (cmsg = CMSG_FIRSTHDR(&msg);
          cmsg != NULL;
-         cmsg = CMSG_NXTHDR(&msg, cmsg))
+         cmsg = NXT_CMSG_NXTHDR(&msg, cmsg))
     {
         size = cmsg->cmsg_len - CMSG_LEN(0);
 


### PR DESCRIPTION
Alpine's aports CI fails to build the 1.36.1 tarball with clang22:

```
src/test/nxt_unit_port_recv_test.c:107:17: error: comparison of integers of
different signs: '__size_t' (aka 'unsigned long') and '__ptrdiff_t' (aka 'long')
[-Werror,-Wsign-compare]
  107 |          cmsg = CMSG_NXTHDR(&msg, cmsg))
/usr/include/sys/socket.h:358:44: note: expanded from macro 'CMSG_NXTHDR'
```

<https://gitlab.alpinelinux.org/alpine/aports/-/jobs/2493891>

musl's `CMSG_NXTHDR` expands to a comparison between a `size_t` and the
`ptrdiff_t` of a pointer subtraction. `src/nxt_socket_msg.h` already carries
`NXT_CMSG_NXTHDR` for exactly this case, guarded by
`#if !defined(__GLIBC__) && defined(__clang__)`, and both production call
sites (`nxt_socket_msg.h:154`, `:193`) use it. This test reached for the raw
macro instead.

Two lines: include `nxt_socket_msg.h`, and call the wrapper.

### Why CI did not catch it

`.github/workflows/build-distros.yml` has an `alpine-edge` leg with a `clang`
matrix entry -- exactly this configuration. Its `push` and `pull_request`
triggers are commented out, leaving `workflow_dispatch` as the only way in,
and the workflow has never been dispatched (verified via the Actions API,
including under its pre-rename name `ci-dev-distro-compiler.yaml`). Alpine's
pipeline runs; ours does not.

A separate change to put that workflow on a weekly schedule is prepared on
`ci/distros-weekly-schedule`.

### Verification

`./configure --tests && make build/src/test/nxt_unit_port_recv_test.o` is
clean on glibc/gcc. The failing configuration is musl + clang, which is not
reproducible on the author's machine; the Alpine job above is the reference.