### PR TITLE
router: clear proto_port_requests when a prototype start fails

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -181,6 +181,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_new_port_test.c \
     src/test/nxt_router_start_fail_test.c \
     src/test/nxt_router_start_fail_soak_test.c \
+    src/test/nxt_router_proto_wedge_test.c \
     src/test/nxt_port_change_file_test.c \
     src/test/nxt_port_fd_test.c \
 "

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -229,7 +229,8 @@ static void nxt_router_app_port_ready(nxt_task_t *task,
     nxt_port_recv_msg_t *msg, void *data);
 static void nxt_router_app_port_error(nxt_task_t *task,
     nxt_port_recv_msg_t *msg, void *data);
-static void nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app);
+static void nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app,
+    uint32_t count);
 
 static void nxt_router_app_use(nxt_task_t *task, nxt_app_t *app, int i);
 static void nxt_router_app_unlink(nxt_task_t *task, nxt_app_t *app);
@@ -503,7 +504,7 @@ failed:
         nxt_mp_free(b->data, b);
     }
 
-    nxt_router_app_start_failed(task, app);
+    nxt_router_app_start_failed(task, app, 1);
 
 skip:
 
@@ -5054,6 +5055,7 @@ static void
 nxt_router_app_port_error(nxt_task_t *task, nxt_port_recv_msg_t *msg,
     void *data)
 {
+    uint32_t             n;
     nxt_app_t            *app;
     nxt_app_joint_t      *app_joint;
     nxt_app_joint_rpc_t  *app_joint_rpc;
@@ -5077,19 +5079,56 @@ nxt_router_app_port_error(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 
     nxt_debug(task, "app '%V' %p start error", &app->name, app);
 
-    nxt_router_app_start_failed(task, app);
+    if (app_joint_rpc->proto) {
+        /*
+         * The prototype this RPC was armed for will never arrive, and only
+         * nxt_router_app_port_ready() clears proto_port_requests.  Left set,
+         * it makes every later nxt_router_start_app_process_handler() call
+         * for this application take the "wait for prototype process" branch
+         * and park without sending anything -- so no further port_ready or
+         * port_error can ever fire to clear it.  Only replacing the
+         * nxt_app_t recovers, and a reload does that only when the
+         * application's own config text changes.  Clear it here, and
+         * release the slots of the whole parked cohort: the initiator's,
+         * plus one for each caller that joined the wait.  This mirrors
+         * port_ready(), which takes the same count and replays that many
+         * starts on success.
+         */
+
+        nxt_thread_mutex_lock(&app->mutex);
+
+        n = app->proto_port_requests;
+        app->proto_port_requests = 0;
+
+        nxt_thread_mutex_unlock(&app->mutex);
+
+        /*
+         * The counter is incremented in the same branch that sets ->proto,
+         * so an armed prototype RPC always owns at least its own slot.
+         */
+        nxt_assert(n != 0);
+
+    } else {
+        n = 1;
+    }
+
+    nxt_router_app_start_failed(task, app, n);
 }
 
 
 /*
- * A start attempt that will never yield a port: give back the
- * pending_processes slot its initiator took and, if the application is left
- * with no way to answer at all, fail the requests waiting for an
- * acknowledgement instead of letting them sit until they time out.
+ * A start attempt that will never yield a port: give back the "count"
+ * pending_processes slots it owns and, if the application is left with no way
+ * to answer at all, fail the requests waiting for an acknowledgement instead
+ * of letting them sit until they time out.
+ *
+ * "count" is 1 for an ordinary attempt, which owns only its initiator's slot.
+ * A failed prototype attempt owns the whole parked cohort: see
+ * nxt_router_app_port_error().
  */
 
 static void
-nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app)
+nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app, uint32_t count)
 {
     nxt_queue_link_t    *link;
     nxt_http_request_t  *r;
@@ -5098,9 +5137,20 @@ nxt_router_app_start_failed(nxt_task_t *task, nxt_app_t *app)
 
     nxt_thread_mutex_lock(&app->mutex);
 
-    nxt_assert(app->pending_processes != 0);
+    nxt_assert(app->pending_processes >= count);
 
-    app->pending_processes--;
+    /*
+     * The accounting above guarantees this, but nxt_assert() is nothing in a
+     * release build and the two directions are not equally bad: releasing one
+     * slot too few merely leaks it, while releasing one too many wraps the
+     * counter to UINT32_MAX and makes nxt_router_app_can_start() false
+     * forever -- a worse wedge than the one this path exists to clear.
+     */
+    if (nxt_slow_path(count > app->pending_processes)) {
+        count = app->pending_processes;
+    }
+
+    app->pending_processes -= count;
 
     if (app->processes == 0 && !nxt_queue_is_empty(&app->ack_waiting_req)) {
         link = nxt_queue_first(&app->ack_waiting_req);

--- a/src/test/nxt_router_proto_wedge_test.c
+++ b/src/test/nxt_router_proto_wedge_test.c
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for the prototype-start wedge: a prototype START_PROCESS
+ * RPC that resolves through nxt_router_app_port_error() instead of
+ * nxt_router_app_port_ready() used to leave app->proto_port_requests set.
+ *
+ * Only port_ready() cleared that counter, so once it was stranded every
+ * later nxt_router_start_app_process_handler() call for the application
+ * took the "wait for prototype process" branch at src/nxt_router.c:430 and
+ * parked without sending anything.  Nothing was left to send a prototype
+ * request, so no port_ready or port_error could fire to clear it: the
+ * application could never start another process for the router's lifetime,
+ * and a reload that left its config block unchanged reused the wedged
+ * nxt_app_t rather than replacing it.
+ *
+ * The stranded counter also stranded pending_processes.  Each parked caller
+ * holds one increment its initiator took, but port_error() released exactly
+ * one -- so a cohort of N parked callers leaked N-1 start slots on top of
+ * the wedge.
+ *
+ * The arrangement here is the one the router really uses: no prototype port
+ * yet, so the handler builds a START_PROCESS payload and arms an RPC with
+ * ->proto set; a second call then joins the wait.  Tearing the port's
+ * registrations down with nxt_port_rpc_close() drives the router's own
+ * error handler for the armed RPC, which is how a start that never answers
+ * is reported.  The test then requires what the wedge denied: the counter
+ * cleared, every slot in the cohort given back, and a later call actually
+ * sending a fresh prototype request instead of parking.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_rpc.h>
+#include <nxt_runtime.h>
+#include <nxt_router.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+
+/* File scope: the handler hands the application to the router's
+   reference-counting helpers, so its storage must outlive the frame. */
+static nxt_app_t  nxt_router_proto_wedge_test_app;
+
+
+nxt_int_t
+nxt_router_proto_wedge_test(nxt_thread_t *thr)
+{
+    nxt_mp_t            *mp;
+    nxt_app_t           *app;
+    nxt_int_t           ret;
+    nxt_bool_t          app_mutex;
+    nxt_task_t          *task;
+    nxt_port_t          *router_port, *main_port, *shared_port;
+    nxt_runtime_t       *rt, *saved_rt;
+    nxt_app_joint_t     *joint;
+    nxt_event_engine_t  engine, *saved_engine;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router proto wedge test started");
+
+    ret = NXT_ERROR;
+    router_port = NULL;
+    main_port = NULL;
+    shared_port = NULL;
+    joint = NULL;
+    app_mutex = 0;
+    app = &nxt_router_proto_wedge_test_app;
+
+    task = thr->task;
+    task->thread = thr;
+
+    if (nxt_slow_path(nxt_port_rpc_init() != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    joint = nxt_mp_zalloc(mp, sizeof(nxt_app_joint_t));
+    if (nxt_slow_path(rt == NULL || joint == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * The prototype branch allocates its payload from
+     * task->thread->engine->mem_pool.  Only the members the reached code
+     * touches are set; see src/test/nxt_router_new_port_test.c.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+    thr->runtime = rt;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    /* The port the handler registers its RPC on. */
+
+    router_port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    /*
+     * nxt_port_rpc_register_handler_ex() asserts on a live pair[0]; the
+     * descriptor is never touched here, so borrow the nxt_port_fail_test()
+     * convention of a placeholder that is reset before the port is freed.
+     */
+    router_port->pair[0] = 0;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * A prototype start addresses the main process.  No queue and
+     * write_ready unset, so nxt_port_socket_write2() takes the
+     * nxt_port_msg_chk_insert() path and the message is simply queued:
+     * the write succeeds and the RPC stays armed, which is what this test
+     * needs.
+     */
+
+    main_port = nxt_port_new(task, 1, nxt_pid, NXT_PROCESS_MAIN);
+    if (nxt_slow_path(main_port == NULL)) {
+        goto done;
+    }
+
+    main_port->pair[0] = -1;
+    main_port->pair[1] = -1;
+    main_port->socket.fd = -1;
+
+    rt->port_by_type[NXT_PROCESS_MAIN] = main_port;
+
+    /* Only its two descriptors are read, and both travel as -1. */
+
+    shared_port = nxt_port_new(task, 2, nxt_pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(shared_port == NULL)) {
+        goto done;
+    }
+
+    shared_port->pair[0] = -1;
+    shared_port->pair[1] = -1;
+    shared_port->socket.fd = -1;
+    shared_port->queue_fd = -1;
+
+    nxt_memzero(app, sizeof(nxt_app_t));
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&app->mutex) != NXT_OK)) {
+        goto done;
+    }
+
+    app_mutex = 1;
+
+    nxt_queue_init(&app->ports);
+    nxt_queue_init(&app->spare_ports);
+    nxt_queue_init(&app->idle_ports);
+    nxt_queue_init(&app->ack_waiting_req);
+
+    nxt_str_set(&app->name, "proto-wedge-test");
+
+    app->joint = joint;
+    joint->app = app;
+    joint->use_count = 1;
+
+    app->shared_port = shared_port;
+    app->max_processes = 8;
+    app->max_pending_processes = 4;
+
+    /* No prototype port yet: the next call starts one. */
+    app->proto_port = NULL;
+
+    /* One process alive, so the failure path has no requests to fail. */
+    app->processes = 1;
+
+    /* What a real initiator leaves behind: the slot and the work's use. */
+    app->pending_processes = 1;
+    app->use_count = 2;
+
+    nxt_router_start_app_process_handler(task, router_port, app);
+
+    if (app->proto_port_requests != 1 || joint->use_count != 2
+        || app->use_count != 1)
+    {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto wedge test: prototype start left "
+                      "proto_port_requests %uD joint %uD app use %d "
+                      "(expected 1, 2 and 1)",
+                      app->proto_port_requests, joint->use_count,
+                      (int) app->use_count);
+        goto done;
+    }
+
+    /*
+     * A second caller finds the request already in flight and joins the
+     * wait, adding its own initiator increment to both counters.
+     */
+
+    app->pending_processes = 2;
+    app->use_count = 2;
+
+    nxt_router_start_app_process_handler(task, router_port, app);
+
+    if (app->proto_port_requests != 2 || joint->use_count != 2
+        || app->use_count != 1)
+    {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto wedge test: parked caller left "
+                      "proto_port_requests %uD joint %uD app use %d "
+                      "(expected 2, 2 and 1)",
+                      app->proto_port_requests, joint->use_count,
+                      (int) app->use_count);
+        goto done;
+    }
+
+    /*
+     * The prototype never answers.  Closing the port's registrations drives
+     * nxt_router_app_port_error() for the armed RPC -- the wedge is what it
+     * used to leave behind.
+     */
+
+    nxt_port_rpc_close(task, router_port);
+
+    if (app->proto_port_requests != 0) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto wedge test: failed prototype left "
+                      "proto_port_requests %uD (expected 0)",
+                      app->proto_port_requests);
+        goto done;
+    }
+
+    if (app->pending_processes != 0 || joint->use_count != 1) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto wedge test: failed prototype left "
+                      "pending %uD joint %uD (expected 0 and 1)",
+                      app->pending_processes, joint->use_count);
+        goto done;
+    }
+
+    /*
+     * The behaviour the wedge denied: with no prototype port and the
+     * counter clear, a later call must send a fresh prototype request --
+     * arming an RPC and taking a joint reference -- rather than parking in
+     * the wait branch, which takes neither.
+     */
+
+    app->pending_processes = 1;
+    app->use_count = 2;
+
+    nxt_router_start_app_process_handler(task, router_port, app);
+
+    if (app->proto_port_requests != 1 || joint->use_count != 2
+        || app->use_count != 1)
+    {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto wedge test: app wedged after a failed "
+                      "prototype, proto_port_requests %uD joint %uD "
+                      "app use %d (expected 1, 2 and 1)",
+                      app->proto_port_requests, joint->use_count,
+                      (int) app->use_count);
+        goto done;
+    }
+
+    /* Release the second armed RPC the same way. */
+
+    nxt_port_rpc_close(task, router_port);
+
+    if (app->pending_processes != 0 || joint->use_count != 1
+        || app->proto_port_requests != 0)
+    {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto wedge test: second release left pending "
+                      "%uD joint %uD proto_port_requests %uD "
+                      "(expected 0, 1 and 0)",
+                      app->pending_processes, joint->use_count,
+                      app->proto_port_requests);
+        goto done;
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router proto wedge test passed");
+
+    ret = NXT_OK;
+
+done:
+
+    if (shared_port != NULL) {
+        nxt_port_use(task, shared_port, -1);
+    }
+
+    if (main_port != NULL) {
+        rt->port_by_type[NXT_PROCESS_MAIN] = NULL;
+
+        /*
+         * Both prototype requests were queued rather than written, and
+         * nxt_port_msg_chk_insert() takes a port reference for each.  Left
+         * alone the port never reaches nxt_port_mp_cleanup(), so its pool
+         * and messages leak and the assertions there never run -- which
+         * would quietly hollow out this test under a debug build.
+         */
+        nxt_port_test_run_error_handler(task, main_port);
+
+        if (!nxt_queue_is_empty(&main_port->messages)) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router proto wedge test: main port still holds "
+                          "queued messages after teardown");
+            ret = NXT_ERROR;
+        }
+
+        nxt_port_use(task, main_port, -1);
+    }
+
+    if (router_port != NULL) {
+        router_port->pair[0] = -1;
+
+        nxt_port_use(task, router_port, -1);
+    }
+
+    thr->engine = saved_engine;
+    thr->runtime = saved_rt;
+
+    if (app_mutex) {
+        nxt_thread_mutex_destroy(&app->mutex);
+    }
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -209,6 +209,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_router_proto_wedge_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -76,6 +76,7 @@ nxt_int_t nxt_port_ready_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_soak_test(nxt_thread_t *thr);
+nxt_int_t nxt_router_proto_wedge_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);


