### PR TITLE
test(php): provision a timezone database in the isolation rootfs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -348,6 +348,16 @@ jobs:
           update: true
         if: steps.metadata.outputs.module == 'php'
 
+      # Informational.  A package built --with-system-tzdata reports
+      # "Version => 0.system" and reads /usr/share/zoneinfo at request time,
+      # i.e. inside an isolation.rootfs chroot; a bundled-timelib build
+      # reports a real release and never touches the filesystem.  Which one
+      # the runner has decides how test_php_isolation_rootfs behaves.
+      - name: Report php timezone database
+        run: |
+          php -i | grep -i 'timezone database' || true
+        if: steps.metadata.outputs.module == 'php'
+
       - name: Configure php
         run: |
           ./configure php

--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,6 @@
 **Open questions (decide before August):**
 
 - [ ] PHP TrueAsync — determine source of `nxt_php_extension.c` (fork EdmondDantes or write from scratch)
-- [ ] PHP 8.5 `rootfs` SIGSEGV — needs diagnostics on real hardware
 - [ ] OpenSSL 3.6 migration — verify clang-ast compatibility
 - [ ] Proxy request buffering (#58) — define scope (per-action vs global)
 
@@ -482,24 +481,6 @@ causing `test_php_application_disable_classes` and `test_php_application_disable
 - Remove or conditionalize `disable_classes` handling in `src/php/nxt_php_sapi.c`
 - Consider returning an error from the config API if `disable_classes` is set with PHP 8.5+
 - Or document the removal and drop the feature
-
----
-
-### `rootfs` isolation SIGSEGV (PHP 8.5)
-
-`test_php_isolation_rootfs` fails with signal 11 (SIGSEGV) when running PHP 8.5
-inside a chroot/rootfs-isolated Unit application.
-
-**Test:** `test/test_php_isolation.py` — skipped for PHP >= 8.5 with explicit reason.
-
-**Likely causes:**
-- PHP 8.5 introduced new shared library dependencies not present in the minimal rootfs fixture
-- Or PHP 8.5 accesses paths at startup that are unavailable in the chroot
-
-**Investigation steps:**
-1. Run `ldd $(which php)` with PHP 8.5 and compare against the rootfs fixture contents
-2. Check `unit.log` for the full path that caused the segfault (needs core dump or `strace`)
-3. Check if `php 8.5 --define open_basedir=...` reproduces outside of Unit
 
 ---
 

--- a/test/test_php_isolation.py
+++ b/test/test_php_isolation.py
@@ -1,7 +1,4 @@
-import pytest
-
 from unit.applications.lang.php import ApplicationPHP
-from unit.option import option
 
 prerequisites = {'modules': {'php': 'any'}, 'features': {'isolation': True}}
 
@@ -9,9 +6,6 @@ client = ApplicationPHP()
 
 
 def test_php_isolation_rootfs(is_su, require, temp_dir):
-    versions = option.available['modules'].get('php', [])
-    if versions and versions[0].split('.')[:2] >= ['8', '5']:
-        pytest.skip('PHP 8.5 rootfs isolation: SIGSEGV under investigation')
     isolation = {'rootfs': temp_dir}
 
     if not is_su:

--- a/test/unit/applications/lang/php.py
+++ b/test/unit/applications/lang/php.py
@@ -1,8 +1,24 @@
+import os
 from pathlib import Path
 import shutil
 
+import pytest
+
 from unit.applications.proto import ApplicationProto
 from unit.option import option
+
+
+def _absolute_symlinks(path, names):
+    # A shutil.copytree() filter.  Relative symlinks stay inside the copy,
+    # but an absolute one -- /usr/share/zoneinfo/localtime -> /etc/localtime
+    # on Debian -- points back at the host, and the conftest teardown chmods
+    # every file it walks in the temp dir, following it out of the rootfs.
+    return [
+        name
+        for name in names
+        if os.path.islink(f'{path}/{name}')
+        and os.path.isabs(os.readlink(f'{path}/{name}'))
+    ]
 
 
 class ApplicationPHP(ApplicationProto):
@@ -19,6 +35,27 @@ class ApplicationPHP(ApplicationProto):
 
             if not Path(f'{rootfs}/app/php/{script}').exists():
                 shutil.copytree(script_path, f'{rootfs}/app/php/{script}')
+
+            # PHP built with --with-system-tzdata -- every Debian, Ubuntu and
+            # Fedora package -- opens the timezone database lazily, at request
+            # time, which is after Unit has chroot()ed the app worker into
+            # "rootfs".  Such builds segfault instead of raising an error when
+            # the database is not there, so provision it and keep these tests
+            # about Unit rather than about PHP packaging.
+            tzdir = '/usr/share/zoneinfo'
+
+            if not Path(tzdir).is_dir():
+                pytest.skip(
+                    f'no timezone database at {tzdir} to copy into the rootfs'
+                )
+
+            if not Path(f'{rootfs}{tzdir}').exists():
+                shutil.copytree(
+                    tzdir,
+                    f'{rootfs}{tzdir}',
+                    symlinks=True,
+                    ignore=_absolute_symlinks,
+                )
 
             script_path = f'/app/php/{script}'
 


### PR DESCRIPTION
Fixes #256.

### Root cause

`test_php_isolation_rootfs` has been skipped on PHP >= 8.5 since `529e8e62`
(Apr 2026) as *"PHP 8.5 rootfs isolation: SIGSEGV under investigation"*. The
version gate is misattributed — this is neither a PHP 8.5 defect nor a Unit
defect. PHP built `--with-system-tzdata` (every Debian, Ubuntu and Fedora
package; `php -i` reports `"Olson" Timezone Database Version => 0.system`)
opens the timezone database under `/usr/share/zoneinfo` lazily, at request
time, which is *after* Unit has `chroot()`ed the app worker into `rootfs`. The
test hands PHP a completely empty rootfs, so the lookup returns `NULL`, the
distro patch dereferences it without a check, and the worker dies before it can
answer.

Backtrace summary (`gdb` on the app worker, PHP 8.5.4 / Ubuntu 26.04): the
faulting instruction is `mov 0x38(%rdi),%rax` with `%rdi == NULL`, in a static
timelib function inside `ext/date`; frames 0-2 are the timezone lookup below
`php_format_date`, reached from the `ext/date` MINFO handler via
`php_print_info`, and Unit appears only as the request dispatch —
`nxt_php_execute` (`src/nxt_php_sapi.c:1662`) → `nxt_php_dynamic_request` →
`nxt_php_request_handler` → `nxt_unit_process_ready_req`. Unit logs only
`app process <pid> exited on signal 11` and returns 503. It reproduces with no
Unit involved at all: `mount --bind /empty /usr/share/zoneinfo; php -r 'echo
date("r");'` segfaults on 8.3.33, 8.4.24, 8.4.25 and 8.5.4 alike.

### The change

`ApplicationPHP.load()` already provisions the rootfs with the application; it
now also copies the host's timezone database into it, so the isolation tests
stay about Unit rather than about PHP packaging. Absolute symlinks are excluded
from the copy — `/usr/share/zoneinfo/localtime -> /etc/localtime` on Debian and
Ubuntu — because the conftest teardown (`_clear_temp_dir()` → `public_dir()`)
`os.chmod()`s every file it walks in the temp dir, which follows an absolute
link out of the rootfs and leaves the *host's* zone file mode 0777. Relative
links are kept, so the copy stays 611 KB / 505 entries.

If the host has no `/usr/share/zoneinfo` at all the rootfs cannot be
provisioned, so the tests skip with that reason rather than fail with an
inscrutable signal 11. This is deliberately conservative: a bundled-timelib
build would not need the database, but every image checked (including
`php:8.5-cli-trixie`, which is bundled-timelib) ships the directory, so the
skip is not expected to fire in practice.

The version skip in `test/test_php_isolation.py` and its now-unused imports go
away, along with the corresponding `TODO.md` entry.

### CI diagnostic

The PHP leg of `build-test.yml` now prints `php -i | grep -i 'timezone
database'` before configuring. This is informational and settles an open
question from the investigation: the same ondrej 8.4.25 package that CI uses
fails this test locally, yet GitHub-hosted runners pass it, and the runner's
timezone-database flavour is the missing datum. It does not affect the fix,
which passes in both flavours.

### Validation

Built from this tree in privileged `docker --platform linux/amd64` containers,
`unitd` as root (the plain-`chroot` path, as CI runs it):

| environment | PHP | tz source | before (skip removed, no fixture change) | after |
|---|---|---|---|---|
| `ubuntu:24.04` + ondrej PPA (the exact build CI uses) | 8.4.25 | `0.system` | 1 failed (`assert 503 == 200`, `[alert] app process N exited on signal 11`), 1 passed, 1 error | **2 passed** |
| `ubuntu:26.04` | 8.5.4 | `0.system` | 1 failed, 1 passed, 1 error | **2 passed** |
| `php:8.5-cli-trixie` | 8.5.9 | bundled, `2026.3` | 2 passed | **2 passed** |

Also checked: the passing case is a real HTTP 200 and not a no-op — asserting
`== 999` yields `assert 200 == 999`; the skip branch fires with its reason when
the database is absent; the host's `/usr/share/zoneinfo/Etc/UTC` keeps mode
0644 across a run (it went to 0777 with a naive `symlinks=True` copy); and the
wider PHP suite (`test_php_application.py`, `test_php_targets.py`,
`test_php_isolation.py`) is 55 passed, 1 skipped.

### Follow-up, not in this PR

PHP is the only language module with no `automount.language_deps` mounts —
`nxt_app_module_t.mounts` is `NULL, 0` at `src/nxt_php_sapi.c:387`, whereas
Java, Python and Ruby all populate it. That is the real user-facing gap behind
this test: a PHP app in a rootfs on any distro build segfaults on its first
`date()` with nothing in the log but `exited on signal 11`, and PHP is absent
from the "Language-Specific Mounts" table in the docs. Giving
`auto/modules/php` a generated `nxt_php_mounts.h` that binds the timezone
database when the build uses one is a separate product decision, worth roughly
a day with its own test and docs row. The NULL dereference itself belongs to
the distro `--with-system-tzdata` patch and is worth reporting downstream —
PHP has a `Timezone database is corrupt` path it should be taking instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
