### PR TITLE
ci: run the in-repo fuzzers on pull requests

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,43 +1,103 @@
-name: "Fuzzing (OSS-Fuzz)"
-on:
-  workflow_dispatch: # manual only
-  # pull_request:
-  #   paths:
-  #     - 'src/**'
-  #     - 'fuzzing/**'
-  #     - '.github/workflows/fuzzing.yml'
+name: "Fuzzing (libFuzzer)"
 
-permissions: {}
+on:
+  # The HTTP parsers are the reason this runs on pull requests: they are the
+  # code an attacker reaches first, and the seed corpus already covers them.
+  pull_request:
+    paths:
+      - 'src/nxt_http*'
+      - 'src/nxt_h1proto*'
+      - 'src/nxt_conf*'
+      # nxt_http_controller_fuzz.c #includes nxt_controller.c, so a change
+      # there is a change to what this job fuzzes.
+      - 'src/nxt_controller*'
+      # configure --fuzz, auto/fuzzing and auto/sources are what produce the
+      # binaries; break them and the job has nothing to run.
+      - configure
+      - 'auto/**'
+      - 'fuzzing/**'
+      - '.github/workflows/fuzzing.yml'
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: 'libFuzzer budget per target, in seconds'
+        required: false
+        default: '60'
+      targets:
+        description: 'Space-separated fuzzer names (empty = all five)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel superseded runs for the same pull request.  Non-PR events fall back
+  # to the run id, which is unique, so a dispatch is never grouped with
+  # another: Actions keeps only one PENDING run per group and would drop a
+  # queued one even with cancel-in-progress false.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  Fuzzing:
+  libfuzzer:
+    name: libFuzzer (ASan + UBSan)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      security-events: write
+    # Five targets at a 60s budget is a little over five minutes -- each
+    # finishes within a second or two of its budget, and run-ci.sh caps the
+    # worst case at two minutes each.  The clang/ASan build is a few minutes
+    # on top.  A dispatch can ask for a much longer budget across all five
+    # targets, so it gets a much longer bound; a pull request must not, or a
+    # hung job holds a runner for an hour.
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && 120 || 25 }}
+
     steps:
-    - name: Build Fuzzers
-      id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'unit'
-        language: c
-    - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'unit'
-        language: c
-        fuzz-seconds: 300
-        output-sarif: true
-    - name: Upload Crash
-      uses: actions/upload-artifact@v4
-      if: failure() && steps.build.outcome == 'success'
-      with:
-        name: artifacts
-        path: ./out/artifacts
-    - name: Upload Sarif
-      if: always() && steps.build.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        # Path to SARIF file relative to the root of the repository
-        sarif_file: cifuzz-sarif/results.sarif
-        checkout_path: cifuzz-sarif
+      - uses: actions/checkout@v5
+
+      # libclang-rt-dev carries libclang_rt.fuzzer, which -fsanitize=fuzzer
+      # links against; clang alone is not enough.
+      - name: Install clang and the sanitizer runtimes
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y --no-install-recommends \
+              clang llvm libclang-rt-dev
+
+      - name: Build the fuzzers
+        env:
+          CC: clang
+          CXX: clang++
+          CFLAGS: >-
+            -g -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            -fsanitize=address,undefined -fsanitize=fuzzer-no-link
+          CXXFLAGS: >-
+            -g -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            -fsanitize=address,undefined -fsanitize=fuzzer-no-link
+          # configure compiles and runs small probe programs.  Built with ASan
+          # they report leaks and exit non-zero, and configure then records the
+          # feature as absent -- a silently different build, not a failure.
+          ASAN_OPTIONS: detect_leaks=0
+        run: |
+          ./configure --no-regex --no-pcre2 --fuzz=-fsanitize=fuzzer
+          make fuzz -j"$(nproc)"
+
+      # All five targets, on a pull request and on a dispatch alike.  Picking a
+      # subset per changed path was tried and dropped: every path filter above
+      # already maps to a target, `fuzzing/**` maps to all of them, and a
+      # target left out of the list is a harness that CI compiles but never
+      # runs.  At about 61 seconds each the whole set is close to five minutes.
+      - name: Run the fuzzers
+        env:
+          FUZZ_SECONDS: ${{ github.event.inputs.seconds || '60' }}
+          FUZZ_TARGETS: ${{ github.event.inputs.targets }}
+        run: |
+          # shellcheck disable=SC2086  # deliberate word splitting
+          ./fuzzing/run-ci.sh -t "${FUZZ_SECONDS}" ${FUZZ_TARGETS}
+
+      # A reproducer is the only thing that makes a fuzzing failure actionable.
+      - name: Upload reproducers
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts
+          path: build/fuzz-artifacts/
+          if-no-files-found: ignore