### PR DESCRIPTION
## The bug

A prototype `START_PROCESS` that resolves through `nxt_router_app_port_error()` instead of
`nxt_router_app_port_ready()` left `app->proto_port_requests` set, and nothing else ever cleared it.

Only the success path reset the counter. The error path never referenced it, and did not even branch
on `app_joint_rpc->proto`. Once the counter was stranded, every later
`nxt_router_start_app_process_handler()` call for that application took the "wait for prototype
process" branch and parked without sending anything — so nothing remained that could produce another
`port_ready` or `port_error` to clear it.

The application could then never start another process for the router's lifetime. Recovery needs the
`nxt_app_t` itself replaced: a fresh one is allocated only when the application's own config text
changes, so **a reload that leaves the block byte-identical reuses the wedged struct**. "restart
application" bumps `app->generation` and QUITs an existing `proto_port`, but never touches
`proto_port_requests` — and a wedged app has no prototype to QUIT in the first place.

### The counter was not the only casualty

Every caller parked in the wait branch holds one `app->pending_processes` increment, taken by its
initiator before the work was posted. The error path released exactly one, so a cohort of N parked
callers leaked N-1 start slots on top of the wedge. That is the same counter #214 leaked, and it
gates every future start.

## The fix

Branch on `app_joint_rpc->proto` in `nxt_router_app_port_error()`: read and zero
`proto_port_requests` under `app->mutex`, and release that many `pending_processes` slots. This
mirrors the success path, which takes the same count and replays that many starts; the error path
fails them instead.

