### PR TITLE
ci(distros): fix the PHP option, and run rolling distros weekly

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -1,23 +1,17 @@
 name: "Build (Fedora/Alpine · GCC/Clang)"
 
 on:
-  workflow_dispatch: # manual only
-#  push:
-#    branches: master
-#    paths:
-#      - configure
-#      - 'auto/**'
-#      - 'src/**'
-#      - 'test/**'
-#      - '.github/workflows/build-distros.yml'
-#  pull_request:
-#    branches: master
-#    paths:
-#      - configure
-#      - 'auto/**'
-#      - 'src/**'
-#      - 'test/**'
-#      - '.github/workflows/build-distros.yml'
+  # Rolling distributions break on their own schedule, not on ours, so this is
+  # a weekly gate rather than a PR gate: Fedora rawhide and Alpine edge move
+  # under us between pull requests, and a red check nobody caused is a check
+  # nobody reads.  A failure opens or updates a tracking issue instead.
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
 
@@ -167,7 +161,7 @@ jobs:
       - name: configure unit-php
         run: |
           ln -s /usr/lib/libphp83.so /usr/lib/libphp.so
-          ./configure php --php-config=/usr/bin/php-config83
+          ./configure php --config=/usr/bin/php-config83
 
       - name: make unit-php
         run: make -j 4
@@ -195,3 +189,43 @@ jobs:
 
       - name: make unit-java
         run: make -j 4 java
+
+  # A weekly red check that nobody caused is a check nobody reads, so a
+  # scheduled failure is reported as a tracking issue instead, the same way
+  # eol-check.yml handles its weekly run.
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [ fedora-rawhide, alpine-edge ]
+    if: failure() && github.event_name == 'schedule'
+
+    steps:
+      - name: Open or update tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # This job does not check out the repository, so gh has no local git
+          # remote to infer the target from and would exit before creating the
+          # issue -- silently defeating the point of the job.
+          GH_REPO: ${{ github.repository }}
+        run: |
+          title='Rolling distro build is failing (Fedora rawhide / Alpine edge)'
+          {
+            echo 'The weekly rolling-distribution build failed. These distributions'
+            echo 'move between our pull requests, so a failure here is usually a'
+            echo 'toolchain or package change rather than a regression in Unit.'
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo 'Reproduce locally, e.g. for Alpine:'
+            echo
+            echo '```'
+            echo 'docker run --rm -it --platform linux/amd64 alpine:edge sh'
+            echo '```'
+          } > issue-body.md
+          existing=$(gh issue list --state open --search "in:title ${title}" \
+            --json number,title --jq ".[] | select(.title == \"${title}\") | .number" | head -n1)
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file issue-body.md
+          else
+            gh issue create --title "${title}" --body-file issue-body.md
+          fi


### PR DESCRIPTION
Repairs the rolling-distribution workflow, which has been failing on every run, and moves it from manual-only to a weekly schedule.

## The bug

```
./configure: error: invalid PHP option "--php-config=/usr/bin/php-config83"
```

The PHP module's option is **`--config=`**, not `--php-config=` (`auto/modules/php:17`). Both Alpine legs abort there in ~2 minutes. The workflow is `workflow_dispatch`-only, so nobody was watching: the most recent run is red on exactly this.

## Weekly, not per-PR

The commented-out block in this file proposed `push`/`pull_request` triggers. I don't think that's the right tier, and the numbers say so:

| | cost | catches |
|---|---|---|
| PR gate | ~25 job-min × ~107 runs/week = **~2,800 job-min/week** | breakage that wasn't in the pull request |
| weekly | **~30 job-min/week** | the same breakage, within a week |

Fedora rawhide and Alpine edge move *between* our pull requests. Their failures arrive on the distribution's schedule, not ours — so as a PR gate they mostly produce red checks that the PR author didn't cause and can't fix. And this repo's queue is already the binding constraint: a busy evening turned a 15-minute Build & Test into 44–57 minutes, with one run waiting 1h48m to start.

A red schedule nobody caused is a check nobody reads, so a **scheduled** failure opens or updates a tracking issue instead of just going red — the same pattern `eol-check.yml:82-108` already uses for its weekly run. Manual (`workflow_dispatch`) runs keep failing normally.

## Why this workflow matters more than it looks

These two legs are the only place the project meets a **rolling toolchain**. Fedora rawhide currently carries **clang 22.1.8** — the compiler version that exposed the bindgen parse failure fixed in #250, where `bindgen 0.68.1` silently emits opaque `_address` structs instead of parsing Unit's headers.

Neither leg builds `wasm-wasi-component` today (Alpine stops at java; rawhide builds only the C `wasm` module), so **this workflow would not have caught #250 either**. Adding that coverage is worth doing — it's the natural second gate, on a machine that really has clang 22 rather than one we install — but it belongs in its own change where it can be tested rather than assumed.

## Also worth knowing, not fixed here

The Alpine leg pins `php83` (package names and the `libphp83.so` symlink). Edge will drop that version eventually and the leg will break again, differently. Left alone deliberately: unpinning it is a separate judgement about how the leg should track edge.