--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -66,3 +66,48 @@ may vary).
 ```
 clang, llvm & compiler-rt
 ```
+
+## In CI
+
+`.github/workflows/fuzzing.yml` builds these targets with clang, ASan and
+UBSan and runs `fuzzing/run-ci.sh`, which gives each target a bounded
+libFuzzer budget against its seed corpus and fails on the first crash.
+
+```shell
+$ fuzzing/run-ci.sh                                   # all five, 60s each
+$ fuzzing/run-ci.sh -t 120 fuzz_http_h1p              # one target, longer
+```
+
+A pull request that touches `src/nxt_http*`, `src/nxt_h1proto*`,
+`src/nxt_controller*`, `src/nxt_conf*` or `fuzzing/` runs all five targets --
+roughly five minutes; a manual `workflow_dispatch` takes a budget and a
+target list as inputs.  Reproducers land in `build/fuzz-artifacts/` and are
+uploaded as an artifact when the job fails.
+
+Each target finishes within a second or two of its budget.  `run-ci.sh` caps
+it at the budget plus a minute anyway -- libFuzzer only checks the budget
+between runs -- and treats hitting that cap as a warning rather than a
+failure, while distinguishing it from a kill that arrives early: an OOM is a
+finding, not slowness.
+
+It sets `UBSAN_OPTIONS=halt_on_error=1`.  `-fsanitize=undefined` is
+recoverable by default -- UBSan prints the report and carries on, libFuzzer
+exits 0, and the check goes green on a finding.  It deliberately does *not*
+set `print_stacktrace=1`, which reintroduces the symbolizer cost below; the
+report keeps its file:line and the reproducer is saved, so rerun the
+reproducer with `UBSAN_OPTIONS=print_stacktrace=1` when you want the trace.
+
+It also passes `-print_funcs=0`, which is worth knowing about if you run the
+fuzzers by hand.  libFuzzer symbolizes every newly covered function to print
+its `NEW_FUNC` line, and llvm-symbolizer needs about thirteen seconds per call
+against a 14 MB ASan+UBSan binary.  On a fresh corpus -- which is what CI has
+every time -- that is the whole run: `fuzz_json` managed **7 executions in 90
+seconds** with the default, and **1,190,884 in 31 seconds** without it.  Crash
+reports keep their symbols either way; those come from the sanitizer's stack
+printer, not from libFuzzer's coverage output.
+
+This is a smoke gate, not a campaign.  It replaced an OSS-Fuzz CIFuzz job
+that could not have worked here: the OSS-Fuzz `unit` project is marked
+`disabled: true` ("Project is archived") and its `main_repo` is
+`https://github.com/nginx/unit`, so a run from this repository would have
+built upstream's source rather than the pull request's.

--- a/fuzzing/nxt_http_h1p_fuzz.c
+++ b/fuzzing/nxt_http_h1p_fuzz.c
@@ -28,6 +28,9 @@ LLVMFuzzerInitialize(int *argc, char ***argv)
         return NXT_ERROR;
     }
 
+    /* Keep a fuzzing run quiet: nothing below alert is worth printing. */
+    nxt_main_log.level = NXT_LOG_ALERT;
+
     ret = nxt_http_fields_hash(&nxt_h1p_fields_hash,
                                nxt_h1p_fields, nxt_nitems(nxt_h1p_fields));
     if (ret != NXT_OK) {
@@ -75,6 +78,13 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (req->conf->socket_conf == NULL) {
         goto failed;
     }
+
+    /*
+     * A field handler may log, and nxt_log() dereferences task->log.  The
+     * request is zeroed memory here, so without this any handler that logs
+     * is a null dereference in the harness rather than a finding.
+     */
+    req->task.log = &nxt_main_log;
 
     buf.start = (u_char *)data;
     buf.end = (u_char *)data + size;

--- a/fuzzing/nxt_http_h1p_peer_fuzz.c
+++ b/fuzzing/nxt_http_h1p_peer_fuzz.c
@@ -28,6 +28,9 @@ LLVMFuzzerInitialize(int *argc, char ***argv)
         return NXT_ERROR;
     }
 