`nxt_router_app_start_failed()` grows a `count` parameter for it, and the ordinary callers pass 1 —
what they owned before. It also clamps `count` to the counter: the accounting cannot exceed it, but
`nxt_assert()` is nothing in a release build, and the two error directions are not symmetric.
Under-releasing leaks a slot; over-releasing wraps `pending_processes` to `UINT32_MAX` and makes
`nxt_router_app_can_start()` false forever — a worse wedge than the one being fixed.

## Relationship to #214 / #236

Distinct mechanism. #214/#236 fixed the *pre-arm* leak at the `goto failed` label; those three sites
never arm an RPC, so they leave `proto_port_requests` untouched. PR #236 listed this one as
deliberately out of its scope.

## Locking

All five accesses to the counter are on one thread, so the two increments need no mutex:
`nxt_port_post()` runs the handler on `port->engine`'s thread, the RPC is registered on that same
port, and the read path asserts it dispatches there (`nxt_port_socket.c:779`, `:887`). The mutex
taken here is for `pending_processes`, which other engines do read.

## Test

`src/test/nxt_router_proto_wedge_test.c` drives the real arrangement — no prototype port, so the
handler builds a `START_PROCESS` payload and arms an RPC with `->proto` set, then a second call joins
the wait — and tears the port's registrations down with `nxt_port_rpc_close()`, which is how a start
that never answers is reported.

