### PR TITLE
ci(distros): build the wasm component, so the rolling gate catches bindgen

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -37,7 +37,7 @@ jobs:
               python-unversioned-command python3 python3-devel \
               php-devel php-embedded perl-devel perl-ExtUtils-Embed \
               ruby-devel java-devel nodejs-devel nodejs-npm golang \
-              cargo rust cmake
+              cargo rust cmake clang-devel
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             dnf -y install --setopt=install_weak_deps=False clang
           fi
@@ -123,6 +123,22 @@ jobs:
       - name: make unit-wasm
         run: make wasm
 
+      # The Rust component module is the reason this workflow is worth running
+      # weekly: bindgen parses Unit's headers with libclang, and a new libclang
+      # breaks that silently -- it emits opaque `_address` placeholder structs
+      # rather than failing, so the crate then fails to compile with errors that
+      # point at Unit's code.  That is what #250 fixed for clang 22, which this
+      # distribution already ships.  Only the gcc leg builds it: bindgen uses
+      # libclang whatever the C compiler is, so the clang leg would test the
+      # same parse twice.
+      - name: configure unit-wasm-wasi-component
+        run: ./configure wasm-wasi-component
+        if: matrix.compiler == 'gcc'
+
+      - name: make unit-wasm-wasi-component
+        run: make wasm-wasi-component
+        if: matrix.compiler == 'gcc'
+
   alpine-edge:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -142,7 +158,7 @@ jobs:
           apk add gcc make musl-dev openssl-dev pcre2-dev curl \
               zlib-dev zstd-dev brotli-dev \
               php83-dev php83-embed python3-dev perl-dev ruby-dev \
-              openjdk21-jdk cargo rust
+              openjdk21-jdk cargo rust clang-dev linux-headers
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             apk add clang
           fi
@@ -191,6 +207,19 @@ jobs:
 
       - name: make unit-java
         run: make -j 4 java
+
+      # See the note on the same steps in fedora-rawhide: this is the gate that
+      # would have caught the bindgen/libclang breakage #250 fixed.  Alpine
+      # matters twice over here -- it defaults clang-dev to clang 22 in edge AND
+      # in stable 3.24, and it is where the module could not be packaged at all
+      # before #250.  gcc leg only: bindgen goes through libclang either way.
+      - name: configure unit-wasm-wasi-component
+        run: ./configure wasm-wasi-component
+        if: matrix.compiler == 'gcc'
+
+      - name: make unit-wasm-wasi-component
+        run: make wasm-wasi-component
+        if: matrix.compiler == 'gcc'
 
   # A weekly red check that nobody caused is a check nobody reads, so a
   # scheduled failure is reported as a tracking issue instead, the same way


### PR DESCRIPTION
Builds `wasm-wasi-component` in both rolling-distro legs, so the weekly gate actually covers the module a rolling toolchain breaks. This is the follow-up flagged in #251's body.

## Why it matters

`build-distros.yml` is the only place the project meets a rolling toolchain — and until now it didn't build the one module that a rolling toolchain breaks. **Fedora rawhide already carries clang 22.1.8**, the exact compiler behind #250, and it sat unused: the fedora leg built only the C `wasm` module, the alpine leg stopped at java.

The failure mode is why nothing else catches it. bindgen doesn't error on a libclang it can't parse with — it emits opaque `_address` placeholder structs, and the crate then fails to compile with ~20 errors that all point at *Unit's* code. Nothing short of building the component finds that, and `build-test.yml` can't: it runs on a fixed Ubuntu image.

## The change

| leg | added |
|---|---|
| fedora-rawhide | `clang-devel`, then `configure`/`make wasm-wasi-component` |
| alpine-edge | `clang-dev`, `linux-headers`, same two steps |

**gcc leg only.** bindgen goes through **libclang** whatever `matrix.compiler` is set to, so building it in the clang leg would parse the same headers with the same libclang at twice the cost. That distinction is what made #250 subtle — `CLANG_PATH` picks the *executable*, `LIBCLANG_PATH` picks the *parser* — so the reasoning is a comment in the file, not a bare `if:` for someone to "fix" later.

## Verified in the real containers, before writing the workflow

| | result |
|---|---|
| `fedora:rawhide` | clang **22.1.8**, libclang at `/usr/lib64/libclang.so`, bindgen 0.72.1, **154** `nxt_` structs, **0** opaque, module 21,953,336 bytes |
| `alpine:edge` | same, module 21,855,008 bytes |

That test is how the `linux-headers` dependency was found: alpine failed with `fatal error: 'linux/openat2.h' file not found`, because bindgen parses that header via `nxt_unix.h` while the C build never reaches it. Had this been written from the workflow alone it would have gone red on its first weekly run — with an error naming a kernel header, on a change about clang.

Fedora needed only `clang-devel`.

## Cost

Two extra module builds per weekly run (one per distro), on a workflow that costs ~30 job-minutes a week total. No effect on any PR.
