### PR TITLE
port: authenticate PROCESS_READY by the sender's kernel pid

### DIFF
--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -241,15 +241,27 @@ nxt_port_enable(nxt_task_t *task, nxt_port_t *port,
  *
  * The audit recommends rejecting application workers / prototypes
  * that forge cert/script/socket/access-log/etc. messages to the
- * main process.  A first draft was implemented but caused
- * regressions in the isolation test suite — the kernel-validated
- * sender PID (SCM_CREDENTIALS) is not consistently available on
- * the existing socketpair setup, and the message-dispatch path
- * runs before the prototype's process registration completes.
+ * main process.  A first draft was reverted because the
+ * kernel-validated sender PID was not available on the existing
+ * socketpair setup.  That blocker is gone: nxt_socketpair_create()
+ * sets SO_PASSCRED on both ends (and libunit does the same on its
+ * own sockets), NXT_HAVE_MSGHDR_CMSGCRED platforms get an SCM_CREDS
+ * control message attached to every send by
+ * nxt_socket_msg_oob_init(), and both receive paths in
+ * nxt_port_socket.c fill msg->cmsg_pid.  Individual handlers are
+ * being gated on nxt_recv_msg_cmsg_pid() one at a time --
+ * nxt_main_process_created_handler(), nxt_main_start_process_handler(),
+ * nxt_port_process_ready_handler(), nxt_proto_process_created_handler()
+ * and the cert/script/socket/access-log handlers already are.
  *
- * Reverted to the pre-audit dispatch path here and deferred the
- * ACL to a follow-up that introduces SO_PASSCRED on the relevant
- * socketpairs and updates the process-registration ordering.
+ * What is left is the table-driven part: a per-message-type sender
+ * ACL applied here, in the dispatcher, so that a handler which
+ * forgets its own gate is still covered.  That still needs the
+ * process-registration ordering sorted out -- dispatch can run
+ * before the prototype has finished registering a child, so the ACL
+ * cannot simply require an already registered sender.  Platforms
+ * with neither SCM_CREDENTIALS nor SCM_CREDS (macOS, NetBSD,
+ * OpenBSD, illumos) stay unauthenticated either way.
  * See https://github.com/andypost/unit/pull/14 review thread.
  */
 
@@ -469,14 +481,14 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     /* Unreferenced: main and prototype processes run a single engine. */
 
     /*
-     * The lookup stays on msg->port_msg.pid.  The kernel-validated sender
-     * PID cannot replace it here: the prototype installs this handler too,
-     * and there SCM_CREDENTIALS carries the namespace-local pid of a
-     * pid-isolated worker, while the runtime hash is keyed on the global
-     * one (see nxt_proto_process_created_handler(), which uses the two as
-     * distinct values, and nxt_process_created() refusing to register an
-     * isolated pid).  Authenticating this handler needs to accept either
-     * pid of the process it resolves; see the sender-ACL TODO above.
+     * The lookup stays on msg->port_msg.pid: it is the key of the runtime
+     * hash.  The kernel-validated sender PID cannot replace it, because the
+     * prototype installs this handler too, and there SCM_CREDENTIALS
+     * carries the namespace-local pid of a pid-isolated worker while the
+     * hash is keyed on the global one (see nxt_proto_process_created_handler(),
+     * which uses the two as distinct values, and nxt_process_create()
+     * refusing to register an isolated pid).  It authenticates the resolved
+     * process instead, right below.
      */
     process = nxt_runtime_process_find(rt, msg->port_msg.pid);
     if (nxt_slow_path(process == NULL)) {
@@ -484,14 +496,55 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         return;
     }
 
+#if (NXT_USE_CMSG_PID)
     /*
-     * A repeated PROCESS_READY is not rejected: the message is not
-     * authenticated, so refusing it would let a forged one arriving first
-     * make itself permanent and lock the legitimate sender out of its own
-     * queue.  It replaces the mapping instead, as it did before this check
-     * existed, and the previous mapping is released below rather than
-     * leaked.  nxt_assert() is not used because it compiles out in release
-     * builds, leaving no diagnostic at all.
+     * Authenticate the sender before anything else is read or written: the
+     * port socket of the main or the prototype process is duplicated into
+     * every child (nxt_proc_keep_matrix[]), the wire pid in the message is
+     * chosen by the sender, and the handler below re-points the named
+     * process's port at the queue this message carries.  Without this gate
+     * any worker can announce a sibling and hand the receiver a shared
+     * memory queue of its own making.
+     *
+     * The credential is compared against process->isolated_pid, and only
+     * against it.  isolated_pid is by construction the pid of the process
+     * as the receiver sees it -- the fork() return value in
+     * nxt_process_create(), left alone when nxt_proto_process_created_handler()
+     * rewrites process->pid to the global pid of a pid-isolated worker.
+     * Accepting process->pid as well would be a bypass: inside a pid
+     * namespace another task whose namespace-local pid happens to equal the
+     * victim's global pid would pass, and a compromised worker can fork
+     * towards such a collision.
+     *
+     * A non-positive isolated_pid means the record was not created by a
+     * fork() in this process -- nxt_runtime_process_get() only fills
+     * ->pid -- so there is nothing to authenticate against and no
+     * legitimate PROCESS_READY to lose: a worker announces itself to its
+     * parent prototype, and main's own children are all forked by main.
+     * Reject rather than compare, so that a cmsg_pid of 0 or the -1 that
+     * the shared-memory queue path leaves in place (see
+     * nxt_port_queue_read_handler()) cannot match by accident.
+     */
+    if (nxt_slow_path(process->isolated_pid <= 0
+                      || nxt_recv_msg_cmsg_pid(msg) != process->isolated_pid))
+    {
+        nxt_alert(task, "process %PI sent PROCESS_READY claiming process %PI",
+                  nxt_recv_msg_cmsg_pid(msg), msg->port_msg.pid);
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
+#endif
+
+    /*
+     * A repeated PROCESS_READY from the authenticated owner is not
+     * rejected: on ucred and cmsgcred platforms the gate above has already
+     * turned a forged repeat into a rejection, and a genuine one has to
+     * keep working -- the process may legitimately re-announce a new queue,
+     * and refusing it would strand the process on the mapping it has.  It
+     * replaces the mapping instead, as it did before this check existed,
+     * and the previous mapping is released below rather than leaked.
+     * nxt_assert() is not used because it compiles out in release builds,
+     * leaving no diagnostic at all.
      */
     if (nxt_slow_path(process->state == NXT_PROCESS_STATE_READY)) {
         nxt_log(task, NXT_LOG_WARN, "repeated PROCESS_READY claiming "
@@ -499,8 +552,8 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     }
 
     /*
-     * Both guards reject before the state is set: a message that is not
-     * acted upon must leave no trace.  Marking a process ready and only
+     * Every guard here rejects before the state is set: a message that is
+     * not acted upon must leave no trace.  Marking a process ready and only
      * then rejecting it would make the next, legitimate PROCESS_READY trip
      * the guard above, and would let nxt_main_process_sigchld_handler()
      * clear the start stream of a process that never finished starting,
@@ -565,14 +618,13 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
              * unreachable copy; a QUIT can never arrive, while requests
              * still flow through the shared app queue.  See issue #231.
              *
-             * The message is still not refused outright: it is not
-             * authenticated, and refusing it would let a forged
-             * PROCESS_READY carrying a bad descriptor keep the process
-             * from ever being marked ready.  Failing the start is the
-             * honest reaction to a genuine mmap failure, but it hands the
-             * same forgery a way to kill a legitimate start, so it has to
-             * wait for sender authentication (see the lookup comment
-             * above).
+             * The message is still not refused outright.  Failing the
+             * start is the honest reaction to a genuine mmap failure, and
+             * the sender gate above now makes that safe to do on ucred and
+             * cmsgcred platforms -- a forged PROCESS_READY can no longer
+             * use it to kill a legitimate start.  The behaviour change
+             * itself, and the kill of the worker that is left with no way
+             * of being reached, is issue #231.
              */
             if (port->queue == NULL) {
                 nxt_alert(task, "process %PI ready: cannot map the queue; "

--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -18,6 +18,13 @@
  *
  * A message can carry two descriptors regardless of how many its type
  * normally uses, so the test attaches both and expects both back.
+ *
+ * The handler also authenticates the sender against the isolated_pid of
+ * the process the message names, wherever the platform hands the receiver
+ * a kernel-validated pid (NXT_USE_CMSG_PID).  The fixture models a
+ * pid-isolated process -- pid and isolated_pid deliberately differ -- so
+ * that the cases below can tell the two apart: a credential equal to the
+ * global pid has to be refused just like a foreign one.
  */
 
 #include <nxt_main.h>
@@ -94,6 +101,112 @@ fail:
 
     return NXT_ERROR;
 }
+
+
+#if (NXT_USE_CMSG_PID)
+
+/*
+ * A PROCESS_READY whose kernel-validated sender pid does not match the
+ * isolated_pid of the process it names has to be refused outright: the
+ * descriptors it carries are closed, the process keeps the state it had,
+ * and the port keeps the queue it had.
+ *
+ * The message carries a mappable queue descriptor wherever one can be
+ * made, so that a handler without the gate is caught installing it rather
+ * than merely caught failing to map it -- which is what a /dev/null
+ * descriptor would produce, and would pass these checks on a queue that is
+ * already installed.
+ */
+static nxt_int_t
+nxt_port_ready_test_reject(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_process_t *process, nxt_port_t *port,
+    nxt_pid_t cmsg_pid, const char *name)
+{
+    void                 *prev_queue;
+    nxt_fd_t             fd0, fd1, prev_fd;
+    nxt_pid_t            saved_cmsg_pid;
+    nxt_process_state_t  prev_state;
+
+#if (NXT_HAVE_MEMFD_CREATE)
+    fd0 = syscall(SYS_memfd_create, "nxt_port_ready_test", MFD_CLOEXEC);
+
+    if (fd0 != -1 && ftruncate(fd0, sizeof(nxt_port_queue_t)) == -1) {
+        (void) close(fd0);
+        fd0 = -1;
+    }
+#else
+    fd0 = open("/dev/null", O_RDONLY);
+#endif
+
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (fd0 == -1 || fd1 == -1) {
+        nxt_log_alert(thr->log, "port ready test: %s failed to open the "
+                      "descriptors", name);
+        goto fail;
+    }
+
+    prev_state = process->state;
+    prev_queue = port->queue;
+    prev_fd = port->queue_fd;
+
+    saved_cmsg_pid = msg->cmsg_pid;
+    msg->cmsg_pid = cmsg_pid;
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    nxt_port_process_ready_handler(task, msg);
+
+    msg->cmsg_pid = saved_cmsg_pid;
+
+    /*
+     * The state and the queue are checked before the descriptors: a
+     * handler that accepted the message owns fd0 through the port, and
+     * the cleanup below would close it a second time.
+     */
+    if (process->state != prev_state) {
+        nxt_log_alert(thr->log, "port ready test: %s changed the process "
+                      "state", name);
+        return NXT_ERROR;
+    }
+
+    if (port->queue != prev_queue || port->queue_fd != prev_fd) {
+        nxt_log_alert(thr->log, "port ready test: %s replaced the queue",
+                      name);
+        return NXT_ERROR;
+    }
+
+    if (msg->fd[0] != -1 || msg->fd[1] != -1) {
+        nxt_log_alert(thr->log, "port ready test: %s left fds in the message",
+                      name);
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_ready_test_fd_is_open(fd0)
+        || nxt_port_ready_test_fd_is_open(fd1))
+    {
+        nxt_log_alert(thr->log, "port ready test: %s leaked a descriptor",
+                      name);
+        goto fail;   /* closes only what is still open */
+    }
+
+    return NXT_OK;
+
+fail:
+
+    if (fd0 != -1 && nxt_port_ready_test_fd_is_open(fd0)) {
+        (void) close(fd0);
+    }
+
+    if (fd1 != -1 && nxt_port_ready_test_fd_is_open(fd1)) {
+        (void) close(fd1);
+    }
+
+    return NXT_ERROR;
+}
+
+#endif
 
 
 #if (NXT_HAVE_MEMFD_CREATE)
@@ -333,6 +446,7 @@ nxt_int_t
 nxt_port_ready_test(nxt_thread_t *thr)
 {
     nxt_mp_t             *mp;
+    nxt_pid_t            isolated_pid;
     nxt_task_t           *task;
     nxt_int_t            ret;
     nxt_port_t           *port;
@@ -362,6 +476,8 @@ nxt_port_ready_test(nxt_thread_t *thr)
 
     /* Defined before the first goto done: the cleanup there releases it. */
     port = NULL;
+
+    isolated_pid = nxt_pid + 3;
 
     mp = nxt_mp_create(1024, 128, 256, 32);
     if (nxt_slow_path(mp == NULL)) {
@@ -410,13 +526,25 @@ nxt_port_ready_test(nxt_thread_t *thr)
         goto done;
     }
 
+    /*
+     * A pid-isolated process: pid is the global pid the runtime hash is
+     * keyed on, isolated_pid is the namespace-local pid the receiver reads
+     * out of SCM_CREDENTIALS.  They differ on purpose -- with one value
+     * every case would pass the sender gate whichever of the two it
+     * compared, and the collision the gate exists to refuse could not be
+     * expressed at all.
+     */
     process->pid = nxt_pid + 2;
+    process->isolated_pid = isolated_pid;
     process->state = NXT_PROCESS_STATE_CREATING;
     nxt_queue_init(&process->ports);
 
     nxt_runtime_process_add(task, process);
 
     msg.port_msg.pid = process->pid;
+#if (NXT_USE_CMSG_PID)
+    msg.cmsg_pid = process->isolated_pid;
+#endif
 
     ret = nxt_port_ready_test_case(thr, task, &msg, "ready with no ports");
     if (nxt_slow_path(ret != NXT_OK)) {
@@ -434,13 +562,10 @@ nxt_port_ready_test(nxt_thread_t *thr)
         goto done;
     }
 
-#if (NXT_HAVE_MEMFD_CREATE)
-
     /*
-     * With a port on the process the handler takes the descriptor over and
-     * maps it, and a second PROCESS_READY replaces that mapping instead of
-     * leaking it -- a repeated message is not refused, so that a forged one
-     * arriving first cannot lock the legitimate sender out.
+     * From here on the process has a port, so the empty-ports guard can no
+     * longer be what refuses a message, and a refusal has to come from the
+     * sender gate itself.
      */
     port = nxt_port_new(task, 1, process->pid, NXT_PROCESS_APP);
     if (nxt_slow_path(port == NULL)) {
@@ -454,6 +579,54 @@ nxt_port_ready_test(nxt_thread_t *thr)
 
     nxt_queue_insert_tail(&process->ports, &port->link);
 
+#if (NXT_USE_CMSG_PID)
+
+    /* An unrelated sender announcing somebody else's process. */
+    ret = nxt_port_ready_test_reject(thr, task, &msg, process, port,
+                                     nxt_pid + 4, "a foreign sender");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * The global pid of the very process being announced.  Inside a pid
+     * namespace it is not the pid the receiver sees for that process, and
+     * another task's namespace-local pid can be made to equal it, so
+     * accepting it as well would leave the gate bypassable.
+     */
+    ret = nxt_port_ready_test_reject(thr, task, &msg, process, port,
+                                     process->pid, "the global pid");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * A record the receiver never forked keeps isolated_pid 0 --
+     * nxt_runtime_process_get() fills only ->pid.  There is nothing to
+     * authenticate against, so the credential of 0 that a plain equality
+     * test would accept has to be refused as well.
+     */
+    process->isolated_pid = 0;
+
+    ret = nxt_port_ready_test_reject(thr, task, &msg, process, port, 0,
+                                     "a process record nothing forked");
+
+    process->isolated_pid = isolated_pid;
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+#endif
+
+#if (NXT_HAVE_MEMFD_CREATE)
+
+    /*
+     * The handler takes the descriptor over and maps it, and a second
+     * PROCESS_READY from the same, authenticated sender replaces that
+     * mapping instead of leaking it: a process may re-announce a new queue,
+     * and refusing the repeat would strand it on the mapping it has.
+     */
     ret = nxt_port_ready_test_queue(thr, task, &msg, port, "first ready");
     if (nxt_slow_path(ret != NXT_OK)) {
         goto done;
@@ -465,6 +638,25 @@ nxt_port_ready_test(nxt_thread_t *thr)
     }
 
     ret = nxt_port_ready_test_short_queue(thr, task, &msg, port);
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+#if (NXT_USE_CMSG_PID)
+
+    /*
+     * The same forgery once a queue is installed and the process is ready:
+     * this is the one that matters, because it is where an accepted message
+     * would re-point a live port at shared memory of the sender's choosing.
+     */
+    ret = nxt_port_ready_test_reject(thr, task, &msg, process, port,
+                                     nxt_pid + 4, "a foreign sender re-arming "
+                                     "an installed queue");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+#endif
 
 #endif
 


### PR DESCRIPTION
Part 1 of #231 (behavioural half); prerequisite for failing a start whose port queue could not be mapped.

`nxt_port_process_ready_handler()` accepted any PROCESS_READY that named a known process. Port sockets are per-owner and `pair[1]` is duplicated to every peer, so any application worker can forge a READY naming a sibling and — since e8b7f644 absorbs the message — re-point that sibling's `port->queue` at attacker-supplied shared memory, or mark a still-starting process ready.

This gate compares the kernel-supplied sender pid (`nxt_recv_msg_cmsg_pid()`, SO_PASSCRED on Linux / SCM_CREDS on FreeBSD — already used by ~10 privileged handlers) against `process->isolated_pid` **only**: the pid as the receiver sees it, i.e. the `fork()` return, left untouched when a pid-isolated worker's `process->pid` is rewritten to its global pid. Accepting the global pid as well would be a namespace-collision bypass. Records not created by a fork in this process (`isolated_pid == 0`, e.g. main's WHOAMI-created worker records) are rejected outright — no legitimate READY targets them.

Verified: C suite (`--tests --debug`) 39/0 with three negative controls (gate disabled, gate accepting `process->pid`, zero-guard removed → each fails a test); live run with `isolation.namespaces.{credential,pid}` — workers announce as ns-pid 2/3, zero alerts; PHP/process/reconfigure/access-log pytest legs green (isolation rootfs case needs root). Non-ucred/cmsgcred platforms stay unauthenticated, as for every sibling gate. NEW_PORT handlers remain ungated — #223 scope.

Plan: plan-231-queueless-port.md (Codex + Opus reviewed). Local `codex review --commit 099d560d`: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
