### PR TITLE
capability: keep running when capget() is filtered

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -543,6 +543,28 @@ jobs:
           fi
         if: steps.metadata.outputs.module != 'wasm'
 
+      # test_capget_fallback.py needs a unitd that actually calls capget(),
+      # which a root one never does, so every leg above skips it -- the file
+      # is inside "test" but has never once run.  Repeat it here without
+      # sudo.  The python leg is the one chosen because the test drives a
+      # real application to show it inherits the shim harmlessly, and this
+      # leg is where a language module exists.
+      #
+      # pytest-3 is named absolutely: setup-python puts a toolcache bin
+      # directory ahead of /usr/bin for this step and not for the sudo'd one
+      # above, and both must run the pytest that "apt install python3-pytest"
+      # provided.
+      #
+      # !cancelled() rather than the implicit success(): this is the only leg
+      # that ever runs the file, and gating it on the whole sudo'd suite above
+      # would let one unrelated flake silently take that coverage away again --
+      # the very problem this step exists to fix.
+      - name: Run capget fallback tests unprivileged
+        run: |
+          export UNIT_PYTHONHOME="${UNIT_PYTHON_PREFIX}"
+          /usr/bin/pytest-3 --print-log test/test_capget_fallback.py
+        if: ${{ !cancelled() && steps.metadata.outputs.module == 'python' }}
+
   # C unit-test suite (src/test/ -> build/tests): HTTP parser, port/IPC
   # fault-injection, lvlhsh, mp, rbtree, base64, utf8, clone creds, etc.
   # Previously compiled but never executed in CI; runs here on every PR as its

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,17 @@
 
+Changes with FreeUnit 1.36.2                                     30 Aug 2026
+
+    *) Bugfix: do not exit when the capget() syscall is denied. A syscall
+       filter that omits capget -- a systemd "SystemCallFilter=" allowlist,
+       a hand-written seccomp profile -- made a non-root unitd fail to start
+       with "failed to get process capabilities". Unit now warns and runs
+       without assuming any capability: user and group switching and
+       "rootfs" isolation are disabled for applications that do not enable
+       the "credential" namespace, and applications run as unitd's own uid.
+       Capabilities the process may still hold are not dropped, since Unit
+       does not call capset(). Every other capget() failure remains fatal.
+
+
 Changes with FreeUnit 1.36.1                                     28 Aug 2026
 
     *) Feature: configuration validation errors now say where they are. A

--- a/CHANGES
+++ b/CHANGES
@@ -8,8 +8,44 @@ Changes with FreeUnit 1.36.2                                     30 Aug 2026
        without assuming any capability: user and group switching and
        "rootfs" isolation are disabled for applications that do not enable
        the "credential" namespace, and applications run as unitd's own uid.
-       Capabilities the process may still hold are not dropped, since Unit
-       does not call capset(). Every other capget() failure remains fatal.
+       Every other capget() failure remains fatal.
+
+    *) Security: application processes no longer inherit unitd's
+       capabilities. A unitd started as a non-root user that had been
+       granted capabilities -- systemd "AmbientCapabilities=", file
+       capabilities -- passed them through fork() to every application it
+       ran, because switching between two nonzero uids does not clear them
+       and a filtered capget() skips the switch entirely. Each forked
+       process now empties its permitted, effective, inheritable and
+       ambient sets once its credentials are final, before the worker
+       serves any request. The language module's own startup still runs
+       before the drop: the mount, pivot_root and chroot work for "rootfs"
+       isolation happens after it and needs the capabilities that are being
+       given up. Where a syscall filter denies capset() as well, an
+       application start is now refused rather than allowed to proceed with
+       capabilities still held: the request is answered 503 and the log
+       names the denied syscall. A process with an empty permitted,
+       effective and ambient set -- which is every process of a root unitd
+       once it has switched away from uid 0, and every process of an
+       unprivileged one that was granted no capabilities -- keeps behaving
+       as before, since there is nothing an application could have
+       inherited from it. Its inheritable set is emptied as well, which on
+       its own is not counted and grants nothing without an execve() of a
+       file carrying a matching capability. The
+       main process is unchanged, since it needs CAP_NET_BIND_SERVICE to
+       bind listening sockets on every reconfiguration; the router,
+       controller and discovery processes warn and carry on rather than
+       refuse, because they run no application code. Applications
+       configured with "user": "root" are also unchanged, since a root
+       process regains capabilities on the next execve() anyway. One
+       configuration does lose something it previously kept: an
+       application in a "credential" namespace began with a full
+       capability set inside that namespace, because the default uid_map
+       maps unitd's euid to the application's uid, so the setuid() is not
+       a transition out of uid 0 and nothing cleared it. Those
+       capabilities were valid only inside the namespace and Unit's own
+       use of them is finished before the drop, but an application that
+       relied on them now needs "user": "root".
 
 
 Changes with FreeUnit 1.36.1                                     28 Aug 2026

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -18,9 +18,45 @@ seccomp profile -- made a non-root unitd fail to start with "failed to get
 process capabilities".  Unit now warns and runs without assuming any
 capability: user and group switching and "rootfs" isolation are disabled
 for applications that do not enable the "credential" namespace, and
-applications run as unitd's own uid.  Capabilities the process may
-still hold are not dropped, since Unit does not call capset().  Every
-other capget() failure remains fatal.
+applications run as unitd's own uid.  Every other capget() failure
+remains fatal.
+</para>
+</change>
+
+<change type="security">
+<para>
+application processes no longer inherit unitd's capabilities.  A unitd
+started as a non-root user that had been granted capabilities -- systemd
+"AmbientCapabilities=", file capabilities -- passed them through fork()
+to every application it ran, because switching between two nonzero uids
+does not clear them and a filtered capget() skips the switch entirely.
+Each forked process now empties its permitted, effective, inheritable
+and ambient sets once its credentials are final, before the worker
+serves any request.  The language module's own startup still runs before
+the drop: the mount, pivot_root and chroot work for "rootfs" isolation
+happens after it and needs the capabilities that are being given up.
+Where a syscall filter denies capset() as well, an application start is
+now refused rather than allowed to proceed with capabilities still held:
+the request is answered 503 and the log names the denied syscall.  A
+process with an empty permitted, effective and ambient set -- which is
+every process of a root unitd once it has switched away from uid 0, and
+every process of an unprivileged one that was granted no capabilities --
+keeps behaving as before, since there is nothing an application could
+have inherited from it.  Its inheritable set is emptied as well, which
+on its own is not counted and grants nothing without an execve() of a
+file carrying a matching capability.  The main process is
+unchanged, since it needs CAP_NET_BIND_SERVICE to bind listening sockets
+on every reconfiguration; the router, controller and discovery processes
+warn and carry on rather than refuse, because they run no application
+code.  Applications configured with "user": "root" are also unchanged,
+since a root process regains capabilities on the next execve() anyway.
+One configuration does lose something it previously kept: an application
+in a "credential" namespace began with a full capability set inside that
+namespace, because the default uid_map maps unitd's euid to the
+application's uid, so the setuid() is not a transition out of uid 0 and
+nothing cleared it.  Those capabilities were valid only inside the
+namespace and Unit's own use of them is finished before the drop, but an
+application that relied on them now needs "user": "root".
 </para>
 </change>
 

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -6,6 +6,51 @@
 
 
 <changes apply="unit"
+         ver="1.36.2" rev="1"
+         date="2026-08-30" time="00:00:00 +0000"
+         packager="FreeUnit Packaging &lt;team@freeunit.org&gt;">
+
+<change type="bugfix">
+<para>
+do not exit when the capget() syscall is denied.  A syscall filter that
+omits capget -- a systemd "SystemCallFilter=" allowlist, a hand-written
+seccomp profile -- made a non-root unitd fail to start with "failed to get
+process capabilities".  Unit now warns and runs without assuming any
+capability: user and group switching and "rootfs" isolation are disabled
+for applications that do not enable the "credential" namespace, and
+applications run as unitd's own uid.  Capabilities the process may
+still hold are not dropped, since Unit does not call capset().  Every
+other capget() failure remains fatal.
+</para>
+</change>
+
+</changes>
+
+
+<changes apply="unit-php unit-php8.3 unit-php8.4 unit-php8.5
+                unit-python unit-python2.7
+                unit-python3.8 unit-python3.9 unit-python3.10 unit-python3.11
+                unit-python3.12 unit-python3.13 unit-python3.14
+                unit-go
+                unit-perl
+                unit-ruby
+                unit-jsc-common unit-jsc11 unit-jsc17 unit-jsc18
+                unit-jsc19 unit-jsc20 unit-jsc21
+                unit-wasm"
+         ver="1.36.2" rev="1"
+         date="2026-08-30" time="00:00:00 +0000"
+         packager="FreeUnit Packaging &lt;team@freeunit.org&gt;">
+
+<change>
+<para>
+FreeUnit updated to 1.36.2.
+</para>
+</change>
+
+</changes>
+
+
+<changes apply="unit"
          ver="1.36.1" rev="1"
          date="2026-08-28" time="00:00:00 +0000"
          packager="FreeUnit Packaging &lt;team@freeunit.org&gt;">