+    /* Keep a fuzzing run quiet: nothing below alert is worth printing. */
+    nxt_main_log.level = NXT_LOG_ALERT;
+
     ret = nxt_http_fields_hash(&nxt_h1p_peer_fields_hash,
                                 nxt_h1p_peer_fields,
                                 nxt_nitems(nxt_h1p_peer_fields));
@@ -71,6 +74,13 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (req->peer->proto.h1 == NULL) {
         goto failed;
     }
+
+    /*
+     * A field handler may log, and nxt_log() dereferences task->log.  The
+     * request is zeroed memory here, so without this any handler that logs
+     * is a null dereference in the harness rather than a finding.
+     */
+    req->task.log = &nxt_main_log;
 
     buf.start = (u_char *)data;
     buf.end = (u_char *)data + size;

--- a/fuzzing/run-ci.sh
+++ b/fuzzing/run-ci.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+#
+# Run libFuzzer targets for a bounded time against their seed corpora and fail
+# on the first crash.  This is a smoke gate, not a fuzzing campaign: the
+# question it answers is "does the HTTP parser still survive its own seed
+# corpus and a minute of shallow mutation", which is the part worth blocking a
+# pull request on.
+#
+# Usage:
+#   fuzzing/run-ci.sh [-t SECONDS] [TARGET ...]
+#
+#   -t SECONDS   libFuzzer budget per target (default 60)
+#   TARGET ...   fuzzer names; default is all five
+#
+# Expects the fuzzers to be built already:
+#   CC=clang CXX=clang++ \
+#   CFLAGS="-g -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION \
+#           -fsanitize=address,undefined -fsanitize=fuzzer-no-link" \
+#   ./configure --no-regex --no-pcre2 --fuzz=-fsanitize=fuzzer && make fuzz
+#
+# Any crash, leak or sanitizer report leaves the reproducer in
+# build/fuzz-artifacts/ for CI to upload.
+
+set -eu
+
+BUDGET=60
+BUILD=${BUILD_DIR:-build}
+
+die() { echo "run-ci.sh: $*" >&2; exit 1; }
+
+while getopts 't:' opt; do
+    case "$opt" in
+        t) BUDGET=$OPTARG ;;
+        *) die "usage: $0 [-t SECONDS] [TARGET ...]" ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+# The budget reaches this from a workflow input and is then used in shell
+# arithmetic, where a non-numeric value is at best a confusing error.
+case "$BUDGET" in
+    ''|*[!0-9]*) die "budget must be a whole number of seconds, got '$BUDGET'" ;;
+esac
+
+# Seed corpus and dictionary per target.  fuzz_http_* share the HTTP corpus.
+corpus_for() {
+    case "$1" in
+        fuzz_basic)     echo fuzz_basic_seed_corpus ;;
+        fuzz_json)      echo fuzz_json_seed_corpus ;;
+        fuzz_http_*)    echo fuzz_http_seed_corpus ;;
+        *)              die "unknown target: $1" ;;
+    esac
+}
+
+dict_for() {
+    case "$1" in
+        fuzz_http_*)    echo fuzz_http.dict ;;
+        *)              echo "" ;;
+    esac
+}
+
+[ $# -gt 0 ] || set -- fuzz_basic fuzz_json fuzz_http_controller \
+                       fuzz_http_h1p fuzz_http_h1p_peer
+
+# Freeze the list: the loop below rebuilds "$@" to hold each target's libFuzzer
+# arguments, so it cannot also be the list being iterated.
+TARGETS=$*
+
+# -fsanitize=undefined is recoverable by default: UBSan prints the report and
+# execution continues, so libFuzzer exits 0 and a green check hides the
+# finding.  halt_on_error turns a report into an abort, which libFuzzer
+# records as a crash and saves a reproducer for.  Set here rather than in the
+# build flags so the guarantee travels with the runner, whoever built the
+# binaries.
+#
+# Deliberately without print_stacktrace=1: that pulls in llvm-symbolizer, the
+# same thirteen-seconds-a-call cost that -print_funcs=0 exists to avoid, and
+# it turns the abort into a stall the wall-clock cap then files as "slow".
+# The report keeps its file:line and the reproducer is saved, which is what a
+# rerun needs.
+# Appended rather than defaulted: sanitizer flags are parsed left to right and
+# the last wins, so this stays authoritative even when the caller already has
+# UBSAN_OPTIONS set to something (including halt_on_error=0).
+UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}halt_on_error=1"
+export UBSAN_OPTIONS
+
+ART="$BUILD/fuzz-artifacts"
+CORPORA="$BUILD/fuzz-corpora"
+mkdir -p "$ART" "$CORPORA" || die "cannot write under $BUILD -- wrong BUILD_DIR?"
+
+# Check every binary up front: a build that silently produced nothing must not
+# be mistaken for a clean run.
+for target in $TARGETS; do
+    [ -x "$BUILD/$target" ] || die "no fuzzer at $BUILD/$target -- was 'make fuzz' run?"
+    [ -d "fuzzing/$(corpus_for "$target")" ] \
+        || die "no seed corpus fuzzing/$(corpus_for "$target") for $target"
+done
+
+# -print_funcs=0 is not cosmetic.  libFuzzer symbolizes every newly covered
+# function to print its NEW_FUNC line, and llvm-symbolizer takes about thirteen
+# seconds per call against a 14 MB ASan+UBSan binary, so the exploration phase
+# -- exactly the part a fresh CI corpus is all of -- stalls on the symbolizer.
+# Measured here, 30-second budget, before and after:
+#
+#   fuzz_json              7 runs / 90s   ->  1190884 runs / 31s
+#   fuzz_http_h1p        161 runs / 91s   ->  1267717 runs / 31s
+#   fuzz_http_controller                  ->  1567704 runs / 31s
+#   fuzz_http_h1p_peer                    ->  1442178 runs / 32s
+#
+# Crash reports keep their symbols either way: those go through the sanitizer's
+# own stack printer, not libFuzzer's coverage output.  Verified on a purpose-
+# built crashing target.
+PRINT_FUNCS=-print_funcs=0
+
+# -max_total_time is only checked between runs and libFuzzer's own -timeout
+# defaults to twenty minutes, so a single pathological unit can still run far
+# past the budget.  Bound the wall clock rather than tightening -timeout: a
+# slow target is not a finding, and turning slowness into a red check would
+# only teach people to ignore the job.  A minute of headroom is ample now that
+# a target finishes within a second or two of its budget.
+#
+# FUZZ_WALL_MARGIN exists so the two branches below can be exercised in a
+# test without waiting a minute for the cap.
+WALL=$((BUDGET + ${FUZZ_WALL_MARGIN:-60}))
+
+status=0
+attempted=0
+ran=0
+slow=0
+
+for target in $TARGETS; do
+    seed=$(corpus_for "$target")
+    dict=$(dict_for "$target")
+
+    mkdir -p "$CORPORA/$target"
+    set -- "$CORPORA/$target" "fuzzing/$seed" \
+        "-max_total_time=$BUDGET" \
+        "-artifact_prefix=$ART/$target-" \
+        "$PRINT_FUNCS" -print_final_stats=1 -rss_limit_mb=2560
+    [ -n "$dict" ] && set -- "$@" "-dict=fuzzing/$dict"
+
+    attempted=$((attempted + 1))
+    echo "=== $target (${BUDGET}s budget, ${WALL}s wall cap, seeds: $seed${dict:+, dict: $dict}) ==="
+    rc=0
+    started=$(date +%s)
+    timeout -k 5 "$WALL" "$BUILD/$target" "$@" || rc=$?
+    elapsed=$(( $(date +%s) - started ))
+
+    # 137 is 128+SIGKILL, which is what `timeout -k` reports for a target it
+    # had to kill -- and also what the kernel's OOM killer produces mid-run.
+    # Distinguishing them matters: an OOM is a finding and must not be filed
+    # under "slow".  Only a kill at or past the cap is the cap.
+    case "$rc" in
+        0)
+            ran=$((ran + 1))
+            ;;
+        124|137)
+            if [ "$elapsed" -ge "$WALL" ]; then
+                echo "run-ci.sh: $target hit the ${WALL}s wall cap (not a finding)" >&2
+                slow=$((slow + 1))
+                ran=$((ran + 1))
+            else
+                echo "run-ci.sh: $target KILLED after ${elapsed}s, well inside the" \
+                     "${WALL}s cap -- treating as a failure (OOM killer?)" >&2
+                status=1
+            fi
+            ;;
+        *)
+            echo "run-ci.sh: $target FAILED (exit $rc after ${elapsed}s)" >&2
+            status=1
+            ;;
+    esac
+    echo ""
+done
+
+# Guard on what was attempted, not on what succeeded: an empty target list
+# would otherwise be a green run that fuzzed nothing.
+[ "$attempted" -gt 0 ] || die "no fuzzer actually ran"
+echo "run-ci.sh: $attempted target(s) attempted, $ran finished, $slow hit the wall cap, ${BUDGET}s budget each"
+exit "$status"


