### PR TITLE
test(router): drain the soak test's destination port on teardown

### DIFF
--- a/src/test/nxt_router_start_fail_soak_test.c
+++ b/src/test/nxt_router_start_fail_soak_test.c
@@ -308,6 +308,23 @@ nxt_router_start_fail_soak_test(nxt_thread_t *thr)
 done:
 
     if (dport != NULL) {
+        /*
+         * The successful start above was queued rather than written, and
+         * nxt_port_msg_chk_insert() takes a port reference for every queued
+         * message.  Releasing only the test's own reference leaves the port
+         * above zero, so it never reaches nxt_port_mp_cleanup() and the
+         * assertions there -- the ones a --debug build exists to run --
+         * never execute for it.
+         */
+        nxt_port_test_run_error_handler(task, dport);
+
+        if (!nxt_queue_is_empty(&dport->messages)) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router start fail soak test: destination port "
+                          "still holds queued messages after teardown");
+            ret = NXT_ERROR;
+        }
+
         nxt_port_use(task, dport, -1);
     }
 


### PR DESCRIPTION
## The problem

`nxt_router_start_fail_soak_test()` released `dport` with a bare
`nxt_port_use(task, dport, -1)`, but the successful start at the end of the test is *queued* rather
than written, and `nxt_port_msg_chk_insert()` takes a port reference for every queued message.

The port therefore stayed above zero and never reached `nxt_port_mp_cleanup()` — whose assertions
(descriptors closed, `use_count` zero, message queue and rpc hashes empty) are exactly the ones a
`--debug` build exists to run.

So the soak's "green in `--debug`" was weaker than it looked: green partly *because the port leaked*,
not because the fixture was clean. The port's `mem_pool` and its queued `nxt_port_send_msg_t` leaked
with it, and the message's `buf` pointed into a pool the test destroys moments later.

## Evidence

Under gdb, breaking on `nxt_port_mp_cleanup()`:

**Before** — the soak tears down only one of its two ports, while the sibling single-shot test tears
down both of its own:

```
tests: [notice] router start fail test passed
CLEANUP id=1 use=0
CLEANUP id=0 use=0          <- single-shot: both ports
tests: [notice] router start fail soak test passed: 1000 iterations over failure sites 1-3
CLEANUP id=0 use=0          <- soak: dport (id=1) missing
```

**After** — both ports, each at `use_count 0`:

```
tests: [notice] router start fail soak test passed: 1000 iterations over failure sites 1-3
CLEANUP id=1 use=0
CLEANUP id=0 use=0
```

## The fix

Drain with `nxt_port_test_run_error_handler()` — the existing `NXT_TESTS` wrapper that
`src/test/nxt_port_fail_test.c` already uses for exactly this — then *require* the queue to be empty
rather than assume it.

That check is not decoration. With the drain removed and the check kept, the suite exits 1:

```
tests: [notice] router start fail soak test: destination port still holds queued messages after teardown
```

The buffer completion handlers the drain queues onto the fixture's work queue never run, which is
safe rather than lossy: `nxt_buf_completion()` would only return the buffers to the same pool
`nxt_mp_destroy()` frees wholesale, and the queued work items live in cache chunks that
`nxt_work_queue_cache_destroy()` frees the same way.

## Verification

- Full C suite green in a normal **and** a `--debug` build (`NXT_DEBUG` asserted `1` in
  `build/include/nxt_auto_config.h` before trusting the debug result).
- Negative control as above — the new check fails the suite when the drain is removed.
- Re-verified after rebasing onto master with #255 merged.

Found while reviewing #255, whose new test had the same shape and fixes it the same way.

Closes #258
