### PR TITLE
build(wasm): update bindgen so the module builds under clang 22

### DIFF
--- a/src/wasm-wasi-component/Cargo.lock
+++ b/src/wasm-wasi-component/Cargo.lock
@@ -63,25 +63,22 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -138,7 +135,7 @@ dependencies = [
  "io-lifetimes 3.0.1",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.4",
+ "rustix",
  "rustix-linux-procfs",
  "windows-sys 0.61.2",
  "winx",
@@ -153,7 +150,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes 3.0.1",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -300,7 +297,7 @@ dependencies = [
  "postcard",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "serde",
  "serde_derive",
  "sha2",
@@ -502,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -675,15 +672,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "http"
@@ -903,6 +891,15 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -915,18 +912,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
@@ -961,12 +946,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1010,7 +989,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -1057,12 +1036,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1181,7 +1154,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "serde",
  "smallvec",
 ]
@@ -1223,28 +1196,9 @@ checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "rustix"
@@ -1255,7 +1209,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1266,7 +1220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -1654,7 +1608,7 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
- "rustix 1.1.4",
+ "rustix",
  "semver",
  "serde",
  "serde_derive",
@@ -1751,7 +1705,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",
@@ -1774,7 +1728,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.4",
+ "rustix",
  "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
@@ -1854,7 +1808,7 @@ dependencies = [
  "futures",
  "io-lifetimes 3.0.1",
  "rand",
- "rustix 1.1.4",
+ "rustix",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1905,18 +1859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
 dependencies = [
  "leb128",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/src/wasm-wasi-component/Cargo.toml
+++ b/src/wasm-wasi-component/Cargo.toml
@@ -27,7 +27,7 @@ wasmtime-wasi = "47.0.2"
 wasmtime-wasi-http = { version = "47.0.2", default-features = false, features = ['p2'] }
 
 [build-dependencies]
-bindgen = "0.68.1"
+bindgen = "0.72"
 cc = "1.0.83"
 
 [profile.dev]

--- a/src/wasm-wasi-component/build.rs
+++ b/src/wasm-wasi-component/build.rs
@@ -15,7 +15,7 @@ fn main() {
         .blocklist_function("nxt_vsprintf")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // disable some features which aren't necessary
         .layout_tests(false)
         .derive_debug(false)


### PR DESCRIPTION
`bindgen 0.68.1` (2023) cannot parse Unit's headers with **clang 22**, and it doesn't fail — it emits opaque placeholder structs whose only field is `_address`. The crate then fails to compile with ~20 errors like `no field 'request' on type 'nxt_unit_request_info_s'`, pointing at Unit's code rather than at the parse that never happened.

This isn't a hypothetical toolchain. **Alpine defaults `clang-dev` to clang 22 in both edge and current stable 3.24**, so `src/wasm-wasi-component` cannot be packaged there today, and every distribution moving to clang 22 hits the same wall.

## The change

```diff
-bindgen = "0.68.1"
+bindgen = "0.72"

-.parse_callbacks(Box::new(bindgen::CargoCallbacks))
+.parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
```

`CargoCallbacks` became a struct requiring `::new()` in 0.69. The lockfile drops seven transitive dependencies (`home`, `lazycell`, `lazy_static`, `linux-raw-sys`, `peeking_take_while`, `rustc-hash`, `rustix`, `which`) and gains `itertools`.

## Verification — same layout, not just "it compiles"

Since the bug being fixed is *silently wrong bindings*, a successful build proves nothing on its own. So:

| check | result |
|---|---|
| declarations, clang18+0.68.1 vs clang22+0.72.1 | **byte-identical** — 1,346 lines, 154 `nxt_` structs with `#[repr]` attributes attached, md5 `16db8308` |
| 0.68.1 layout assertions (C-computed sizes/offsets) | 170 emitted, **170 pass** |
| the 147 covering `nxt_` types, compiled against the **0.72.1** bindings | **147 pass, 0 fail** |
| generator stamp on each artifact | verified to match the bindgen the run requested |
| glibc, clang 19 (`rust:1.98`) | module links, 154 `nxt_` structs, no opaque placeholders |

The third row is the one that matters: the new bindings are checked *directly* against the layout the C compiler computes from Unit's headers, rather than inferred from a diff.

Two process notes, both learned the hard way while producing this. An earlier run of the same comparison was **invalid** because a stale `target/` meant both legs read a cached 0.68.1 artifact — hence the generator-stamp assertion, which is cheap and catches the whole class. And bindgen **0.72.1 emits no layout assertions at all** even with `layout_tests(true)` explicitly set, so `cargo test` reports "ok. 0 passed" and exits 0 — a correctness gate silently becoming a no-op. That looks like a bindgen regression and is worth reporting upstream separately; it does not affect this change, since the assertions used here come from 0.68.1.

## Not included

Pinning an older clang in packaging would also work and was tested as far as confirming clang 18 + 0.68.1 produces complete, layout-verified bindings. It's the wrong fix: it makes every distro carry a pin for an upstream parse failure.