--- a/src/nxt_capability.c
+++ b/src/nxt_capability.c
@@ -49,7 +49,7 @@ nxt_capability_set(nxt_task_t *task, nxt_capabilities_t *cap)
 {
     nxt_assert(cap->setid == 0);
 
-    if (geteuid() == 0) {
+    if (nxt_euid == 0) {
         cap->setid = 1;
         cap->chroot = 1;
         return NXT_OK;
@@ -77,6 +77,7 @@ nxt_capability_linux_get_version(void)
 static nxt_int_t
 nxt_capability_specific_set(nxt_task_t *task, nxt_capabilities_t *cap)
 {
+    nxt_err_t                        err;
     struct __user_cap_data_struct    *val, data[2];
     struct __user_cap_header_struct  hdr;
 
@@ -100,7 +101,43 @@ nxt_capability_specific_set(nxt_task_t *task, nxt_capabilities_t *cap)
     hdr.pid = nxt_pid;
 
     if (nxt_slow_path(nxt_capget(&hdr, val) == -1)) {
-        nxt_alert(task, "failed to get process capabilities: %E", nxt_errno);
+        err = nxt_errno;
+
+        /*
+         * A syscall filter that does not allow capget() reports it
+         * through SECCOMP_RET_ERRNO, conventionally as EPERM or ENOSYS.
+         * Capabilities then cannot be observed at all, which is not a
+         * reason to refuse to start: leave both flags clear and run the
+         * way an ordinary unprivileged unitd already does.
+         *
+         * Any other errno means the call itself is wrong -- EINVAL,
+         * which a working version probe would have prevented, or EFAULT
+         * for a bad pointer -- so it is a bug in Unit rather than a
+         * policy decision made by the operator.  Keep failing closed
+         * there, rather than silently downgrading privileges.
+         */
+
+        if (err == NXT_EPERM || err == NXT_ENOSYS) {
+            nxt_log(task, NXT_LOG_WARN, "capget() failed %E; process "
+                    "capabilities are unknown and will not be used: user and "
+                    "group switching and \"rootfs\" isolation are disabled "
+                    "for applications that do not enable the \"credential\" "
+                    "namespace, and applications run as uid %d",
+                    err, (int) nxt_euid);
+
+            /*
+             * The log file is not open yet -- this runs from
+             * nxt_runtime_conf_init() -- so the warning above reaches
+             * stderr only.  Record it, and nxt_runtime_start() repeats it
+             * once unit.log exists, or a daemonised unitd would keep no
+             * trace of running without knowing its own capabilities.
+             */
+            cap->unknown = 1;
+
+            return NXT_OK;
+        }
+
+        nxt_alert(task, "failed to get process capabilities: %E", err);
         return NXT_ERROR;
     }
 

--- a/src/nxt_capability.c
+++ b/src/nxt_capability.c
@@ -4,15 +4,21 @@
  */
 
 /*
- * NOTE: this module currently exposes capability *detection*
- * (capget), used by nxt_isolation.c and the credential machinery to
- * decide whether a non-root build can honor setuid/setgid in the
- * "user"/"group" config keys.  Capabilities are NOT dropped
- * programmatically via capset(2): the privilege barrier for app
- * processes is the existing setuid + PR_SET_NO_NEW_PRIVS dance in
- * nxt_credential.c / nxt_process.c.  Operators expecting an explicit
- * capability-drop step should not assume one exists; isolation in
- * Unit relies on uid/namespace/seccomp boundaries, not capset.
+ * NOTE: this module does two separate things, in two different
+ * processes.
+ *
+ * nxt_capability_set() is *detection* (capget), run once in the main
+ * process from nxt_runtime_conf_init().  nxt_isolation.c and the
+ * credential machinery use its answer to decide whether a non-root
+ * unitd can honour setuid/setgid in the "user"/"group" config keys
+ * and "rootfs" isolation.
+ *
+ * nxt_capability_drop() is *disposal* (capset), run in every forked
+ * process from the tail of nxt_process_apply_creds().  It is never
+ * run in main, which keeps CAP_NET_BIND_SERVICE for the bind() in
+ * nxt_main_listening_socket() -- listeners are created on every
+ * reconfiguration, long after conf_init, so main cannot drop
+ * anything.  See nxt_capability_drop() for the rest.
  */
 
 #include <nxt_main.h>
@@ -20,7 +26,9 @@
 #if (NXT_HAVE_LINUX_CAPABILITY)
 
 #include <linux/capability.h>
+#include <sys/prctl.h>
 #include <sys/syscall.h>
+#include <sys/vfs.h>
 
 
 #if (_LINUX_CAPABILITY_VERSION_3)
@@ -157,10 +165,618 @@ nxt_capability_specific_set(nxt_task_t *task, nxt_capabilities_t *cap)
     return NXT_OK;
 }
 
+
+/*
+ * The magic number rather than <linux/magic.h>: one constant, stable
+ * since procfs existed, against a header that is not present on every
+ * libc Unit builds against.
+ */
+#define NXT_PROC_SUPER_MAGIC  0x9fa0
+
+
+static nxt_int_t
+nxt_capability_status_line(u_char *p, u_char *end, uint64_t *bits)
+{
+    u_char      *q;
+    uint64_t    v;
+    nxt_uint_t  digits;
+
+    if (end - p <= (ssize_t) nxt_length("CapXxx:")
+        || memcmp(p, "Cap", 3) != 0)
+    {
+        return 0;
+    }
+
+    if (memcmp(p, "CapPrm:", 7) != 0
+        && memcmp(p, "CapEff:", 7) != 0
+        && memcmp(p, "CapAmb:", 7) != 0)
+    {
+        /* CapInh and CapBnd, deliberately: see nxt_capability_still_held(). */
+        return 0;
+    }
+
+    q = p + nxt_length("CapXxx:");
+
+    while (q < end && (*q == ' ' || *q == '\t')) {
+        q++;
+    }
+
+    v = 0;
+    digits = 0;
+
+    while (q < end) {
+        if (*q >= '0' && *q <= '9') {
+            v = (v << 4) | (uint64_t) (*q - '0');
+
+        } else if (*q >= 'a' && *q <= 'f') {
+            v = (v << 4) | (uint64_t) (*q - 'a' + 10);
+
+        } else if (*q >= 'A' && *q <= 'F') {
+            v = (v << 4) | (uint64_t) (*q - 'A' + 10);
+
+        } else {
+            break;
+        }
+
+        q++;
+        digits++;
+    }
+
+    if (digits == 0 || digits > 16) {
+        return -1;
+    }
+
+    *bits |= v;
+
+    return 1;
+}
+
+
+static nxt_int_t
+nxt_capability_proc_status_held(void)
+{
+    int             fd;
+    u_char          *p, *end, *eol;
+    size_t          len;
+    ssize_t         n;
+    uint64_t        bits;
+    nxt_int_t       ret;
+    nxt_uint_t      found;
+    nxt_bool_t      skipping;
+    struct statfs   fs;
+    u_char          buf[1024];
+
+    fd = open("/proc/self/status", O_RDONLY | O_CLOEXEC);
+
+    if (fd < 0) {
+        return -1;
+    }
+
+    /*
+     * Prove it is procfs before believing a word of it.  An application
+     * that enables a "credential" namespace may also use "rootfs" even
+     * when capabilities are unknown, and nxt_proto_setup() has already
+     * pivot_root()ed into it by the time this runs -- with
+     * "automount": {"procfs": false} there may be no /proc there at all,
+     * or there may be a regular file of that name supplied with the
+     * application image.  Reading capability sets out of one would let
+     * the image decide whether the prototype it is about to run keeps
+     * unitd's capabilities.
+     */
+
+    if (fstatfs(fd, &fs) != 0 || fs.f_type != NXT_PROC_SUPER_MAGIC) {
+        close(fd);
+        return -1;
+    }
+
+    bits = 0;
+    found = 0;
+    len = 0;
+    skipping = 0;
+
+    /*
+     * Streamed over a small buffer, with the tail of a partial line
+     * carried across reads, because this file has no bounded size: a
+     * process in enough supplementary groups pushes the Cap* lines past
+     * any fixed buffer on the strength of its "Groups:" line alone, and
+     * reading only the first N bytes would turn "holds nothing" into
+     * "cannot tell" and refuse it.  A line too long for the buffer is
+     * skipped rather than grown into -- a Cap* line is 25 bytes.
+     */
+
+    for ( ;; ) {
+        n = read(fd, buf + len, sizeof(buf) - len);
+
+        if (n < 0) {
+
+            /*
+             * A signal that arrives mid-read is not an answer about
+             * capabilities.  Without the retry it would become one:
+             * read() fails, the reader reports "cannot tell", and the
+             * caller refuses an application over a SIGCHLD.  Every other
+             * errno is a real failure to read the file, and saying so is
+             * the honest reply.
+             */
+
+            if (nxt_errno == NXT_EINTR) {
+                continue;
+            }
+
+            close(fd);
+            return -1;
+        }
+
+        if (n == 0) {
+            break;
+        }
+
+        end = buf + len + n;
+        p = buf;
+
+        for ( ;; ) {
+            eol = memchr(p, '\n', (size_t) (end - p));
+
+            if (eol == NULL) {
+                break;
+            }
+
+            if (!skipping) {
+                ret = nxt_capability_status_line(p, eol, &bits);
+
+                if (nxt_slow_path(ret < 0)) {
+                    close(fd);
+                    return -1;
+                }
+
+                found += ret;
+            }
+
+            skipping = 0;
+            p = eol + 1;
+        }
+
+        len = (size_t) (end - p);
+
+        if (len == sizeof(buf)) {
+            skipping = 1;
+            len = 0;
+
+        } else {
+            memmove(buf, p, len);
+        }
+    }
+
+    /*
+     * Whatever is left when the file ends is a last line with no
+     * trailing newline.  procfs always terminates the one it writes, so
+     * this is unreachable for the real /proc/self/status -- but the
+     * fstatfs() above is the only thing standing between this parser and
+     * a file supplied with an application image, and dropping the tail
+     * would silently turn a "CapPrm: 00000000000000c0" written without a
+     * newline into a file whose Cap* lines simply do not count.
+     */
+
+    if (len > 0 && !skipping) {
+        ret = nxt_capability_status_line(buf, buf + len, &bits);
+
+        if (nxt_slow_path(ret < 0)) {
+            close(fd);
+            return -1;
+        }
+
+        found += ret;
+    }
+
+    close(fd);
+
+    /*
+     * CapPrm and CapEff, at least.  CapAmb needs Linux 4.3 and is
+     * allowed to be missing; fewer than two means this is not the file
+     * we think it is, and guessing from it would be worse than saying
+     * so.
+     */
+
+    if (found < 2) {
+        return -1;
+    }
+
+    return bits != 0;
+}
+
+
+/*
+ * Does this process still hold anything an application could inherit?
+ * 1 yes, 0 no, -1 could not be determined.
+ *
+ * Consulted only after capset() has already been denied, to separate
+ * "the operator filtered a call that had nothing left to do" from "the
+ * sets really are still full".  Without it the refusal in
+ * nxt_process_created_ok() would fire in the two commonest deployments
+ * there are, neither of which is unsafe: a root unitd, whose setuid()
+ * away from uid 0 empties permitted, effective and ambient before this
+ * function is ever reached, and an ordinary unprivileged unitd that was
+ * granted nothing.  Both would lose every application to a filter that
+ * costs them nothing.
+ *
+ * Two readers are tried, cheapest first, because neither covers every
+ * deployment on its own.
+ *
+ *   - capget().  A filter that denies capset() often still permits it,
+ *     and this is the exact answer with no filesystem involved.  It does
+ *     not report the ambient set, which does not matter here:
+ *     PR_CAP_AMBIENT_CLEAR_ALL in nxt_capability_drop() has already
+ *     run, needs no privilege and cannot be refused by the capability
+ *     model.  pid 0 rather than nxt_pid for the same reason capset()
+ *     uses it -- nxt_pid is the global pid, which does not resolve from
+ *     inside a PID namespace.
+ *
+ *   - /proc/self/status, when capget() is filtered too -- the shape this
+ *     whole fallback exists for.  A syscall filter cannot see through
+ *     open() and read().
+ *
+ * Both are readings.  Nothing here is inferred from what this process
+ * ought to be holding, and an earlier draft that did -- a root unitd's
+ * setuid() away from uid 0 empties permitted, effective and ambient, so
+ * the transition alone looks like an answer -- was removed rather than
+ * patched.  It was wrong two separate ways: SECBIT_KEEP_CAPS or
+ * SECBIT_NO_SETUID_FIXUP, either of which a service manager can set,
+ * suppress the clearing entirely; and inside a "credential" namespace a
+ * process can reach a nonzero euid while holding a full capability set
+ * in that namespace, never having made the transition at all.  Both
+ * leave a process that looks disarmed and is not.  It bought only the
+ * case where capget() is filtered *and* procfs is unreadable, and being
+ * wrong there is exactly where it costs the most.
+ *
+ * If neither reader answers, the caller refuses: this is a security
+ * fallback, and "could not tell" is not "there is nothing there".
+ *
+ * "Anything" means the permitted, effective and ambient sets, and only
+ * those three.  The capset() this reader is consulted after still
+ * empties the inheritable set along with them whenever it is allowed to
+ * run -- what this function decides is narrower, and it is the only
+ * question worth asking here: is anything left that an application
+ * could use?
+ *
+ * An inheritable bit is not.  It confers nothing in the process holding
+ * it; capabilities(7) turns it into privilege only on an execve() of a
+ * file whose own inheritable capability set intersects it.  Unit's
+ * language modules are fork()ed and never exec()ed, so they cannot
+ * reach that rule at all, and an "external" application execs the
+ * binary named in its configuration -- an ordinary file, carrying no
+ * file capabilities unless an operator deliberately gave it some, in
+ * which case they asked for exactly this.  Refusing over inheritable
+ * alone would therefore be refusing over something strictly narrower
+ * than the escalation this fallback exists to stop, and it is also
+ * precisely what an unprivileged unitd handed its workers before
+ * nxt_capability_drop() existed: nothing in Unit has ever cleared an
+ * inheritable set before now.
+ *
+ * That leaves a residual, and it is left deliberately: an "external"
+ * application whose own binary an operator gave a matching file
+ * inheritable capability does get that bit promoted on execve().
+ * Refusing would not take it away -- capset() has just been denied, so
+ * nothing here can clear anything -- it would only take away the
+ * application.  The trade is a certain outage on every host with a
+ * stray inheritable bit against a bit the operator had to place twice,
+ * once on unitd and once on the file it execs.
+ *
+ * Counting it would cost a great deal, too.  Inheritable bits turn up on
+ * ordinary hosts without anyone meaning them to matter -- pam_cap exists
+ * to set exactly them, and the desktop this was measured on carries
+ * CapInh=0000000800000000 over entirely empty permitted, effective and
+ * ambient sets.  A root unitd is no safer either, because setuid() away
+ * from uid 0 clears permitted, effective and ambient and leaves
+ * inheritable exactly as it was.  Both would lose every application to a
+ * filter that costs them nothing.
+ * Conditioning it on PR_SET_NO_NEW_PRIVS does not rescue the idea
+ * either: no_new_privs is off in the default configuration --
+ * nxt_isolation_main_prefork() sets isolation.new_privs to 1 and
+ * nxt_process_apply_creds() issues the prctl only when it is 0 -- so
+ * the condition would be false on exactly the hosts that have the
+ * stray bit.
+ *
+ * The bounding set is never counted either, for the reason it is never
+ * emptied: it is a ceiling on what an execve() may add, not something
+ * this process holds, and capset() would not have cleared it either.
+ *
+ * The ambient set is read where a reader offers it, even though the
+ * kernel keeps it a subset of permitted -- so an empty permitted
+ * already implies an empty ambient -- because the
+ * PR_CAP_AMBIENT_CLEAR_ALL in nxt_capability_drop() is only warned
+ * about when it fails.
+ */
+static nxt_int_t
+nxt_capability_still_held(void)
+{
+    uint32_t                         bits;
+    struct __user_cap_data_struct    data[2];
+    struct __user_cap_header_struct  hdr;
+
+    nxt_memzero(data, sizeof(data));
+
+    hdr.version = NXT_CAPABILITY_VERSION;
+    hdr.pid     = 0;
+
+    if (nxt_fast_path(nxt_capget(&hdr, data) == 0)) {
+        bits = data[0].effective | data[0].permitted
+               | data[1].effective | data[1].permitted;
+
+        return bits != 0;
+    }
+
+    return nxt_capability_proc_status_held();
+}
+
+
+/*
+ * Drop every capability the calling process still holds.  Called from
+ * the tail of nxt_process_apply_creds(), which is the last thing that
+ * runs in a freshly forked prototype, router, controller or discovery
+ * process before it starts doing work on an application's behalf -- and
+ * after setgid()/setuid(), after unshare() and main's uid_map write,
+ * and after all the mount/pivot_root/chroot work nxt_proto_setup() does
+ * for "rootfs".  Application workers never reach this function: the
+ * prototype forks them and nxt_app_setup() calls init->start directly,
+ * so they inherit sets this call already emptied.
+ *
+ * It is not the earliest possible point.  nxt_proto_setup() calls the
+ * language module's setup first, and for PHP that is
+ * php_module_startup() with the php.ini named in the configuration,
+ * which loads and initialises whatever extensions that file lists.
+ * Nothing can be dropped before that: the mount, pivot_root and
+ * chroot calls later in the same function need CAP_SYS_ADMIN and
+ * CAP_SYS_CHROOT.  The window is unchanged by this code and is not
+ * widened by it -- setgid()/setuid() have not happened yet either, so
+ * module startup has always run with unitd's own uid, which is the
+ * larger privilege of the two.
+ *
+ * Capabilities are per-thread, and capset() with pid 0 sets only the
+ * calling thread's, so this has to run while the process is still
+ * single-threaded -- and it does.  The router's engine threads are
+ * created from init->start, which runs after this and inherits the
+ * emptied sets; the prototype and its workers never leave one thread;
+ * thread pools spawn on their first posted work item, which is later
+ * still.  The one thread that could pre-exist is the signal thread,
+ * and only for an event engine that cannot poll signals itself
+ * (nxt_signal_thread_start(), reached from nxt_event_engine_create()
+ * when !interface->signal_support).  Linux never selects one: epoll
+ * declares NXT_SIGNAL_EVENTS wherever signalfd exists, and rt->engine
+ * is only ever set to the interface Unit itself chose
+ * (nxt_runtime.c), never by an operator.  Measured: with the router at
+ * nine threads, every /proc/<pid>/task/<tid>/status in every child
+ * reports empty sets.
+ *
+ * Why here and not in main: main binds listening sockets in
+ * nxt_main_listening_socket() every time the configuration changes, so
+ * it needs CAP_NET_BIND_SERVICE for the whole life of the process --
+ * and also chown()s sockets, writes uid_map and moves children into
+ * cgroups.  nxt_capability_set() runs from nxt_runtime_conf_init(),
+ * long before the first bind(), so a drop there would turn "unitd fails
+ * to start" into "unitd starts but cannot listen on :80".
+ *
+ * fork() copies the permitted, effective, inheritable, ambient and
+ * bounding sets verbatim, so without this a non-root unitd that was
+ * granted, say, CAP_SETUID/CAP_SETGID/CAP_SYS_CHROOT would hand those
+ * to every application worker.  Two deployments reach that state:
+ *
+ *   - capget() filtered.  nxt_capability_specific_set() leaves setid
+ *     clear, so nxt_process_apply_creds() skips setgid()/setuid()
+ *     entirely and nothing lowers anything.
+ *   - capget() working.  The credentials are switched, but from one
+ *     nonzero uid to another, and capabilities(7) only clears the sets
+ *     on a transition *out of* uid 0 -- so the capabilities survive
+ *     the setuid() as well.
+ *
+ * A root unitd is the case that was already safe: its setuid() away
+ * from 0 clears the permitted, effective and ambient sets by itself,
+ * which makes the capset() below a verified no-op there rather than a
+ * behaviour change.
+ *
+ * The bounding set is deliberately left alone: emptying it needs
+ * CAP_SETPCAP, which this process is about to give up and usually
+ * never had.  It is a ceiling on what an execve() may add to the
+ * permitted set, and with inheritable emptied below the only thing
+ * left for it to admit is a file capability on the binary an
+ * application execve()s -- which is the operator's own choice, not
+ * something inherited from unitd.  PR_SET_NO_NEW_PRIVS would close
+ * even that, but it is off in the default configuration (see the
+ * comment on nxt_capability_still_held() above), so it is not what
+ * makes this safe.
+ *
+ * The return value is three-way and advisory in the middle case:
+ * NXT_OK when nothing is left to inherit, NXT_ERROR when the call was
+ * malformed, and NXT_DECLINED when a syscall filter denied capset()
+ * and this process is still holding something as a result.
+ * NXT_DECLINED is deliberately not a refusal here.  This function is
+ * reached by the router, the controller and discovery as well, through
+ * nxt_process_core_setup(), and failing those closed is worse than the
+ * bug it would be protecting against: router and controller carry
+ * .restart = 1 and are re-forked immediately and without backoff, so a
+ * filter that is going to deny every attempt turns into an unbounded
+ * respawn loop; and discovery notifies no one when it dies, leaving
+ * unitd running with no modules and no control socket.  Only the caller
+ * knows whether application code is about to inherit what could not be
+ * dropped, so only the caller can decide.
+ */
+nxt_int_t
+nxt_capability_drop(nxt_task_t *task)
+{
+    nxt_int_t                        held;
+    nxt_err_t                        err;
+    struct __user_cap_data_struct    data[2];
+    struct __user_cap_header_struct  hdr;
+
+    if (geteuid() == 0) {
+        /*
+         * An application configured with "user": "root" -- and the
+         * initial state of a root unitd, before apply_creds() has
+         * switched user -- keeps what root has.  Dropping there would
+         * be a compatibility break with no security value: euid 0
+         * regains a full permitted set on the next execve() of any
+         * ordinary file anyway (capabilities(7), "Capabilities and
+         * execution of programs by root"), so the drop could not hold
+         * for an exec'd application and would only make an embedded
+         * one inconsistently crippled.  This mirrors the geteuid()==0
+         * short-circuit in nxt_capability_set() above.
+         *
+         * It is also the escape hatch for the one case that does lose
+         * something here: an application in a "credential" namespace
+         * starts with a full capability set in that namespace
+         * (user_namespaces(7)), and unless it is mapped to uid 0 it
+         * now loses it.  Those capabilities were only ever valid
+         * inside the namespace, and everything Unit itself does with
+         * them -- the mounts, pivot_root and chroot for "rootfs" --
+         * has already happened in nxt_proto_setup() by the time this
+         * runs.  An application that wants to keep them can ask for
+         * uid 0 within its own namespace.
+         *
+         * geteuid() rather than nxt_euid: nxt_euid is sampled once in
+         * nxt_lib_start() and is stale in a process that has just
+         * called setuid().
+         */
+
+        return NXT_OK;
+    }
+
+#ifdef PR_CAP_AMBIENT
+
+    /*
+     * Clear the ambient set first, and separately.  For a non-root
+     * process executing a file with no capabilities, capabilities(7)
+     * reduces to P'(permitted) = P'(effective) = P(ambient): the
+     * ambient set is the only one that carries real privilege across
+     * execve(), inheritable survives but does nothing without a
+     * matching file inheritable set.  So ambient is precisely what an
+     * "external" application -- Go, Node, anything Unit runs through
+     * the execve() in nxt_external.c -- would otherwise inherit.
+     * PR_CAP_AMBIENT_CLEAR_ALL needs no privilege and no prior read of
+     * the set, so it still works when capget() and capset() are both
+     * denied; emptying the permitted set below clears ambient
+     * implicitly, but only if that call succeeds.
+     *
+     * A plain #ifdef rather than an auto/ feature test: PR_CAP_AMBIENT
+     * is a macro in <sys/prctl.h>, so this compiles out on headers too
+     * old to define it, and a kernel older than 4.3 has no ambient set
+     * to clear and answers EINVAL, which is not worth a warning.
+     */
+
+    if (nxt_slow_path(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0)
+                      != 0))
+    {
+        nxt_debug(task, "prctl(PR_CAP_AMBIENT_CLEAR_ALL) failed %E",
+                  nxt_errno);
+    }
+
+#endif
+
+    nxt_memzero(data, sizeof(data));
+
+    /*
+     * The compiled-in version constant, not
+     * nxt_capability_linux_get_version(): the probe is a capget() call,
+     * and this function has to work in the deployment where capget() is
+     * exactly what is filtered.  On every
+     * header Unit builds against this is _LINUX_CAPABILITY_VERSION_3,
+     * which the kernel has accepted since 2.6.26 and which describes the
+     * two-element data array above.
+     *
+     * pid 0, not nxt_pid: capset() takes only 0 or the caller's own pid,
+     * and nxt_pid holds the *global* pid in a process that was moved into
+     * a PID namespace (nxt_process_whoami()), which would be EPERM here.
+     */
+
+    hdr.version = NXT_CAPABILITY_VERSION;
+    hdr.pid     = 0;
+
+    if (nxt_fast_path(nxt_capset(&hdr, data) == 0)) {
+        return NXT_OK;
+    }
+
+    err = nxt_errno;
+
+    /*
+     * Same errno split as nxt_capability_specific_set(): EPERM and
+     * ENOSYS are what a syscall filter returns, and a filter is an
+     * operator's decision, not an error.  It is also the only way this
+     * call can fail with EPERM: lowering all three sets to empty is
+     * always permitted for any process (capabilities(7), the transition
+     * rules for a caller without CAP_SETPCAP), so a refusal cannot have
+     * come from the capability model itself.
+     *
+     * A denial is not automatically a problem, though, which is why
+     * nxt_capability_still_held() gets the last word: a root unitd has
+     * already emptied every set by switching away from uid 0, and an
+     * unprivileged one never held anything, so in both the call that
+     * was just refused would have done nothing.  Only a process that
+     * demonstrably still holds something -- or cannot find out -- has
+     * anything to report.
+     *
+     * NXT_DECLINED rather than NXT_ERROR, and rather than NXT_OK: the
+     * consequence of a denied capset() is not the same for every
+     * caller, so this function reports "the sets are still full" and
+     * lets nxt_process_apply_creds()'s callers decide.  A prototype
+     * refuses to start, because its whole remaining job is to fork
+     * application workers that would inherit those sets; the router,
+     * controller and discovery processes warn and continue, because
+     * they run no application code and killing them is worse than the
+     * bug -- see nxt_process_created_ok() and nxt_process_core_setup().
+     *
+     * Anything else -- EINVAL, EFAULT -- means the call we just made is
+     * malformed, which can only be a bug in Unit, since neither the
+     * version nor the pointer depends on anything an operator controls.
+     * Fail closed there, for every caller alike.
+     */
+
+    if (err == NXT_EPERM || err == NXT_ENOSYS) {
+        held = nxt_capability_still_held();
+
+        if (held == 0) {
+            /*
+             * The overwhelmingly common case, and the reason this is
+             * measured rather than assumed.  A root unitd has already
+             * cleared every set by switching away from uid 0, and an
+             * ordinary unprivileged unitd never had anything -- in both
+             * the call that was just denied would have been a no-op, and
+             * refusing over it would take the application down for no
+             * security benefit at all.  Not even a warning: nothing
+             * happened.
+             */
+
+            nxt_debug(task, "capset() failed %E, and no capability is held",
+                      err);
+
+            return NXT_OK;
+        }
+
+        if (held > 0) {
+            nxt_log(task, NXT_LOG_WARN, "capset() failed %E; the capabilities "
+                    "this process holds could not be dropped", err);
+
+        } else {
+            nxt_log(task, NXT_LOG_WARN, "capset() failed %E, and whether this "
+                    "process holds any capability could not be determined "
+                    "either", err);
+        }
+
+        return NXT_DECLINED;
+    }
+
+    nxt_alert(task, "failed to drop process capabilities: %E", err);
+
+    return NXT_ERROR;
+}
+
 #else
 
 static nxt_int_t
 nxt_capability_specific_set(nxt_task_t *task, nxt_capabilities_t *cap)
+{
+    return NXT_OK;
+}
+
+
+nxt_int_t
+nxt_capability_drop(nxt_task_t *task)
 {
     return NXT_OK;
 }

--- a/src/nxt_capability.h
+++ b/src/nxt_capability.h
@@ -9,6 +9,7 @@
 typedef struct {
     uint8_t  setid;     /* 1 bit */
     uint8_t  chroot;    /* 1 bit */
+    uint8_t  unknown;   /* 1 bit */
 } nxt_capabilities_t;
 
 

--- a/src/nxt_capability.h
+++ b/src/nxt_capability.h
@@ -15,5 +15,14 @@ typedef struct {
 
 NXT_EXPORT nxt_int_t nxt_capability_set(nxt_task_t *task,
     nxt_capabilities_t *cap);
+/*
+ * NXT_OK: nothing is left to inherit -- either the sets were emptied,
+ * or they were already empty when a filter denied the attempt.
+ * NXT_DECLINED: capset() is filtered and this process is still holding
+ * capabilities, or cannot determine that it is not -- advisory, the
+ * caller decides whether that is fatal.  NXT_ERROR: the call was
+ * malformed.
+ */
+NXT_EXPORT nxt_int_t nxt_capability_drop(nxt_task_t *task);
 
 #endif /* _NXT_CAPABILITY_INCLUDED_ */

--- a/src/nxt_process.c
+++ b/src/nxt_process.c
@@ -991,6 +991,39 @@ nxt_process_created_ok(nxt_task_t *task, nxt_port_recv_msg_t *msg, void *data)
     init = nxt_process_init(process);
 
     ret = nxt_process_apply_creds(task, process);
+
+    if (nxt_slow_path(ret == NXT_DECLINED)) {
+        /*
+         * capset() is filtered and nxt_capability_still_held() found
+         * this process carrying capabilities because of it, or could
+         * not establish that it is not.  Only a prototype reaches
+         * nxt_process_created_ok(): the core processes set
+         * NXT_PROCESS_STATE_READY in nxt_process_core_setup() and never
+         * send PROCESS_CREATED, and an application worker never sends
+         * one either, because nxt_app_setup() returns init->start()
+         * directly and that call does not come back with NXT_OK.  The
+         * entire remaining job of a prototype is to fork workers that
+         * would inherit those sets.  Refuse the start
+         * instead, and say which syscall and which consequence, so the
+         * operator's next step is to allow capset() rather than to
+         * hunt for a broken application.
+         *
+         * The refusal is visible: this exits nonzero, main's SIGCHLD
+         * reaper notifies the router with the start's stream still
+         * attached (main zeroes ->stream only at state READY, and its
+         * copy of a prototype that died here is still CREATED), the
+         * router turns that REMOVE_PID into an RPC error for the start
+         * attempt, and the requests waiting on the application are
+         * answered 503 rather than left to time out.
+         */
+
+        nxt_alert(task, "%s refused to start: capset() is denied, so the "
+                  "capabilities this process holds cannot be dropped and "
+                  "would be inherited by application code", process->name);
+
+        goto fail;
+    }
+
     if (nxt_slow_path(ret != NXT_OK)) {
         goto fail;
     }
@@ -1039,7 +1072,24 @@ nxt_process_core_setup(nxt_task_t *task, nxt_process_t *process)
     nxt_int_t  ret;
 
     ret = nxt_process_apply_creds(task, process);
-    if (nxt_slow_path(ret != NXT_OK)) {
+
+    /*
+     * NXT_DECLINED -- capset() filtered, capabilities still held -- is
+     * warn-and-continue here, unlike on the nxt_process_created_ok()
+     * path.  This is the router, the controller and discovery: they run
+     * no application code, so there is nothing to inherit what they
+     * keep, and refusing costs far more than it buys.  Router and
+     * controller declare .restart = 1 and nxt_main_process_sigchld_
+     * handler() re-forks them immediately and without backoff, so a
+     * filter that denies every attempt would spin a respawn loop
+     * instead of reporting anything; discovery's row in
+     * nxt_proc_remove_notify_matrix is all zeroes and it is the main
+     * process's only startup action, so its death would leave unitd up
+     * with no modules, no control socket and no error.
+     * nxt_capability_drop() has already logged the warning.
+     */
+
+    if (nxt_slow_path(ret != NXT_OK && ret != NXT_DECLINED)) {
         return NXT_ERROR;
     }
 
@@ -1128,7 +1178,23 @@ nxt_process_apply_creds(nxt_task_t *task, nxt_process_t *process)
     }
 #endif
 
-    return NXT_OK;
+    /*
+     * Last: nothing after this point in any child needs a capability,
+     * and everything before it might.  PR_SET_NO_NEW_PRIVS above stops
+     * this process *gaining* privilege across execve(); it does not
+     * take away what the process already carries, and fork() copies
+     * every capability set verbatim, so a unitd that was granted
+     * capabilities would otherwise pass them straight to application
+     * code.  Main never calls apply_creds() and so never drops -- it
+     * binds listeners on every reconfiguration.
+     *
+     * Its NXT_DECLINED -- a filtered capset(), sets still full -- is
+     * passed through rather than folded into either NXT_OK or
+     * NXT_ERROR, because the two callers answer it differently: see
+     * nxt_process_created_ok() and nxt_process_core_setup().
+     */
+
+    return nxt_capability_drop(task);
 }
 
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -5127,6 +5127,7 @@ nxt_router_app_port_error(nxt_task_t *task, nxt_port_recv_msg_t *msg,
     void *data)
 {
     uint32_t             n;
+    nxt_bool_t           restarted;
     nxt_app_t            *app;
     nxt_app_joint_t      *app_joint;
     nxt_app_joint_rpc_t  *app_joint_rpc;
@@ -5148,7 +5149,81 @@ nxt_router_app_port_error(nxt_task_t *task, nxt_port_recv_msg_t *msg,
         return;
     }
 
-    nxt_debug(task, "app '%V' %p start error", &app->name, app);
+    /*
+     * Two ways in are not failures at all, and both are excluded rather
+     * than tolerated.
+     *
+     * A restart: nxt_router_app_restart_handler() bumps app->generation
+     * and sends QUIT to the prototype, and a worker that prototype had
+     * already forked for an in-flight start goes with it.  The REMOVE_PID
+     * for that worker still carries the start's stream -- the prototype
+     * set it when it forked (nxt_application.c) and nothing clears it for
+     * a process that never became ready -- so the router retypes it into
+     * an RPC error and it lands here, reporting a start the operator
+     * themselves cancelled.  Nothing about the RPC peer is involved: the
+     * registration this handler belongs to never sets one.  Generation is
+     * how nxt_router_app_port_ready() tells the same two apart before it
+     * quietly QUITs a port that arrives for a superseded one.
+     *
+     * And a shutdown: nxt_port_close() runs nxt_port_rpc_close() over the
+     * router port, which turns every registration still on it into an
+     * RPC error, so a start that was merely still pending when Unit was
+     * asked to stop would report itself as a failure.  Nothing bumps the
+     * generation there, so it needs its own test -- engine->shutdown, the
+     * same flag this file already consults before deciding to start
+     * another process at all.
+     *
+     * Only the log line is conditional either way: the cleanup below has
+     * to run regardless, since the slots and the parked requests belong
+     * to an attempt that is over whatever ended it.
+     */
+
+    nxt_thread_mutex_lock(&app->mutex);
+
+    restarted = (app->generation != app_joint_rpc->generation);
+
+    nxt_thread_mutex_unlock(&app->mutex);
+
+    /*
+     * Otherwise: logged, not nxt_debug()d.  This handler is armed for one
+     * start attempt and disarmed the moment the port arrives, so it
+     * cannot fire for an ordinary worker exit or an idle timeout: every
+     * remaining call means an application process that was asked for will
+     * never exist, and the requests parked on it are about to be answered
+     * 503.  At debug level that was invisible in a default configuration,
+     * which left "the application returns 503" with no corresponding line
+     * anywhere in the log.
+     *
+     * NXT_LOG_ERR rather than nxt_alert(), which the early-failure path
+     * in nxt_router_start_app_process_handler() uses.  That one can only
+     * be Unit's own fault; this one is usually the application's -- a
+     * module that fails to import, a worker that exits during startup --
+     * and Unit is working exactly as designed when it reports one.
+     * [error] is emitted at the default log level, which is the whole
+     * point of the change.
+     *
+     * A different sentence from that alert, deliberately, even though
+     * the two describe the same disappointment.  The test suite skips
+     * expected alerts by an unanchored regex over the log
+     * (Log.check_alerts()), so a test that skipped this [error] line by
+     * quoting "failed to start a process" would silently swallow the
+     * alert as well, in every test that ran alongside it.  The two are
+     * worth telling apart; the level alone is a thin thing to rely on.
+     *
+     * It cannot say *why*: this is usually a REMOVE_PID that
+     * nxt_router_remove_pid_handler() retyped, and its payload is the
+     * dead pid and nothing else.  The reason is in whatever the dead
+     * process logged before exiting; this line is what tells the operator
+     * there is something to go and look for.
+     */
+
+    if (nxt_slow_path(restarted || task->thread->engine->shutdown)) {
+        nxt_debug(task, "app '%V' start attempt cancelled", &app->name);
+
+    } else {
+        nxt_log(task, NXT_LOG_ERR,
+                "app '%V' start attempt produced no process", &app->name);
+    }
 
     if (app_joint_rpc->proto) {
         /*

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -357,6 +357,19 @@ nxt_runtime_start(nxt_task_t *task, void *obj, void *data)
         goto fail;
     }
 
+    if (rt->capabilities.unknown) {
+        /*
+         * nxt_capability_set() could only reach stderr: it runs from
+         * nxt_runtime_conf_init(), before the log file exists.  Repeat it
+         * here so the record survives in unit.log too.
+         */
+        nxt_log(task, NXT_LOG_WARN, "capget() failed; process "
+                "capabilities are unknown and will not be used: user and "
+                "group switching and \"rootfs\" isolation are disabled "
+                "for applications that do not enable the \"credential\" "
+                "namespace, and applications run as uid %d", (int) nxt_euid);
+    }
+
     if (nxt_runtime_event_engine_change(task, rt) != NXT_OK) {
         goto fail;
     }

--- a/test/capget_filter.c
+++ b/test/capget_filter.c
@@ -1,0 +1,172 @@
+/*
+ * LD_PRELOAD shim that makes capget(2) fail the way a syscall filter
+ * makes it fail, for test_capget_fallback.py.
+ *
+ * src/nxt_capability.c reaches the kernel through the nxt_capget()
+ * macro, which expands to glibc's syscall() wrapper -- an ordinary
+ * interposable symbol, not a compiler builtin or an inline "syscall"
+ * instruction.  So a preloaded definition of syscall() shadows it and
+ * we can inject an errno without needing seccomp, a privileged
+ * helper, or a container.
+ *
+ * The interposition is total: every syscall() in the process, from
+ * every library, comes through here.  Only SYS_capget is ever
+ * answered locally, and only when NXT_TEST_CAPGET_ERRNO names an
+ * errno; everything else is forwarded to the real symbol untouched.
+ *
+ * Set NXT_TEST_CAPGET_RECORD to a file path to have every pid whose
+ * capget() we failed appended to it, one per line.  The test uses
+ * that to show which processes the filter actually reached -- the
+ * environment is inherited by unitd's children, so "no other process
+ * was affected" has to be demonstrated rather than assumed.
+ *
+ * That path is copied, not kept as the getenv() pointer, and the copy
+ * is what makes the demonstration mean anything.  getenv() returns a
+ * pointer into the contiguous argv+environ block, and
+ * nxt_process_title() (src/nxt_process_title.c) writes the process
+ * title over that block and zero-pads the remainder, so in every
+ * process unitd forks the inherited pointer would read as "" and
+ * open("") would fail silently.  The main process looked correct only
+ * by accident of ordering: nxt_capability_set() runs from
+ * nxt_runtime_conf_init(), before nxt_main_process_title()
+ * (src/nxt_main_process.c:96) rewrites the area.  A record file that
+ * no child could have written to proves nothing about what the
+ * children did.
+ *
+ * Build:
+ *     cc -shared -fPIC -o capget_filter.so capget_filter.c -ldl
+ */
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+/*
+ * glibc declares syscall() variadic, but it is an assembly stub that
+ * only moves registers: it never walks a va_list, so calling it
+ * through a fixed six-argument prototype is what every syscall
+ * interposer does and is correct on every Linux ABI Unit builds for.
+ */
+typedef long (*nxt_syscall_fn)(long, long, long, long, long, long, long);
+
+static nxt_syscall_fn  nxt_real_syscall;
+static int             nxt_capget_errno;   /* 0: filter disabled */
+static char           *nxt_record_path;    /* strdup()ed, see above */
+
+
+static void
+nxt_shim_init(void)
+{
+    const char  *value;
+
+    nxt_real_syscall = (nxt_syscall_fn) dlsym(RTLD_NEXT, "syscall");
+
+    value = getenv("NXT_TEST_CAPGET_ERRNO");
+
+    if (value != NULL && *value != '\0') {
+        nxt_capget_errno = (int) strtol(value, NULL, 10);
+    }
+
+    value = getenv("NXT_TEST_CAPGET_RECORD");
+
+    if (nxt_record_path == NULL && value != NULL && *value != '\0') {
+        nxt_record_path = strdup(value);
+    }
+}
+
+
+__attribute__((constructor))
+static void
+nxt_shim_ctor(void)
+{
+    nxt_shim_init();
+}
+
+
+static void
+nxt_shim_record(void)
+{
+    int   fd, len;
+    char  buf[32];
+
+    if (nxt_record_path == NULL) {
+        return;
+    }
+
+    /*
+     * open()/write()/close() are their own glibc stubs, not calls to
+     * syscall(), so this cannot recurse back into the shim.
+     */
+
+    fd = open(nxt_record_path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+
+    if (fd < 0) {
+        return;
+    }
+
+    len = snprintf(buf, sizeof(buf), "%ld\n", (long) getpid());
+
+    if (len > 0) {
+        (void) !write(fd, buf, (size_t) len);
+    }
+
+    close(fd);
+}
+
+
+long
+syscall(long number, ...)
+{
+    long     a0, a1, a2, a3, a4, a5;
+    va_list  ap;
+
+    if (nxt_real_syscall == NULL) {
+        /*
+         * A constructor in another preloaded object may run before
+         * ours and call syscall() from it.
+         */
+        nxt_shim_init();
+
+        if (nxt_real_syscall == NULL) {
+            /*
+             * Nothing to forward to.  Fail loudly: silently returning
+             * an error here would corrupt an unrelated syscall and
+             * make the test lie about what it exercised.
+             */
+            _exit(127);
+        }
+    }
+
+    /*
+     * Reading six arguments when the caller passed fewer yields
+     * garbage in the unused ones, which the kernel ignores for every
+     * syscall that does not declare them.
+     */
+
+    va_start(ap, number);
+    a0 = va_arg(ap, long);
+    a1 = va_arg(ap, long);
+    a2 = va_arg(ap, long);
+    a3 = va_arg(ap, long);
+    a4 = va_arg(ap, long);
+    a5 = va_arg(ap, long);
+    va_end(ap);
+
+#ifdef SYS_capget
+    if (number == SYS_capget && nxt_capget_errno != 0) {
+        nxt_shim_record();
+        errno = nxt_capget_errno;
+        return -1;
+    }
+#endif
+
+    return nxt_real_syscall(number, a0, a1, a2, a3, a4, a5);
+}

--- a/test/capget_filter.c
+++ b/test/capget_filter.c
@@ -33,6 +33,41 @@
  * no child could have written to proves nothing about what the
  * children did.
  *
+ * NXT_TEST_CAPSET_RECORD does the same for capset(2).  That is how the
+ * test observes nxt_capability_drop(): the drop has no visible effect
+ * in a suite that runs without any capability to drop, so "the app has
+ * no capabilities" would pass just as well without the code.  Which
+ * *processes* called capset() is the part that cannot pass by
+ * accident: main must never appear (it keeps CAP_NET_BIND_SERVICE for
+ * bind()), the prototype must, and the application worker must not,
+ * because it inherits the prototype's already-emptied sets rather than
+ * dropping again.
+ *
+ * NXT_TEST_CAPGET_HOLD is the other direction: a hex mask that makes
+ * capget(2) *succeed* and report that mask in the permitted, effective
+ * and inheritable sets of the first data element.  The suite runs as an
+ * ordinary user with no capabilities, so without it there is nothing to
+ * refuse over -- nxt_capability_still_held() would correctly answer
+ * "empty" and the refusal below would never fire.  Faking the answer is
+ * what lets an unprivileged pytest reach the code the harness smoke test
+ * reaches with real ambient capabilities.
+ *
+ * The mask the test passes is CAP_NET_BIND_SERVICE, deliberately: main's
+ * own capget() sees it too, and nxt_capability_specific_set() only looks
+ * for CAP_SETUID, CAP_SETGID and CAP_SYS_CHROOT, so unitd still starts
+ * and behaves exactly like the unprivileged process it really is.  A
+ * mask containing CAP_SETUID would make it attempt a setuid() it cannot
+ * perform.
+ *
+ * NXT_TEST_CAPSET_ERRNO makes capset(2) fail the same way, which is
+ * the other half of a "SystemCallFilter=" allowlist: a profile that
+ * omits capget() almost always omits capset() too.  The call is still
+ * recorded before it is failed, so the record says who *tried*.  Unit
+ * answers that differently per process -- a prototype refuses to start
+ * rather than fork workers that would inherit what it could not drop,
+ * while the router, controller and discovery warn and carry on -- so
+ * the test needs to be able to produce it.
+ *
  * Build:
  *     cc -shared -fPIC -o capget_filter.so capget_filter.c -ldl
  */
@@ -49,6 +84,8 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#include <linux/capability.h>
+
 /*
  * glibc declares syscall() variadic, but it is an assembly stub that
  * only moves registers: it never walks a va_list, so calling it
@@ -59,7 +96,10 @@ typedef long (*nxt_syscall_fn)(long, long, long, long, long, long, long);
 
 static nxt_syscall_fn  nxt_real_syscall;
 static int             nxt_capget_errno;   /* 0: filter disabled */
+static int             nxt_capset_errno;   /* 0: filter disabled */
+static unsigned        nxt_capget_hold;    /* 0: report the real sets */
 static char           *nxt_record_path;    /* strdup()ed, see above */
+static char           *nxt_capset_record_path;
 
 
 static void
@@ -75,10 +115,28 @@ nxt_shim_init(void)
         nxt_capget_errno = (int) strtol(value, NULL, 10);
     }
 
+    value = getenv("NXT_TEST_CAPSET_ERRNO");
+
+    if (value != NULL && *value != '\0') {
+        nxt_capset_errno = (int) strtol(value, NULL, 10);
+    }
+
+    value = getenv("NXT_TEST_CAPGET_HOLD");
+
+    if (value != NULL && *value != '\0') {
+        nxt_capget_hold = (unsigned) strtoul(value, NULL, 16);
+    }
+
     value = getenv("NXT_TEST_CAPGET_RECORD");
 
     if (nxt_record_path == NULL && value != NULL && *value != '\0') {
         nxt_record_path = strdup(value);
+    }
+
+    value = getenv("NXT_TEST_CAPSET_RECORD");
+
+    if (nxt_capset_record_path == NULL && value != NULL && *value != '\0') {
+        nxt_capset_record_path = strdup(value);
     }
 }
 
@@ -92,12 +150,12 @@ nxt_shim_ctor(void)
 
 
 static void
-nxt_shim_record(void)
+nxt_shim_record(const char *path)
 {
     int   fd, len;
     char  buf[32];
 
-    if (nxt_record_path == NULL) {
+    if (path == NULL) {
         return;
     }
 
@@ -106,7 +164,7 @@ nxt_shim_record(void)
      * syscall(), so this cannot recurse back into the shim.
      */
 
-    fd = open(nxt_record_path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+    fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
 
     if (fd < 0) {
         return;
@@ -149,6 +207,36 @@ syscall(long number, ...)
      * Reading six arguments when the caller passed fewer yields
      * garbage in the unused ones, which the kernel ignores for every
      * syscall that does not declare them.
+     *
+     * ISO C calls that undefined (C17 7.16.1.1p2: va_arg with no
+     * actual next argument), and there is no portable fix -- a
+     * variadic forwarder cannot learn its own argument count, and
+     * re-declaring syscall() with a fixed prototype only trades this
+     * undefined behaviour for calling a function through an
+     * incompatible type.  It is left as-is deliberately, because the
+     * concrete behaviour is the one every implementation already
+     * depends on:
+     *
+     *   - glibc's syscall() is an assembly stub that unconditionally
+     *     moves six argument registers, and musl's is a fixed
+     *     seven-parameter C function.  Neither ever walks a va_list,
+     *     so both read exactly the slots this reads.
+     *   - The slots read are always mapped memory, on every ABI Unit
+     *     builds for.  On x86-64 SysV the first five come from the
+     *     register save area gcc/clang spill at entry and the sixth
+     *     from the caller's own frame via overflow_arg_area; on
+     *     aarch64 all seven fit the eight-register save area; on
+     *     32-bit ABIs the excess reads land in the caller's frame.
+     *     None of them can fault, and none of them is used: only
+     *     `number` decides what happens below.
+     *
+     * Whether the shim should install a real seccomp filter instead
+     * was weighed and rejected: a filter needs PR_SET_NO_NEW_PRIVS,
+     * after which it is inherited across both fork() and execve(), so
+     * every unitd child would see capget() fail too -- and the record
+     * file below, whose whole value is showing that only main was
+     * affected, could no longer say anything.  It would also filter
+     * capset() in the children, which is the call the drop depends on.
      */
 
     va_start(ap, number);
@@ -162,9 +250,45 @@ syscall(long number, ...)
 
 #ifdef SYS_capget
     if (number == SYS_capget && nxt_capget_errno != 0) {
-        nxt_shim_record();
+        nxt_shim_record(nxt_record_path);
         errno = nxt_capget_errno;
         return -1;
+    }
+
+    /*
+     * Only when a data pointer was passed: nxt_capability_linux_get_
+     * version() calls capget() with NULL to have the kernel rewrite the
+     * header, and answering that one locally would leave the header
+     * untouched and change what Unit thinks the kernel supports.
+     */
+    if (number == SYS_capget && nxt_capget_hold != 0 && (void *) a1 != NULL) {
+        struct __user_cap_data_struct  *d = (void *) a1;
+
+        memset(d, 0, 2 * sizeof(*d));
+
+        d[0].effective = nxt_capget_hold;
+        d[0].permitted = nxt_capget_hold;
+        d[0].inheritable = nxt_capget_hold;
+
+        return 0;
+    }
+#endif
+
+#ifdef SYS_capset
+    if (number == SYS_capset) {
+        /*
+         * Recorded first, then failed only if asked.  The record is
+         * who *tried* to drop, which is what the unfiltered run
+         * asserts on; failing afterwards keeps that meaning intact
+         * for the filtered run, where the point is which processes
+         * survive a denial and which refuse to start.
+         */
+        nxt_shim_record(nxt_capset_record_path);
+
+        if (nxt_capset_errno != 0) {
+            errno = nxt_capset_errno;
+            return -1;
+        }
     }
 #endif
 

--- a/test/syscalls/baseline-linux-glibc.txt
+++ b/test/syscalls/baseline-linux-glibc.txt
@@ -8,6 +8,7 @@ access
 arch_prctl
 bind
 brk
+capset
 chmod
 clone
 clone3

--- a/test/syscalls/baseline-linux-musl.txt
+++ b/test/syscalls/baseline-linux-musl.txt
@@ -7,6 +7,7 @@ accept4
 arch_prctl
 bind
 brk
+capset
 chmod
 clone
 close

--- a/test/syscalls/run-in-docker.sh
+++ b/test/syscalls/run-in-docker.sh
@@ -57,7 +57,13 @@ if [ "$LIBC" = glibc ]; then
              gcc make libc6-dev libpcre2-dev strace curl ca-certificates >/dev/null'
 else
     IMAGE=alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
-    INSTALL='apk add --no-cache gcc make musl-dev pcre2-dev strace curl >/dev/null'
+    # linux-headers, which musl-dev does not carry: <linux/capability.h> is
+    # what auto/capability probes for, and without it NXT_HAVE_LINUX_CAPABILITY
+    # is off, nxt_capability_specific_set() and nxt_capability_drop() compile
+    # to stubs, and this leg reports "no new syscalls" about a binary that has
+    # no capability handling in it at all.
+    INSTALL='apk add --no-cache gcc make musl-dev linux-headers pcre2-dev \
+             strace curl >/dev/null'
 fi
 
 command -v docker >/dev/null 2>&1 || die "docker not found"

--- a/test/test_capget_fallback.py
+++ b/test/test_capget_fallback.py
@@ -1,0 +1,344 @@
+"""Unit keeps running when a syscall filter denies capget().
+
+A hardened deployment -- a systemd "SystemCallFilter=" allowlist, a
+hand-written seccomp profile -- can make capget(2) fail for a non-root
+unitd.  Since 'capability: keep running when capget() is filtered' that
+is a warning rather than an outage for the two errnos such a filter
+conventionally returns, EPERM and ENOSYS; every other errno still
+aborts, because a privilege downgrade caused by a bug in Unit is worse
+than a hard failure.
+
+Reproducing a seccomp filter in a test would need privileges the suite
+does not have, so the errno is injected instead: src/nxt_capability.c
+calls the kernel through the nxt_capget() macro, which expands to
+glibc's syscall() wrapper, and that is an ordinary interposable symbol.
+test/capget_filter.c preloads a definition of it -- see that file for
+what it does and does not touch.
+
+Inheritance is accepted rather than papered over.  Unit's language
+modules are fork()ed, never exec()ed, so the application process
+inherits the shim already mapped and already armed -- the errno was
+read by the shim's constructor in the main process, long before the
+fork.  Clearing LD_PRELOAD from the application's "environment" would
+therefore disarm nothing; it would only hide the fact.
+
+That inheritance costs nothing, and the test proves it rather than
+asserting it: the shim appends the pid of every process whose capget()
+it failed to a record file, and the test requires that set to be
+exactly the unitd main process.  It can be, because
+nxt_capability_set() has a single caller, nxt_runtime_conf_init(),
+which runs in the main process before anything is forked.  For that
+record to be evidence and not an empty file, the shim keeps a copy of
+the record path rather than the getenv() pointer -- unitd overwrites
+the argv+environ block with its process title, so the pointer alone
+would leave every child unable to record anything at all.  See
+capget_filter.c.
+
+/proc/<pid>/environ deliberately plays no part in that proof.  It
+cannot: nxt_process_arguments() takes the contiguous argv+environ
+string area for the process title, so every Unit process has an
+environ region full of title text and NUL padding while the real
+environment lives on the heap.  Measured here, the main process shows
+the tail of its own argv and the application shows 4807 NUL bytes --
+LD_PRELOAD is invisible in both, in a run where the shim demonstrably
+ran in the main process.  What the application's /proc/<pid>/maps
+shows instead is the shim object itself, mapped, which is the thing
+that would actually matter.
+"""
+
+import errno
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from unit.http import HTTP1
+from unit.option import option
+from unit.utils import public_dir, waitforfiles
+
+client = HTTP1()
+
+WARNING = r'\[warn\].+capget\(\) failed.+capabilities are unknown'
+ALERT = r'\[alert\].+failed to get process capabilities'
+
+# The two errnos a syscall filter conventionally returns for a denied
+# call.  nxt_capability.c accepts both, so both belong in the test.
+FILTERED = [errno.EPERM, errno.ENOSYS]
+
+
+@pytest.fixture(scope='module', autouse=True)
+def requirements():
+    if option.system != 'Linux':
+        pytest.skip('capget() is Linux only')
+
+    if option.is_privileged:
+        pytest.skip('a root unitd never calls capget()')
+
+
+@pytest.fixture(scope='module')
+def shim(requirements):
+    """Build test/capget_filter.c into a preloadable object.
+
+    The suite has no convention for compiling C helpers -- nothing under
+    test/ builds any -- so rather than invent a build system this
+    compiles at test time with cc(1) and skips when there is none.
+
+    Depends on requirements() rather than trusting fixture ordering:
+    both are module-scoped, and the link needs -ldl, so on a platform
+    that should skip the build would otherwise fail first and turn the
+    skip into an error.
+    """
+    compiler = shutil.which('cc') or shutil.which('gcc')
+
+    if compiler is None:
+        pytest.skip('requires a C compiler')
+
+    source = f'{option.test_dir}/capget_filter.c'
+    outdir = tempfile.mkdtemp(prefix='unit-test-capget-')
+    library = f'{outdir}/capget_filter.so'
+
+    build = subprocess.run(
+        [compiler, '-shared', '-fPIC', '-O1', '-o', library, source, '-ldl'],
+        check=False,
+        capture_output=True,
+    )
+
+    assert build.returncode == 0, (
+        f'failed to build the capget shim:\n{build.stderr.decode()}'
+    )
+
+    yield library
+
+    shutil.rmtree(outdir, ignore_errors=True)
+
+
+class Unitd:
+    """A unitd of our own, since conftest's shared one has no way to
+    take an environment."""
+
+    def __init__(self, shim, errno):
+        builddir = f'{option.current_dir}/build'
+        self.unitd = f'{builddir}/sbin/unitd'
+
+        if not Path(self.unitd).is_file():
+            pytest.skip('could not find unitd')
+
+        self.dir = tempfile.mkdtemp(prefix='unit-test-capget-')
+        public_dir(self.dir)
+
+        Path(f'{self.dir}/state').mkdir()
+
+        self.log = f'{self.dir}/unit.log'
+        self.stderr = f'{self.dir}/stderr.log'
+        self.record = f'{self.dir}/capget.pids'
+        self.control = f'{self.dir}/control.unit.sock'
+        self.listener = f'{self.dir}/app.sock'
+        self.pidfile = f'{self.dir}/unit.pid'
+
+        env = os.environ.copy()
+
+        # Same UNIT_PYTHONHOME dance as conftest.unit_run(): PYTHONHOME
+        # must not be set for the pytest interpreter itself.
+        pythonhome = env.pop('UNIT_PYTHONHOME', None)
+        if pythonhome:
+            env['PYTHONHOME'] = pythonhome
+
+        env['LD_PRELOAD'] = shim
+        env['NXT_TEST_CAPGET_ERRNO'] = str(errno)
+        env['NXT_TEST_CAPGET_RECORD'] = self.record
+
+        # unitd's stderr is kept apart from unit.log on purpose.  The
+        # first warning is written from nxt_runtime_conf_init(), before
+        # nxt_runtime_log_files_create() dup2()s the log file over fd 2,
+        # so it can only land here; unit.log then holds exactly the copy
+        # nxt_runtime_start() repeats once the file exists.  Merging the
+        # two -- which is what conftest does -- would make it impossible
+        # to tell which of the two emissions a match came from.
+        self.stderr_file = open(self.stderr, 'w', encoding='utf-8')
+
+        self.process = subprocess.Popen(
+            [
+                self.unitd,
+                '--no-daemon',
+                '--modulesdir',
+                f'{builddir}/lib/unit/modules',
+                '--statedir',
+                f'{self.dir}/state',
+                '--pid',
+                self.pidfile,
+                '--log',
+                self.log,
+                '--control',
+                f'unix:{self.control}',
+                '--tmpdir',
+                self.dir,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=self.stderr_file,
+            start_new_session=True,
+            env=env,
+        )
+
+    def stop(self):
+        if self.process.poll() is None:
+            try:
+                os.killpg(self.process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+        self.process.wait(timeout=30)
+        self.stderr_file.close()
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def read(self, path):
+        return Path(path).read_text(encoding='utf-8', errors='ignore')
+
+    def filtered_pids(self):
+        if not Path(self.record).exists():
+            return set()
+
+        return {int(p) for p in self.read(self.record).split()}
+
+
+@pytest.fixture()
+def unitd_factory(shim):
+    started = []
+
+    def factory(errno):
+        instance = Unitd(shim, errno)
+        started.append(instance)
+        return instance
+
+    yield factory
+
+    for instance in started:
+        instance.stop()
+
+
+def app_conf(appdir):
+    """A one-line application that answers with its own pid, so the
+    /proc lookups below cannot land on the wrong process."""
+    modules = option.available['modules']
+
+    if 'python' in modules:
+        Path(f'{appdir}/wsgi_pid.py').write_text(
+            'import os\n'
+            '\n'
+            '\n'
+            'def application(environ, start_response):\n'
+            '    body = str(os.getpid()).encode()\n'
+            "    start_response('200 OK',"
+            " [('Content-Length', str(len(body)))])\n"
+            '    return [body]\n',
+            encoding='utf-8',
+        )
+
+        return {
+            "type": "python",
+            "processes": {"spare": 0},
+            "path": appdir,
+            "module": "wsgi_pid",
+        }
+
+    if 'php' in modules:
+        Path(f'{appdir}/index.php').write_text(
+            '<?php echo getmypid();\n', encoding='utf-8'
+        )
+
+        return {
+            "type": "php",
+            "processes": {"spare": 0},
+            "root": appdir,
+            "index": "index.php",
+        }
+
+    pytest.skip('requires the python or php module')
+
+
+def wait_for(path, pattern, timeout=150):
+    for _ in range(timeout):
+        if Path(path).exists():
+            found = re.search(pattern, Path(path).read_text(
+                encoding='utf-8', errors='ignore'), re.M)
+
+            if found is not None:
+                return found
+
+        time.sleep(0.1)
+
+    return None
+
+
+@pytest.mark.parametrize('filtered_errno', FILTERED, ids=errno.errorcode.get)
+def test_capget_filtered_keeps_running(shim, unitd_factory, filtered_errno):
+    unitd = unitd_factory(filtered_errno)
+
+    assert waitforfiles(unitd.control), (
+        f'unitd started; its stderr was:\n{unitd.read(unitd.stderr)}'
+    )
+
+    # The early copy, written before the log file exists.
+    assert re.search(WARNING, unitd.read(unitd.stderr), re.M), 'warn on stderr'
+
+    # The copy nxt_runtime_start() repeats into the log file itself.
+    # A daemonised unitd keeps no other trace of it.
+    assert wait_for(unitd.log, WARNING) is not None, 'warn in unit.log'
+    assert wait_for(unitd.log, r'router started') is not None, 'router started'
+
+    appdir = f'{unitd.dir}/app'
+    Path(appdir).mkdir()
+    conf = {
+        "listeners": {f'unix:{unitd.listener}': {"pass": "applications/app"}},
+        "applications": {"app": app_conf(appdir)},
+    }
+    public_dir(appdir)
+
+    resp = client.put(
+        url='/config',
+        sock_type='unix',
+        addr=unitd.control,
+        body=json.dumps(conf),
+    )
+    assert 'success' in resp['body'], 'configure'
+
+    resp = client.get(sock_type='unix', addr=unitd.listener)
+    assert resp['status'] == 200, 'application answers'
+
+    app_pid = int(resp['body'].strip())
+
+    # Capabilities were unknown, so setid stayed clear and the runtime
+    # never resolved credentials: the application runs as unitd's uid.
+    status = Path(f'/proc/{app_pid}/status').read_text(encoding='utf-8')
+    uid = re.search(r'^Uid:\s+(\d+)\s+(\d+)', status, re.M)
+    assert uid is not None, 'app Uid'
+    assert int(uid.group(2)) == os.geteuid(), 'app runs as unitd uid'
+
+    # The application inherited the shim -- fork() carries the mapping,
+    # armed, whatever the environment says afterwards ...
+    maps = Path(f'/proc/{app_pid}/maps').read_text(encoding='utf-8')
+    assert shim in maps, 'shim inherited by the application'
+
+    # ... and still only the main process ever had a capget() filtered,
+    # which is what makes the inheritance harmless.  Two entries: the
+    # version probe and the call that matters.
+    main_pid = int(unitd.read(unitd.pidfile).strip())
+    assert unitd.filtered_pids() == {main_pid}, 'only unitd asked'
+
+
+def test_capget_einval_still_fatal(unitd_factory):
+    unitd = unitd_factory(errno.EINVAL)
+
+    unitd.process.wait(timeout=30)
+    assert unitd.process.returncode != 0, 'unitd exits'
+
+    # nxt_runtime_conf_init() fails before the log file is created, so
+    # stderr is the only place this can be recorded.
+    assert not Path(unitd.log).exists(), 'no unit.log'
+    assert re.search(ALERT, unitd.read(unitd.stderr), re.M), 'alert on stderr'

--- a/test/test_capget_fallback.py
+++ b/test/test_capget_fallback.py
@@ -8,6 +8,48 @@ conventionally returns, EPERM and ENOSYS; every other errno still
 aborts, because a privilege downgrade caused by a bug in Unit is worse
 than a hard failure.
 
+The same shim also watches capset(2), which is how this file covers
+nxt_capability_drop() -- the drop every forked process performs at the
+tail of nxt_process_apply_creds().  Its effect cannot be tested here:
+the suite runs as an ordinary user with no capabilities, so "the
+application has none either" is true with or without the code.  What
+can be tested, and cannot pass by accident, is *which processes drop*.
+Main must not, because it binds listening sockets on every
+reconfiguration; the prototype must, because it is the ancestor of
+every worker; and the worker itself must not, because it inherits.
+A run with real capabilities to lose needs root, and lives in the
+freeunit-harness smoke test instead.
+
+The shim can deny capset(2) as well, which is the deployment a
+"SystemCallFilter=" allowlist actually produces -- a profile that omits
+capget() rarely keeps capset().  Unit answers that per process: the
+prototype refuses to start rather than fork workers that would inherit
+what it could not drop, while the router, controller and discovery warn
+and carry on, because they run no application code and killing them
+would be a respawn loop or a silent death.  Both halves are asserted in
+test_capset_filtered_refuses_the_application().
+
+The refusal is conditional on there being something to refuse over, and
+that is the harder half to test here, because a suite running as an
+ordinary user holds nothing.  So the shim can also make capget() report
+a set it does not have -- which is what lets the refusal be reached at
+all -- and the opposite case, a denied capset() with genuinely empty
+sets, gets its own test: it must serve, through either of the two
+readers nxt_capability_still_held() can answer from.
+
+One branch stays out of reach here, and is named rather than left to be
+found: the /proc/self/status reader reporting a *non-empty* set.  The
+refusal tests get their non-empty answer from the shim's fake capget(),
+because the procfs reader reads the kernel and the kernel will not lie
+for a suite that holds nothing; faking it would mean interposing open(),
+read() and fstatfs() as well, and that fstatfs() check exists precisely
+to stop a file being substituted for the real one.  What is covered
+unprivileged is that reader answering "empty" rather than "cannot tell"
+-- the parsing, the streaming and the fstatfs() check, all of which fail
+closed into a refusal if they break.  Only the final comparison needs a
+run with something genuinely held, under a filter that denies capget()
+and capset() together, which is the harness smoke test's ground.
+
 Reproducing a seccomp filter in a test would need privileges the suite
 does not have, so the errno is injected instead: src/nxt_capability.c
 calls the kernel through the nxt_capget() macro, which expands to
@@ -52,6 +94,7 @@ import os
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import time
@@ -68,6 +111,31 @@ client = HTTP1()
 WARNING = r'\[warn\].+capget\(\) failed.+capabilities are unknown'
 ALERT = r'\[alert\].+failed to get process capabilities'
 
+# nxt_capability_drop() when capset(2) is denied.  Deliberately matched on
+# the syscall alone and not on the sentence around it: this is the test's
+# proof that the injected failure reached Unit at all, and it has to hold on
+# both sides of the change it is a control for.  Wording that only the fixed
+# build emits would make the control fail for the wrong reason.
+CAPSET_WARNING = r'\[warn\].+capset\(\) failed'
+
+# The two lines the refusal writes: one from the prototype that would have
+# forked the workers, one from the router that was waiting for it.
+REFUSED = r'\[alert\].+refused to start: capset\(\) is denied'
+START_FAILED = r"\[error\].+app '.+' start attempt produced no process"
+
+# nxt_capability_still_held() giving up -- neither capget() nor
+# /proc/self/status could say what the process holds.  Never expected in
+# this suite; asserted absent so that a test which reaches the "serves"
+# outcome cannot do so by way of a reader that silently broke.
+UNDETERMINED = r'capset\(\) failed.+could not be determined'
+
+# CAP_NET_BIND_SERVICE.  Handed to the shim so capget() reports a
+# non-empty set: the suite runs with no capabilities of its own, so
+# without this there is genuinely nothing to refuse over.  This
+# particular bit because nxt_capability_specific_set() ignores it --
+# unitd goes on behaving as the unprivileged process it really is.
+HELD = 1 << 10
+
 # The two errnos a syscall filter conventionally returns for a denied
 # call.  nxt_capability.c accepts both, so both belong in the test.
 FILTERED = [errno.EPERM, errno.ENOSYS]
@@ -80,6 +148,31 @@ def requirements():
 
     if option.is_privileged:
         pytest.skip('a root unitd never calls capget()')
+
+    # Everything below reaches unitd through LD_PRELOAD, and everything
+    # below reasons about capabilities this process can see.  A set-id bit
+    # or a file capability on the binary breaks both at once: glibc treats
+    # the exec as secure and drops LD_PRELOAD, so the shim never arms, and
+    # the spawned unitd gets capabilities the pytest process does not have,
+    # which would make the "nothing is held" premise a statement about the
+    # wrong process.  Neither is true of an ordinary build, but "ordinary"
+    # is the sort of thing worth checking rather than assuming.
+    unitd = Path(f'{option.current_dir}/build/sbin/unitd')
+
+    if unitd.is_file():
+        if unitd.stat().st_mode & (stat.S_ISUID | stat.S_ISGID):
+            pytest.skip('unitd is set-id; LD_PRELOAD would be dropped')
+
+        try:
+            os.getxattr(unitd, 'security.capability')
+
+        except OSError:
+            pass  # The ordinary case: no file capabilities.
+
+        else:
+            pytest.skip(
+                'unitd has file capabilities; LD_PRELOAD would be dropped'
+            )
 
 
 @pytest.fixture(scope='module')
@@ -123,7 +216,7 @@ class Unitd:
     """A unitd of our own, since conftest's shared one has no way to
     take an environment."""
 
-    def __init__(self, shim, errno):
+    def __init__(self, shim, errno, capset_errno=0, capget_hold=0):
         builddir = f'{option.current_dir}/build'
         self.unitd = f'{builddir}/sbin/unitd'
 
@@ -138,6 +231,7 @@ class Unitd:
         self.log = f'{self.dir}/unit.log'
         self.stderr = f'{self.dir}/stderr.log'
         self.record = f'{self.dir}/capget.pids'
+        self.capset_record = f'{self.dir}/capset.pids'
         self.control = f'{self.dir}/control.unit.sock'
         self.listener = f'{self.dir}/app.sock'
         self.pidfile = f'{self.dir}/unit.pid'
@@ -153,6 +247,15 @@ class Unitd:
         env['LD_PRELOAD'] = shim
         env['NXT_TEST_CAPGET_ERRNO'] = str(errno)
         env['NXT_TEST_CAPGET_RECORD'] = self.record
+        env['NXT_TEST_CAPSET_RECORD'] = self.capset_record
+
+        # Only when asked, so the tests that do not deny capset() run
+        # with exactly the environment they ran with before.
+        if capset_errno:
+            env['NXT_TEST_CAPSET_ERRNO'] = str(capset_errno)
+
+        if capget_hold:
+            env['NXT_TEST_CAPGET_HOLD'] = f'{capget_hold:x}'
 
         # unitd's stderr is kept apart from unit.log on purpose.  The
         # first warning is written from nxt_runtime_conf_init(), before
@@ -201,18 +304,24 @@ class Unitd:
         return Path(path).read_text(encoding='utf-8', errors='ignore')
 
     def filtered_pids(self):
-        if not Path(self.record).exists():
+        return self.recorded_pids(self.record)
+
+    def capset_pids(self):
+        return self.recorded_pids(self.capset_record)
+
+    def recorded_pids(self, path):
+        if not Path(path).exists():
             return set()
 
-        return {int(p) for p in self.read(self.record).split()}
+        return {int(p) for p in self.read(path).split()}
 
 
 @pytest.fixture()
 def unitd_factory(shim):
     started = []
 
-    def factory(errno):
-        instance = Unitd(shim, errno)
+    def factory(errno, capset_errno=0, capget_hold=0):
+        instance = Unitd(shim, errno, capset_errno, capget_hold)
         started.append(instance)
         return instance
 
@@ -262,11 +371,37 @@ def app_conf(appdir):
     pytest.skip('requires the python or php module')
 
 
+def caps_of(pid='self'):
+    """The four capability sets of a process, as integers.
+
+    CapAmb needs Linux 4.3 and CapInh has been there forever, but read
+    both defensively: a set the file does not name reads as empty, which
+    is the answer that cannot make a test pass by accident here.
+    """
+    status = Path(f'/proc/{pid}/status').read_text(encoding='utf-8')
+    caps = {}
+
+    for name in ('CapInh', 'CapPrm', 'CapEff', 'CapAmb'):
+        found = re.search(rf'^{name}:\s+([0-9a-f]+)', status, re.M)
+        caps[name] = int(found.group(1), 16) if found is not None else 0
+
+    return caps
+
+
+def count_matches(path, pattern):
+    if not Path(path).exists():
+        return 0
+
+    text = Path(path).read_text(encoding='utf-8', errors='ignore')
+
+    return len(re.findall(pattern, text, re.M))
+
+
 def wait_for(path, pattern, timeout=150):
     for _ in range(timeout):
         if Path(path).exists():
-            found = re.search(pattern, Path(path).read_text(
-                encoding='utf-8', errors='ignore'), re.M)
+            text = Path(path).read_text(encoding='utf-8', errors='ignore')
+            found = re.search(pattern, text, re.M)
 
             if found is not None:
                 return found
@@ -292,21 +427,7 @@ def test_capget_filtered_keeps_running(shim, unitd_factory, filtered_errno):
     assert wait_for(unitd.log, WARNING) is not None, 'warn in unit.log'
     assert wait_for(unitd.log, r'router started') is not None, 'router started'
 
-    appdir = f'{unitd.dir}/app'
-    Path(appdir).mkdir()
-    conf = {
-        "listeners": {f'unix:{unitd.listener}': {"pass": "applications/app"}},
-        "applications": {"app": app_conf(appdir)},
-    }
-    public_dir(appdir)
-
-    resp = client.put(
-        url='/config',
-        sock_type='unix',
-        addr=unitd.control,
-        body=json.dumps(conf),
-    )
-    assert 'success' in resp['body'], 'configure'
+    assert 'success' in configure_app(unitd)['body'], 'configure'
 
     resp = client.get(sock_type='unix', addr=unitd.listener)
     assert resp['status'] == 200, 'application answers'
@@ -320,6 +441,40 @@ def test_capget_filtered_keeps_running(shim, unitd_factory, filtered_errno):
     assert uid is not None, 'app Uid'
     assert int(uid.group(2)) == os.geteuid(), 'app runs as unitd uid'
 
+    # The application holds no capabilities at all -- inheritable
+    # included, which is the one set nxt_capability_still_held() does not
+    # count but nxt_capability_drop() does still empty.  On a suite that
+    # runs without any to begin with the other three cannot fail, which
+    # is why they are not the real assertion; see the capset()
+    # bookkeeping below.  CapInh is not in that position: this host may
+    # well have one, and the drop is what clears it.
+    for name, value in caps_of(app_pid).items():
+        assert value == 0, f'app {name}'
+
+    # The real assertion: nxt_capability_drop() ran, and ran in exactly
+    # the processes it is supposed to.  Unlike the zeroes above, none of
+    # this can pass by accident -- on the commit before this one the
+    # file does not exist at all.
+    main_pid = int(unitd.read(unitd.pidfile).strip())
+    proto_pid = int(
+        re.search(r'^PPid:\s+(\d+)', status, re.M).group(1)
+    )
+    dropped = unitd.capset_pids()
+
+    # Main must never drop: it binds listening sockets in
+    # nxt_main_listening_socket() on every reconfiguration and so needs
+    # CAP_NET_BIND_SERVICE for as long as it lives.
+    assert main_pid not in dropped, 'main keeps its capabilities'
+
+    # The prototype must, since it is the ancestor of every worker.
+    assert proto_pid in dropped, 'the prototype drops'
+
+    # The worker must not: nxt_app_setup() calls init->start directly
+    # without going through nxt_process_apply_creds(), so it inherits
+    # sets the prototype already emptied.  If that ever changes this
+    # assertion is the thing that says so.
+    assert app_pid not in dropped, 'the worker inherits rather than drops'
+
     # The application inherited the shim -- fork() carries the mapping,
     # armed, whatever the environment says afterwards ...
     maps = Path(f'/proc/{app_pid}/maps').read_text(encoding='utf-8')
@@ -328,7 +483,6 @@ def test_capget_filtered_keeps_running(shim, unitd_factory, filtered_errno):
     # ... and still only the main process ever had a capget() filtered,
     # which is what makes the inheritance harmless.  Two entries: the
     # version probe and the call that matters.
-    main_pid = int(unitd.read(unitd.pidfile).strip())
     assert unitd.filtered_pids() == {main_pid}, 'only unitd asked'
 
 
@@ -342,3 +496,190 @@ def test_capget_einval_still_fatal(unitd_factory):
     # stderr is the only place this can be recorded.
     assert not Path(unitd.log).exists(), 'no unit.log'
     assert re.search(ALERT, unitd.read(unitd.stderr), re.M), 'alert on stderr'
+
+
+def configure_app(unitd):
+    """Load a one-process application and return the config response."""
+    appdir = f'{unitd.dir}/app'
+    Path(appdir).mkdir()
+    public_dir(appdir)
+
+    conf = {
+        "listeners": {f'unix:{unitd.listener}': {"pass": "applications/app"}},
+        "applications": {"app": app_conf(appdir)},
+    }
+
+    return client.put(
+        url='/config',
+        sock_type='unix',
+        addr=unitd.control,
+        body=json.dumps(conf),
+    )
+
+
+@pytest.mark.parametrize('filtered_errno', FILTERED, ids=errno.errorcode.get)
+def test_capset_filtered_refuses_the_application(
+    shim, unitd_factory, filtered_errno
+):
+    """A denied capset() with capabilities still held must refuse.
+
+    This is the deployment the whole file is about, taken one step
+    further: a "SystemCallFilter=" allowlist that omits capget() rarely
+    keeps capset(), so the fallback that lets unitd start lands in a
+    prototype that then cannot give up what it holds.  Warning and
+    continuing there would hand unitd's capabilities to application
+    code -- silently, since the operator asked for neither.
+
+    The refusal is deliberately not made inside nxt_capability_drop().
+    That function is also on the router's, the controller's and
+    discovery's path through nxt_process_core_setup(), and those three
+    run no application code: router and controller are re-forked
+    immediately and without backoff, so refusing there would be a
+    respawn loop, and discovery notifies nobody when it dies.  Both
+    halves are asserted below -- unitd comes up and stays up, and only
+    the application start fails.
+    """
+    unitd = unitd_factory(0, capset_errno=filtered_errno, capget_hold=HELD)
+
+    assert waitforfiles(unitd.control), (
+        f'unitd started; its stderr was:\n{unitd.read(unitd.stderr)}'
+    )
+
+    # The injected failure reached Unit, and nxt_capability_still_held()
+    # found something to refuse over -- without both, the rest of this
+    # test could pass against a shim that never fired.  And the core
+    # processes met the same denial in nxt_process_core_setup() and
+    # carried on: the controller is answering on the socket above and the
+    # router logged its own start line.
+    assert wait_for(unitd.log, CAPSET_WARNING) is not None, 'capset denied'
+    assert wait_for(unitd.log, r'router started') is not None, 'router started'
+
+    assert 'success' in configure_app(unitd)['body'], 'configure'
+
+    # The application does not serve.  503 rather than a hang: the
+    # prototype exits, main's SIGCHLD reaper notifies the router with the
+    # start's stream still attached, and the router fails the requests
+    # parked on the application instead of letting them time out.
+    resp = client.get(sock_type='unix', addr=unitd.listener)
+    assert resp['status'] == 503, 'application refused'
+
+    # Both ends of that route say so above debug level, which is what an
+    # operator sees in a default configuration: the prototype names the
+    # syscall and the consequence, the router names the application.
+    assert wait_for(unitd.log, REFUSED) is not None, 'prototype refuses'
+    assert wait_for(unitd.log, START_FAILED) is not None, 'router reports'
+
+    # No respawn loop.  Nothing in Unit re-arms a start on its own --
+    # every nxt_router_start_app_process() call site is driven by a
+    # request, a port becoming ready or a configuration change -- so
+    # after the one attempt above the count must stay where it is.
+    refusals = count_matches(unitd.log, REFUSED)
+    assert refusals == 1, 'exactly one attempt'
+
+    time.sleep(2)
+    assert count_matches(unitd.log, REFUSED) == refusals, 'no retry on its own'
+
+    # unitd itself is unharmed, which is the half that would have been
+    # lost by refusing inside nxt_capability_drop().
+    assert unitd.process.poll() is None, 'unitd still running'
+    resp = client.get(url='/config', sock_type='unix', addr=unitd.control)
+    assert resp['status'] == 200, 'controller still answering'
+
+    # The failure is stable rather than latched: a second request makes a
+    # second attempt, and that attempt fails the same way.  Only the 503
+    # is asserted -- whether Unit remembers the refusal or repeats it is
+    # an implementation choice this test does not fix.
+    resp = client.get(sock_type='unix', addr=unitd.listener)
+    assert resp['status'] == 503, 'still refused'
+
+    # Main must still never appear among the processes that tried to
+    # drop, filter or no filter.
+    main_pid = int(unitd.read(unitd.pidfile).strip())
+    tried = unitd.capset_pids()
+    assert tried, 'somebody tried to drop'
+    assert main_pid not in tried, 'main never tries'
+
+
+# Which reader nxt_capability_still_held() has to answer from: capget()
+# when the filter left it alone, /proc/self/status when it did not.
+READERS = {'capget': 0, 'proc': errno.EPERM}
+
+
+@pytest.mark.parametrize('reader', READERS)
+def test_capset_filtered_serves_when_nothing_is_held(
+    shim, unitd_factory, reader
+):
+    """A denied capset() with nothing to drop must not refuse anything.
+
+    The refusal above is conditional on actually holding something, and
+    that condition is not decoration.  Both of the commonest deployments
+    reach nxt_capability_drop() with every set already empty: a root
+    unitd, because switching away from uid 0 clears them, and an
+    ordinary unprivileged unitd, because it was never granted anything.
+    A filter that denies capset() in either of those denies a call that
+    had nothing left to do, and refusing over it would take every
+    application down for no security benefit whatsoever.
+
+    Both readers are exercised, because they cover different filters and
+    a broken one fails the same way in each: silently, by returning "I
+    cannot tell", which is treated as a refusal.  That is why the
+    absence of the "could not be determined" warning is asserted rather
+    than assumed -- without it this test would still pass with both
+    readers removed, on the strength of a refusal that never happened.
+    """
+    # The premise, stated rather than inherited from whatever the host
+    # happens to be.  unitd is about to be forked from this process, so
+    # "nothing is held" is a property of this process, and the reader is
+    # going to read it back through whichever of the two legs is under
+    # test.  Without this the test says only "the host agreed with us
+    # today": on a runner with empty sets it passes for the right reason,
+    # and on a host that does hold something it would fail with a 503 and
+    # no clue as to why.
+    caps = caps_of()
+    held = {
+        name: caps[name]
+        for name in ('CapPrm', 'CapEff', 'CapAmb')
+        if caps[name] != 0
+    }
+
+    if held:
+        pytest.skip(f'the test process holds capabilities: {held}')
+
+    # CapInh is deliberately not in that list, and this is the test that
+    # says so.  An inheritable bit confers nothing without an execve() of
+    # a file carrying a matching one, so nxt_capability_still_held() does
+    # not count it -- and a desktop with pam_cap or a container runtime in
+    # the picture commonly has one, which is exactly the host where
+    # counting it would refuse every application for nothing.  This run is
+    # only evidence of that when the bit is actually set, so record which
+    # kind of host produced the result.
+    print(f'\nCapInh of the test process: {caps["CapInh"]:016x}')
+
+    unitd = unitd_factory(READERS[reader], capset_errno=errno.EPERM)
+
+    assert waitforfiles(unitd.control), (
+        f'unitd started; its stderr was:\n{unitd.read(unitd.stderr)}'
+    )
+    assert wait_for(unitd.log, r'router started') is not None, 'router started'
+
+    assert 'success' in configure_app(unitd)['body'], 'configure'
+
+    resp = client.get(sock_type='unix', addr=unitd.listener)
+    assert resp['status'] == 200, 'application serves'
+
+    log = unitd.read(unitd.log)
+    assert re.search(UNDETERMINED, log, re.M) is None, 'the reader answered'
+    assert re.search(REFUSED, log, re.M) is None, 'nothing was refused'
+
+    # And the drop still happened where it always does, so the reader is
+    # not being consulted in place of the capset() itself.
+    proto_pid = int(
+        re.search(
+            r'^PPid:\s+(\d+)',
+            Path(f'/proc/{int(resp["body"].strip())}/status').read_text(
+                encoding='utf-8'
+            ),
+            re.M,
+        ).group(1)
+    )
+    assert proto_pid in unitd.capset_pids(), 'the prototype still tried'


### PR DESCRIPTION
`unitd` refused to start whenever the `capget()` syscall was denied: a
non-root process got `[alert] failed to get process capabilities` and
exited. A syscall filter that omits `capget` is the trigger — a systemd
`SystemCallFilter=` allowlist, a `bwrap --seccomp` sandbox, or a
hand-written OCI profile on a runtime that does not itself need the call.

Unit now warns and continues, assuming no capability.

## What this is, and what it is not

Hardening, not an adoption blocker. The claim that Docker's default seccomp
profile blocks `capget` — recorded as a P0 in the internal audit matrix —
**is false and this PR supersedes it**: Moby's `default.json` allows
`capget` by name (so it is arch-independent), a profile that denies it kills
`runc` before `unitd` ever runs, and the official image runs as root, where
`nxt_capability_set()` short-circuits and never calls `capget` at all. No
such failure was ever reported against this project or upstream. The
correction to the KB is written up separately in `kb-correction-capget-a4.md`.

Design and verification notes: `plan-capget-fallback.md`.

## The errno set is deliberately narrow

Only `EPERM` and `ENOSYS` — the signatures a filter reports through
`SECCOMP_RET_ERRNO` — fall through to the warning. Every other errno keeps
the alert and the non-zero exit, because `EINVAL` or `EFAULT` means the call
itself is malformed: a bug in Unit rather than a policy decision by the
operator, and failing closed is right there.

An unconditional "unknown means none" would have been wrong. With
`setid == 0` the runtime never resolves credentials and never calls
`setgid()`/`setuid()`, and an application's `user` is only string-compared
against `--user`, so a `unitd` that genuinely held `CAP_SETUID` with
`capget` filtered would run every application as its own uid while the
configuration said otherwise — a silent downgrade.

## The warning has to survive daemonisation

`nxt_capability_set()` runs from `nxt_runtime_conf_init()`, before
`nxt_runtime_start()` opens the log file, so on its own the warning reaches
stderr only and a daemonised `unitd` — the normal deployment — would record
nothing at all. A flag on the capabilities carries the fact forward and the
warning is repeated once `unit.log` exists. Both wordings are otherwise
identical.

The neighbouring "Unit is running unprivileged" warning has the same gap and
is deliberately left alone: it reports a configuration, not a capability the
process could not observe.

## Residual

Capabilities the process may still hold are **not** dropped — Unit does not
call `capset()`. Dropping them here was considered and rejected: `capset()`
in the main process would strip `CAP_NET_BIND_SERVICE` before
`nxt_main_listening_socket()` binds, so a non-root `unitd` with
`AmbientCapabilities=CAP_NET_BIND_SERVICE` plus a filter — which is the only
real trigger for this code path — would start and then fail to bind :80.
That would be a worse outcome than the bug being fixed.

The right place for that is the application child after `fork()`, where the
listeners are already inherited and the application needs no capabilities.
Tracked as its own item (`plan-capget-fallback.md` §4 item 5) with its own
review; the smoke script already asserts the current residual, so that work
turns an assertion documenting the gap into one guarding the fix.

## Verification

Reproducing this needs a real seccomp filter: pytest cannot mock syscalls,
and a Docker seccomp profile denying `capget` kills `runc` first. The
wrapper used here lives in the contributor harness (`tools/secexec.c`,
`tools/capget-probe.c`, `tools/capget-fallback-smoke.sh`) and is submitted
separately.

Under a filter, non-root, in a container on an x86_64 build host:

| errno | result |
|---|---|
| `EPERM` | warns on stderr and in `unit.log`, `router started`, serves |
| `ENOSYS` | same |
| `EINVAL` | `[alert] failed to get process capabilities` and exit — fail-closed intact |
| unfiltered | unchanged: no warning, capabilities detected as before |

The `unit.log` line, verbatim:

    [warn] capget() failed; process capabilities are unknown and will not be
    used: user and group switching and "rootfs" isolation are disabled for
    applications that do not enable the "credential" namespace, and
    applications run as uid 1000

Independently reproduced with a PHP application on a second machine: the
application reports `uid=1000` via `posix_geteuid()` under both errnos.

Capability detection on the unfiltered path is unchanged, checked as an A/B
against the base commit as a non-root process with and without ambient
`CAP_SETUID`/`CAP_SETGID`: both the `setid=0` and `setid=1` outcomes are
identical between the two binaries. `test_python_isolation.py`,
`test_python_isolation_chroot.py`, `test_go_isolation_rootfs.py` and
`test_java_isolation_rootfs.py` were run against base and patched in the
same container with identical results; note that a root run does not
exercise this code at all, since `geteuid() == 0` short-circuits before
`capget()`.

## Changelog

`CHANGES` and `docs/changes.xml` carry a single `apply="unit"` stanza for
1.36.2, following `6a8e80f9`, which added the equivalent stanza for 1.36.1
mid-cycle. The per-module stanza is added at release cut, when
`grep -c 'ver="1.36.2"'` must become 2 or the module packages fail to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Follow-up commits (pushed 2026-08-30):**
- `7ca2d99b` test: in-suite pytest exercising the fallback via an `LD_PRELOAD` shim on glibc's `syscall()` (EPERM and ENOSYS keep running; EINVAL still fatal). Proven to fail on the base tree; the shim's pid record is `strdup`'d because `nxt_process_title()` overwrites the environ block in every forked child.
- `fd8ddb69` docs: companion per-module `changes.xml` stanza for 1.36.2 (`grep -c 'ver="1.36.2"'` = 2), so module .deb builds don't break at the version bump.
- `e38fdf80` ci: run that test without sudo in the python leg — under `sudo` the whole suite is privileged and the test was silently skipped everywhere.