Against the unfixed router it reports `proto_port_requests 2 (expected 0)` and the suite exits 1.
With the fix the counter is clear, both parked slots are returned, and a later call sends a fresh
prototype request instead of parking.

The fixture drains the main port on teardown rather than leaving the queued requests behind:
`nxt_port_msg_chk_insert()` takes a port reference per queued message, and a port left above zero
never reaches `nxt_port_mp_cleanup()`, whose assertions are the ones a `--debug` build exists to run.

## Verification

- Full C suite green in a normal **and** a `--debug` build.
- Negative control: with `src/nxt_router.c` reverted to master and everything else unchanged, the
  suite exits 1 on this test.
- Under gdb, all three ports in the new fixture reach `nxt_port_mp_cleanup()` with `use_count 0`.
- Python suite against a real `unitd` + PHP 8.5.4 build: 62 passed across `test_app_lifecycle`,
  `test_process_abrupt_teardown`, `test_process_shm_oosm`, `test_process_teardown_churn`,
  `test_php_application`, `test_respawn`, `test_reconfigure`.

## Known gap, not addressed here

These prototype RPCs never call `nxt_port_rpc_ex_set_peer()`, so process-death cleanup cannot resolve
them. This change closes the "main replies RPC_ERROR" case and the router-shutdown case; if the main
process dies *without* replying, the counter is still stranded. Worth a follow-up issue rather than
scope creep here.