### PR DESCRIPTION
The fuzzers have been in the tree since 2022 and no pull request has ever run
one. This makes them a gate, and fixes the two things that stopped them being
one: a harness crash that fired within ten seconds, and a default that spent
the entire run in the symbolizer.

Two commits, off `origin/master` a8c9318e:

| | |
|---|---|
| `24fc01cd` | `fix(fuzzing): give the HTTP harnesses a log, so a logging handler is not a crash` |
| `df74d348` | `ci(fuzzing): run the in-repo fuzzers on pull requests` |

5 files, +344 / −39.

---

### `24fc01cd` — a crash in the harness

Ten seconds into the first run, on an input from the checked-in seed corpus:

```
SUMMARY: AddressSanitizer: SEGV src/nxt_http_proxy.c:432
         in nxt_http_proxy_content_length
```

Line 432 is the `nxt_log()` that `accb5054` added when it started rejecting
duplicate upstream `Content-Length` headers. The request the harness hands to
`nxt_http_fields_process()` is `nxt_mp_zget()` memory and nothing fills in
`req->task`, so `task->log` is NULL.

**This is the harness, not the product** — in a real router the request always
carries a task with a log — but any field handler that logs would hit it, and
the peer target could not go into CI until it was fixed. Both HTTP harnesses
now point `req->task.log` at `nxt_main_log`, the way
`nxt_http_controller_fuzz.c` already does for `req->conn->log`. The
request-side harness has no logging handler today; it builds its request the
same way, so it is the same crash waiting for the next handler that logs.