## How this fires in production

The commit message deliberately claims no trigger, because the cause is main-process-side rather
than in `nxt_router.c`. The paths below have each been traced end to end.

`nxt_main_process.c:607` calls `nxt_process_start()` and takes its `failed:` label for any result
that is not `NXT_OK`/`NXT_AGAIN`; that label writes `NXT_PORT_MSG_RPC_ERROR` back to the reply port,
which is what reaches `nxt_router_app_port_error()`. Three ordinary failures land there:

- **`fork()` returning `EAGAIN`** under `RLIMIT_NPROC` or a `pids` cgroup limit —
  `nxt_process.c:631-635` returns `-1`, which `nxt_process_start()` maps to `NXT_ERROR`.
- **Adding the new process to its cgroup failing** (an unwritable `cgroup.procs` being the usual
  cause) — the parent branch at `nxt_process.c:696-704` kills the child and returns `-1`.
- **`socketpair()` failing** with `EMFILE` — `nxt_port_socket_init()` fails at
  `nxt_port_socket.c:81-82` and `nxt_process_start()` returns that error via its `free_port:` label.

A prototype that dies *after* a successful start but before it reports READY reaches the same
handler by a different route: `nxt_router.c:1131-1133` retypes a `REMOVE_PID` carrying a stream into
`_NXT_PORT_MSG_RPC_ERROR`.

So the wedge is reachable from resource exhaustion — which is exactly the condition under which an
operator most needs the application to recover on its own, and the condition under which a permanent
wedge is least likely to be attributed to the router.