### `df74d348` — the CI job

The workflow that was meant to run these has been `workflow_dispatch`-only
since `8d59a464` (April 2026, upstream), which records **no reason** — its
subject is just the line it changed and it has no body — and by the January
note in `148cc0b1` it had "never run at all".

It could not have worked from here regardless. The OSS-Fuzz project it invokes
is archived: `projects/unit/project.yaml` carries `disabled: true` with the
comment "Project is archived", and `main_repo` is
`https://github.com/nginx/unit`, so CIFuzz would have built upstream's source
rather than the pull request's. (Fetched from `google/oss-fuzz` master while
writing this.) So it is replaced rather than re-enabled: clang + ASan + UBSan,
the tree's own `make fuzz`, and `fuzzing/run-ci.sh`.

**All five targets on a pull request**, 60 seconds each, when it touches
`src/nxt_http*`, `src/nxt_h1proto*`, `src/nxt_controller*`, `src/nxt_conf*`,
`fuzzing/`, `configure` or `auto/`. `nxt_controller.c` is in that list because
`nxt_http_controller_fuzz.c` `#include`s it; `configure` and `auto/` because
`--fuzz`, `auto/fuzzing` and `auto/sources` are what produce the binaries at
all. Running a subset per changed path was tried and dropped — every filter
maps to a target and `fuzzing/**` maps to all of them, so a target left out is
a harness CI compiles and never runs.

Two settings are what make this a gate rather than a formality, and both came
out of measurement:

**`halt_on_error=1` appended to `UBSAN_OPTIONS`.** `-fsanitize=undefined` is
recoverable by default: UBSan prints the report, execution continues, libFuzzer
exits 0 and the check is green on a finding. Reproduced on a purpose-built
target before fixing it. Appended rather than defaulted, since sanitizer flags
are parsed left to right and the last wins, so it stays authoritative against a
caller's own `halt_on_error=0`. Not `print_stacktrace=1` as well — that pulls
in the symbolizer, which is the next problem.

**`-print_funcs=0`.** libFuzzer symbolizes every newly covered function to
print its `NEW_FUNC` line, and llvm-symbolizer takes about thirteen seconds a
call against a 14 MB ASan+UBSan binary. On a fresh corpus — which is what CI
has every time — that is the entire run:

| target, 30s budget | before | after |
|---|---|---|
| `fuzz_json` | 7 runs / 90s | 1,190,884 runs / 31s |
| `fuzz_http_h1p` | 161 runs / 91s | 1,267,717 runs / 31s |
| `fuzz_http_controller` | — | 1,567,704 runs / 31s |
| `fuzz_http_h1p_peer` | — | 1,442,178 runs / 32s |

Crash reports keep their symbols either way; those come from the sanitizer's
stack printer, not from libFuzzer's coverage output — verified on a
purpose-built crashing target.

`-max_total_time` is still only checked between runs, and libFuzzer's own
`-timeout` defaults to twenty minutes, so each target runs under a wall-clock
cap of its budget plus a minute. Hitting the cap **warns**; slowness is not a
finding and a red check for it only teaches people to ignore the job. That
warning is not extended to every kill: `timeout -k` reports 137 for a target it
had to SIGKILL and so does the kernel's OOM killer, and an OOM is a finding —
the elapsed time separates them.

The job timeout follows the trigger: 25 minutes on a pull request, because a
hung job must not hold a runner for an hour; 120 on a dispatch, which can ask
for a long budget across all five targets.

---

## Verification

All executed locally (kernel 7.0, docker 29.7.2, `--platform linux/amd64`).

- **Before the harness fix:** `fuzz_http_h1p_peer` crashed at 10s, reproducer
  saved. **After:** the saved reproducer no longer crashes.
- **All five targets, 60s each: 5m07s total, 2.2–3.4 million executions each,
  no findings, no artifacts.**
- **UBSan gate proven both ways** on a purpose-built target: without
  `halt_on_error` the run is green with a `runtime error:` in the log; with it
  the run fails and saves a reproducer. Also proven to survive a caller's
  `UBSAN_OPTIONS=halt_on_error=0`.
- **Kill classification proven on stubs:** a stub that never exits → "hit the
  wall cap", exit 0; a stub that `kill -9`s itself → "KILLED … well inside the
  cap … (OOM killer?)", exit 1; a stub exiting 1 → "FAILED", exit 1.
- **Guards:** a missing binary, a missing corpus, an unknown target name and a
  non-numeric budget each fail loudly; the summary counts targets *attempted*,
  so an empty list cannot be a green run that fuzzed nothing.
- **Toolchain:** built with clang 21.1.8 natively and clang 18.1.3 inside
  `ubuntu:24.04` (the runner's base) to confirm the package set
  `clang llvm libclang-rt-dev`.
- **Lint:** `actionlint` (docker `rhysd/actionlint`) — zero findings in
  `fuzzing.yml`. The 24 findings it reports repo-wide are pre-existing and
  spread over `analysis-clang-ast.yml` (2), `build-test.yml` (9),
  `eol-check.yml` (1), `lint-whitespace.yml` (2), `sanitize.yml` (3) and
  `unitctl.yml` (7). `shellcheck -s sh` clean. `git diff --check` clean.
- **`codex review --commit`** run on each commit until clean: four rounds on
  `df74d348`. Its findings drove the `-print_funcs=0` investigation, the UBSan
  `halt_on_error` gap, the `src/nxt_controller*` and `configure`/`auto/**` path
  filters, running all five targets, and the dispatch timeout. Final round:
  "No actionable correctness issues were identified."

## Not verified here

- **Nothing has run on a GitHub Actions runner.** The specific unknown is
  `libclang-rt-dev`: it resolves on `ubuntu:24.04` and provides
  `libclang_rt.fuzzer`, but the runner image ships its own clang and the apt
  install may be a no-op or a different version.
- Runner timings will differ; 5m07s is an 8-core figure.

## Follow-up

`fuzz_basic` and `fuzz_json` have no dictionary and small seed corpora. Not
addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
