### PR TITLE
port: fail the start when a worker's queue cannot be mapped

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -182,6 +182,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_start_fail_test.c \
     src/test/nxt_router_start_fail_soak_test.c \
     src/test/nxt_router_proto_wedge_test.c \
+    src/test/nxt_router_remove_pid_soak_test.c \
     src/test/nxt_port_change_file_test.c \
     src/test/nxt_port_fd_test.c \
 "

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -318,6 +318,10 @@ nxt_port_send_new_port(nxt_task_t *task, nxt_runtime_t *rt,
     nxt_port_t     *port;
     nxt_process_t  *process;
 
+#if (NXT_TESTS)
+    nxt_port_test_broadcasts++;
+#endif
+
     nxt_debug(task, "new port %d for process %PI",
               new_port->pair[1], new_port->pid);
 
@@ -566,11 +570,19 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         return;
     }
 
-    process->state = NXT_PROCESS_STATE_READY;
+    /*
+     * The start already failed and the process was killed for it.  Acting on
+     * a retransmission would signal that pid a second time, and once it has
+     * been reaped the pid may name an unrelated process.
+     */
+    if (nxt_slow_path(process->start_failed)) {
+        nxt_log(task, NXT_LOG_WARN, "PROCESS_READY claiming process %PI, "
+                "whose start has already failed", msg->port_msg.pid);
+        nxt_port_recv_msg_close_fds(msg);
+        return;
+    }
 
     port = nxt_process_port_first(process);
-
-    nxt_debug(task, "process %PI ready", msg->port_msg.pid);
 
     if (msg->fd[0] != -1) {
         mem = nxt_port_queue_mmap(task, msg->fd[0], sizeof(nxt_port_queue_t));
@@ -627,9 +639,123 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
              * of being reached, is issue #231.
              */
             if (port->queue == NULL) {
+#if (NXT_USE_CMSG_PID)
+                /*
+                 * The whole arm, not only the kill, is confined to the
+                 * platforms that authenticate the sender.  Every step of it
+                 * is destructive -- it refuses the announcement, strands the
+                 * process at CREATED and signals it -- and none of that is
+                 * safe to do on a message that cannot be attributed.
+                 *
+                 * Acting on an unauthenticated message would also be worse
+                 * than the bug it fixes: without the kill below there is
+                 * nothing to reap the worker, so the prototype never sends
+                 * the REMOVE_PID that fails the start, and the latch refuses
+                 * every retransmission -- a start pending forever rather
+                 * than one that fails. Elsewhere the old behaviour stands
+                 * until NEW_PORT and PROCESS_READY carry provenance
+                 * everywhere; that is issue #223.
+                 */
+
+                nxt_alert(task, "process %PI ready: cannot map the queue; "
+                          "failing the start", msg->port_msg.pid);
+
+                /*
+                 * The tail below is not reached, so close what the sender
+                 * attached here instead: the descriptor that could not be
+                 * mapped, and fd[1], which this handler never uses.
+                 */
+                nxt_port_recv_msg_close_fds(msg);
+
+                /*
+                 * A retransmitted PROCESS_READY must not signal again: the
+                 * pid has been killed and, once reaped, may name an
+                 * unrelated process.  The state cannot carry this, because
+                 * the process has to stay at CREATED.
+                 */
+                process->start_failed = 1;
+
+                /*
+                 * The kill only fails the start if somebody notices the
+                 * death, and the prototype's SIGCHLD handler notifies the
+                 * others for any state but CREATING
+                 * (nxt_application.c:907).
+                 *
+                 * The record is normally CREATED by then: the worker sends
+                 * PROCESS_CREATED first (nxt_process.c:918) and the
+                 * prototype sets the state when it handles it
+                 * (nxt_application.c:769).  Both messages travel the same
+                 * socketpair, so READY cannot overtake CREATED.  It can
+                 * however be LOST: if that write hits EAGAIN the message is
+                 * buffered on the port (nxt_port_socket.c:331-359) and the
+                 * worker then enters init->start and never returns to its
+                 * loop to flush it, while libunit makes the descriptor
+                 * blocking and sends READY regardless.  The record is then
+                 * still CREATING here.
+                 *
+                 * Advancing it is what guarantees the REMOVE_PID that
+                 * carries the start stream; leaving it at CREATING would
+                 * kill the worker and still leave the start pending, which
+                 * is the wedge this arm exists to end.
+                 *
+                 * CREATED, not READY: it never became usable, and on the
+                 * paths main reports rather than the prototype, READY is
+                 * what makes main clear the start stream
+                 * (nxt_main_process.c:1108-1110).
+                 */
+                if (process->state == NXT_PROCESS_STATE_CREATING) {
+                    process->state = NXT_PROCESS_STATE_CREATED;
+                }
+
+                /*
+                 * The process is left at CREATED because nothing about it
+                 * ever became ready, and that costs the release nothing:
+                 * an app worker announces itself to the prototype, whose
+                 * SIGCHLD handler notifies the others whenever the state is
+                 * anything but CREATING (nxt_application.c:907), so CREATED
+                 * and READY travel the same path.  The stream that REMOVE_PID
+                 * carries -- the one the router turns into the start's
+                 * RPC_ERROR -- was set by the prototype when it forked the
+                 * worker (nxt_application.c:672) and is untouched here.
+                 *
+                 * isolated_pid is the pid as this receiver sees it, which
+                 * inside a pid namespace is a different number from the
+                 * global one; nxt_process.c uses the same identity rule
+                 * when it kills a child whose cgroup setup failed.
+                 *
+                 * The positive test is redundant -- the sender gate above
+                 * rejects a non-positive isolated_pid before this arm is
+                 * reachable, under the same #if -- and is kept only because
+                 * what it guards is kill(0, SIGKILL), which would signal
+                 * the caller's whole process group.  A later change that
+                 * moved or relaxed that gate would otherwise turn this into
+                 * exactly that.
+                 */
+                if (nxt_fast_path(process->isolated_pid > 0)) {
+                    if (kill(process->isolated_pid, SIGKILL) == -1) {
+                        /*
+                         * ESRCH is ordinary here: the process may already
+                         * have exited with a SIGCHLD still pending.
+                         */
+                        nxt_log(task, (nxt_errno == ESRCH) ? NXT_LOG_INFO
+                                                           : NXT_LOG_ALERT,
+                                "kill(%PI, SIGKILL) failed for a process "
+                                "whose queue could not be mapped %E",
+                                process->isolated_pid, nxt_errno);
+                    }
+                }
+
+                return;
+#else
+                /*
+                 * See above: with no kernel-validated sender pid the start
+                 * cannot be failed safely, so the announcement stands and
+                 * the port stays unreachable.  This is issue #231 as it was.
+                 */
                 nxt_alert(task, "process %PI ready: cannot map the queue; "
                           "the process cannot be reached on this port",
                           msg->port_msg.pid);
+#endif
 
             } else {
                 nxt_log(task, NXT_LOG_WARN, "process %PI ready: cannot map "
@@ -638,6 +764,16 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
             }
         }
     }
+
+    /*
+     * Set below the mapping, not above it: a PROCESS_READY that cannot be
+     * acted upon must leave the process at CREATED (see the failure arm).
+     * Core processes -- router, controller, prototype -- send fd -1 and skip
+     * the block entirely, so they become READY here as they always did.
+     */
+    process->state = NXT_PROCESS_STATE_READY;
+
+    nxt_debug(task, "process %PI ready", msg->port_msg.pid);
 
     /*
      * Close whatever the sender attached and the port did not take over:

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -613,156 +613,158 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
             /* The port owns the descriptor now. */
             msg->fd[0] = -1;
 
-        } else {
-            /*
-             * A refused queue leaves the port as it was.  For a repeated
-             * PROCESS_READY that is the queue it already has, and the port
-             * keeps working.  For the first one it is no queue at all, and
-             * that is not a fallback to the socket: only libunit attaches
-             * a queue descriptor to PROCESS_READY, and a libunit process
-             * delivers a socket message only after dequeuing the
-             * READ_SOCKET marker that nxt_port_socket_write2() emits under
-             * port->queue != NULL.  A queueless sender cannot emit the
-             * marker, so its messages are suspended undelivered on the
-             * worker side, and the second one fails the worker's context
-             * ("too many port socket messages").  The broadcast below
-             * forwards queue_fd == -1, so every peer holds the same
-             * unreachable copy; a QUIT can never arrive, while requests
-             * still flow through the shared app queue.  See issue #231.
-             *
-             * The message is still not refused outright.  Failing the
-             * start is the honest reaction to a genuine mmap failure, and
-             * the sender gate above now makes that safe to do on ucred and
-             * cmsgcred platforms -- a forged PROCESS_READY can no longer
-             * use it to kill a legitimate start.  The behaviour change
-             * itself, and the kill of the worker that is left with no way
-             * of being reached, is issue #231.
-             */
-            if (port->queue == NULL) {
+        } else if (port->queue != NULL) {
+            nxt_log(task, NXT_LOG_WARN, "process %PI ready: cannot map "
+                    "the replacement queue, keeping the current one",
+                    msg->port_msg.pid);
+        }
+    }
+
+    /*
+     * One test for both ways an application worker can end up with no queue:
+     * a descriptor that could not be mapped, and no descriptor at all.
+     *
+     * The second is not hypothetical.  Only libunit attaches a queue to
+     * PROCESS_READY, and it always does (nxt_unit.c:1050) -- the processes
+     * that legitimately send fd -1 are the core ones, which announce to main
+     * and are not NXT_PROCESS_APP.  But at the receiver's RLIMIT_NOFILE the
+     * kernel delivers the payload and the credential while discarding
+     * SCM_RIGHTS and setting MSG_CTRUNC, which nothing here inspects, so an
+     * authenticated READY can arrive with its descriptor silently gone.
+     * Treating that as ready would broadcast the same unreachable port that
+     * issue #231 is about, by a different road.
+     *
+     * A queueless APP port is therefore a failed start either way, and the
+     * distinction that matters is not how the descriptor was lost but that
+     * the worker cannot be reached on it: no fallback to the socket exists,
+     * because a libunit process only delivers a socket message after
+     * dequeuing the READ_SOCKET marker that nxt_port_socket_write2() emits
+     * under port->queue != NULL.  A queueless sender never emits the marker,
+     * its messages are suspended undelivered, and the second one fails the
+     * worker with "too many port socket messages".
+     *
+     * A repeated READY whose replacement mapping failed keeps the queue it
+     * has and is not a failed start -- it is excluded here by port->queue.
+     */
+
+    if (port->queue == NULL && port->type == NXT_PROCESS_APP) {
 #if (NXT_USE_CMSG_PID)
+        /*
+         * The whole arm, not only the kill, is confined to the
+         * platforms that authenticate the sender.  Every step of it
+         * is destructive -- it refuses the announcement, strands the
+         * process at CREATED and signals it -- and none of that is
+         * safe to do on a message that cannot be attributed.
+         *
+         * Acting on an unauthenticated message would also be worse
+         * than the bug it fixes: without the kill below there is
+         * nothing to reap the worker, so the prototype never sends
+         * the REMOVE_PID that fails the start, and the latch refuses
+         * every retransmission -- a start pending forever rather
+         * than one that fails. Elsewhere the old behaviour stands
+         * until NEW_PORT and PROCESS_READY carry provenance
+         * everywhere; that is issue #223.
+         */
+
+        nxt_alert(task, "process %PI ready: cannot map the queue; "
+                  "failing the start", msg->port_msg.pid);
+
+        /*
+         * The tail below is not reached, so close what the sender
+         * attached here instead: the descriptor that could not be
+         * mapped, and fd[1], which this handler never uses.
+         */
+        nxt_port_recv_msg_close_fds(msg);
+
+        /*
+         * A retransmitted PROCESS_READY must not signal again: the
+         * pid has been killed and, once reaped, may name an
+         * unrelated process.  The state cannot carry this, because
+         * the process has to stay at CREATED.
+         */
+        process->start_failed = 1;
+
+        /*
+         * The kill only fails the start if somebody notices the
+         * death, and the prototype's SIGCHLD handler notifies the
+         * others for any state but CREATING
+         * (nxt_application.c:907).
+         *
+         * The record is normally CREATED by then: the worker sends
+         * PROCESS_CREATED first (nxt_process.c:918) and the
+         * prototype sets the state when it handles it
+         * (nxt_application.c:769).  Both messages travel the same
+         * socketpair, so READY cannot overtake CREATED.  It can
+         * however be LOST: if that write hits EAGAIN the message is
+         * buffered on the port (nxt_port_socket.c:331-359) and the
+         * worker then enters init->start and never returns to its
+         * loop to flush it, while libunit makes the descriptor
+         * blocking and sends READY regardless.  The record is then
+         * still CREATING here.
+         *
+         * Advancing it is what guarantees the REMOVE_PID that
+         * carries the start stream; leaving it at CREATING would
+         * kill the worker and still leave the start pending, which
+         * is the wedge this arm exists to end.
+         *
+         * CREATED, not READY: it never became usable, and on the
+         * paths main reports rather than the prototype, READY is
+         * what makes main clear the start stream
+         * (nxt_main_process.c:1108-1110).
+         */
+        if (process->state == NXT_PROCESS_STATE_CREATING) {
+            process->state = NXT_PROCESS_STATE_CREATED;
+        }
+
+        /*
+         * The process is left at CREATED because nothing about it
+         * ever became ready, and that costs the release nothing:
+         * an app worker announces itself to the prototype, whose
+         * SIGCHLD handler notifies the others whenever the state is
+         * anything but CREATING (nxt_application.c:907), so CREATED
+         * and READY travel the same path.  The stream that REMOVE_PID
+         * carries -- the one the router turns into the start's
+         * RPC_ERROR -- was set by the prototype when it forked the
+         * worker (nxt_application.c:672) and is untouched here.
+         *
+         * isolated_pid is the pid as this receiver sees it, which
+         * inside a pid namespace is a different number from the
+         * global one; nxt_process.c uses the same identity rule
+         * when it kills a child whose cgroup setup failed.
+         *
+         * The positive test is redundant -- the sender gate above
+         * rejects a non-positive isolated_pid before this arm is
+         * reachable, under the same #if -- and is kept only because
+         * what it guards is kill(0, SIGKILL), which would signal
+         * the caller's whole process group.  A later change that
+         * moved or relaxed that gate would otherwise turn this into
+         * exactly that.
+         */
+        if (nxt_fast_path(process->isolated_pid > 0)) {
+            if (kill(process->isolated_pid, SIGKILL) == -1) {
                 /*
-                 * The whole arm, not only the kill, is confined to the
-                 * platforms that authenticate the sender.  Every step of it
-                 * is destructive -- it refuses the announcement, strands the
-                 * process at CREATED and signals it -- and none of that is
-                 * safe to do on a message that cannot be attributed.
-                 *
-                 * Acting on an unauthenticated message would also be worse
-                 * than the bug it fixes: without the kill below there is
-                 * nothing to reap the worker, so the prototype never sends
-                 * the REMOVE_PID that fails the start, and the latch refuses
-                 * every retransmission -- a start pending forever rather
-                 * than one that fails. Elsewhere the old behaviour stands
-                 * until NEW_PORT and PROCESS_READY carry provenance
-                 * everywhere; that is issue #223.
+                 * ESRCH is ordinary here: the process may already
+                 * have exited with a SIGCHLD still pending.
                  */
-
-                nxt_alert(task, "process %PI ready: cannot map the queue; "
-                          "failing the start", msg->port_msg.pid);
-
-                /*
-                 * The tail below is not reached, so close what the sender
-                 * attached here instead: the descriptor that could not be
-                 * mapped, and fd[1], which this handler never uses.
-                 */
-                nxt_port_recv_msg_close_fds(msg);
-
-                /*
-                 * A retransmitted PROCESS_READY must not signal again: the
-                 * pid has been killed and, once reaped, may name an
-                 * unrelated process.  The state cannot carry this, because
-                 * the process has to stay at CREATED.
-                 */
-                process->start_failed = 1;
-
-                /*
-                 * The kill only fails the start if somebody notices the
-                 * death, and the prototype's SIGCHLD handler notifies the
-                 * others for any state but CREATING
-                 * (nxt_application.c:907).
-                 *
-                 * The record is normally CREATED by then: the worker sends
-                 * PROCESS_CREATED first (nxt_process.c:918) and the
-                 * prototype sets the state when it handles it
-                 * (nxt_application.c:769).  Both messages travel the same
-                 * socketpair, so READY cannot overtake CREATED.  It can
-                 * however be LOST: if that write hits EAGAIN the message is
-                 * buffered on the port (nxt_port_socket.c:331-359) and the
-                 * worker then enters init->start and never returns to its
-                 * loop to flush it, while libunit makes the descriptor
-                 * blocking and sends READY regardless.  The record is then
-                 * still CREATING here.
-                 *
-                 * Advancing it is what guarantees the REMOVE_PID that
-                 * carries the start stream; leaving it at CREATING would
-                 * kill the worker and still leave the start pending, which
-                 * is the wedge this arm exists to end.
-                 *
-                 * CREATED, not READY: it never became usable, and on the
-                 * paths main reports rather than the prototype, READY is
-                 * what makes main clear the start stream
-                 * (nxt_main_process.c:1108-1110).
-                 */
-                if (process->state == NXT_PROCESS_STATE_CREATING) {
-                    process->state = NXT_PROCESS_STATE_CREATED;
-                }
-
-                /*
-                 * The process is left at CREATED because nothing about it
-                 * ever became ready, and that costs the release nothing:
-                 * an app worker announces itself to the prototype, whose
-                 * SIGCHLD handler notifies the others whenever the state is
-                 * anything but CREATING (nxt_application.c:907), so CREATED
-                 * and READY travel the same path.  The stream that REMOVE_PID
-                 * carries -- the one the router turns into the start's
-                 * RPC_ERROR -- was set by the prototype when it forked the
-                 * worker (nxt_application.c:672) and is untouched here.
-                 *
-                 * isolated_pid is the pid as this receiver sees it, which
-                 * inside a pid namespace is a different number from the
-                 * global one; nxt_process.c uses the same identity rule
-                 * when it kills a child whose cgroup setup failed.
-                 *
-                 * The positive test is redundant -- the sender gate above
-                 * rejects a non-positive isolated_pid before this arm is
-                 * reachable, under the same #if -- and is kept only because
-                 * what it guards is kill(0, SIGKILL), which would signal
-                 * the caller's whole process group.  A later change that
-                 * moved or relaxed that gate would otherwise turn this into
-                 * exactly that.
-                 */
-                if (nxt_fast_path(process->isolated_pid > 0)) {
-                    if (kill(process->isolated_pid, SIGKILL) == -1) {
-                        /*
-                         * ESRCH is ordinary here: the process may already
-                         * have exited with a SIGCHLD still pending.
-                         */
-                        nxt_log(task, (nxt_errno == ESRCH) ? NXT_LOG_INFO
-                                                           : NXT_LOG_ALERT,
-                                "kill(%PI, SIGKILL) failed for a process "
-                                "whose queue could not be mapped %E",
-                                process->isolated_pid, nxt_errno);
-                    }
-                }
-
-                return;
-#else
-                /*
-                 * See above: with no kernel-validated sender pid the start
-                 * cannot be failed safely, so the announcement stands and
-                 * the port stays unreachable.  This is issue #231 as it was.
-                 */
-                nxt_alert(task, "process %PI ready: cannot map the queue; "
-                          "the process cannot be reached on this port",
-                          msg->port_msg.pid);
-#endif
-
-            } else {
-                nxt_log(task, NXT_LOG_WARN, "process %PI ready: cannot map "
-                        "the replacement queue, keeping the current one",
-                        msg->port_msg.pid);
+                nxt_log(task, (nxt_errno == ESRCH) ? NXT_LOG_INFO
+                                                   : NXT_LOG_ALERT,
+                        "kill(%PI, SIGKILL) failed for a process "
+                        "whose queue could not be mapped %E",
+                        process->isolated_pid, nxt_errno);
             }
         }
+
+        return;
+#else
+        /*
+         * See above: with no kernel-validated sender pid the start
+         * cannot be failed safely, so the announcement stands and
+         * the port stays unreachable.  This is issue #231 as it was.
+         */
+        nxt_alert(task, "process %PI ready: cannot map the queue; "
+                  "the process cannot be reached on this port",
+                  msg->port_msg.pid);
+#endif
     }
 
     /*

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -389,6 +389,14 @@ nxt_int_t nxt_port_socket_write2(nxt_task_t *task, nxt_port_t *port,
 #if (NXT_TESTS)
 void nxt_port_test_msg_alloc_failures(nxt_uint_t failures);
 void nxt_port_test_run_error_handler(nxt_task_t *task, nxt_port_t *port);
+
+/*
+ * Counts entries into nxt_port_send_new_port().  It is nxt_inline and
+ * skips the announced process and the receiver itself, so a fixture with
+ * one process cannot tell "not broadcast" from "broadcast to nobody" by
+ * observing peers; counting the call itself distinguishes them.
+ */
+NXT_EXPORT extern nxt_uint_t  nxt_port_test_broadcasts;
 #endif
 
 nxt_inline nxt_int_t

--- a/src/nxt_port_socket.c
+++ b/src/nxt_port_socket.c
@@ -40,6 +40,8 @@ static void nxt_port_error_handler(nxt_task_t *task, void *obj, void *data);
 #if (NXT_TESTS)
 static nxt_uint_t  nxt_port_test_msg_alloc_failure_count;
 
+nxt_uint_t  nxt_port_test_broadcasts;
+
 
 void
 nxt_port_test_msg_alloc_failures(nxt_uint_t failures)

--- a/src/nxt_process.h
+++ b/src/nxt_process.h
@@ -123,6 +123,20 @@ struct nxt_process_s {
      */
     nxt_bool_t               released;
 
+    /*
+     * Latched when a PROCESS_READY could not be acted upon and the process
+     * was killed for it (nxt_port_process_ready_handler()).  A retransmitted
+     * PROCESS_READY must not re-enter that arm and signal a pid that has
+     * already been killed -- and, once reaped, may name an unrelated
+     * process.
+     *
+     * The state cannot carry this, because the process is left at CREATED.
+     * Set only where the sender of a PROCESS_READY can be authenticated
+     * (NXT_USE_CMSG_PID); elsewhere that arm is not reachable, so nothing
+     * ever latches it.
+     */
+    nxt_bool_t               start_failed;
+
     nxt_port_mmaps_t         incoming;
 
 

--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -456,6 +456,125 @@ nxt_port_ready_test_short_queue(nxt_thread_t *thr, nxt_task_t *task,
 }
 
 /*
+ * The same wedge reached without any mmap failure: an authenticated
+ * PROCESS_READY for an application worker that carries no descriptor at all.
+ *
+ * At the receiver's RLIMIT_NOFILE the kernel delivers the payload and the
+ * SCM_CREDENTIALS while discarding SCM_RIGHTS and setting MSG_CTRUNC, which
+ * nothing in the receive path inspects -- so the handler sees a message that
+ * passes the sender gate with fd[0] == -1.  Only libunit attaches a queue to
+ * PROCESS_READY and it always does, so for an NXT_PROCESS_APP port this can
+ * never be legitimate; the core processes that do send fd -1 announce to main
+ * and are not APP.
+ *
+ * The fd is injected directly rather than by exhausting descriptors: the
+ * kernel path is the motivation, and reproducing it would make the test
+ * depend on the receiver's rlimit rather than on the handler's decision.
+ */
+static nxt_int_t
+nxt_port_ready_test_no_queue_fd(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_process_t *process, nxt_port_t *port)
+{
+    int    status;
+    pid_t  child, reaped;
+
+    if (nxt_slow_path(port->queue != NULL
+                      || port->type != NXT_PROCESS_APP))
+    {
+        nxt_log_alert(thr->log, "port ready test: the no-queue-fd case needs "
+                      "an app port with no queue");
+        return NXT_ERROR;
+    }
+
+    child = fork();
+    if (child == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to fork the kill "
+                      "target");
+        return NXT_ERROR;
+    }
+
+    if (child == 0) {
+        for ( ;; ) {
+            pause();
+        }
+
+        _exit(0);
+    }
+
+    process->isolated_pid = child;
+    process->start_failed = 0;
+    process->state = NXT_PROCESS_STATE_CREATING;
+
+#if (NXT_USE_CMSG_PID)
+    msg->cmsg_pid = child;
+#endif
+
+    /* What a truncated control block leaves behind. */
+    msg->fd[0] = -1;
+    msg->fd[1] = -1;
+
+    nxt_port_test_broadcasts = 0;
+
+    nxt_port_process_ready_handler(task, msg);
+
+#if (NXT_USE_CMSG_PID)
+
+    if (nxt_port_test_broadcasts != 0 || port->queue != NULL) {
+        nxt_log_alert(thr->log, "port ready test: a READY with no queue "
+                      "descriptor was broadcast anyway");
+        goto fail;
+    }
+
+    if (process->state == NXT_PROCESS_STATE_READY || !process->start_failed) {
+        nxt_log_alert(thr->log, "port ready test: a READY with no queue "
+                      "descriptor still marked the process ready");
+        goto fail;
+    }
+
+    if (waitpid(child, &status, 0) != child) {
+        nxt_log_alert(thr->log, "port ready test failed to reap the kill "
+                      "target");
+        return NXT_ERROR;
+    }
+
+    if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGKILL) {
+        nxt_log_alert(thr->log, "port ready test: the worker that announced "
+                      "no queue did not die of SIGKILL (status %d)", status);
+        return NXT_ERROR;
+    }
+
+#else
+
+    if (process->state != NXT_PROCESS_STATE_READY) {
+        nxt_log_alert(thr->log, "port ready test: a platform with no sender "
+                      "credential did not keep the announcing behaviour");
+        goto fail;
+    }
+
+    (void) kill(child, SIGKILL);
+
+    if (waitpid(child, &status, 0) != child) {
+        nxt_log_alert(thr->log, "port ready test failed to reap the kill "
+                      "target");
+        return NXT_ERROR;
+    }
+
+#endif
+
+    (void) reaped;
+
+    return NXT_OK;
+
+fail:
+
+    (void) kill(child, SIGKILL);
+    (void) waitpid(child, &status, 0);
+
+    return NXT_ERROR;
+}
+
+
+/*
  * Issue #231: a first PROCESS_READY whose queue cannot be mapped.
  *
  * This is a different arm from nxt_port_ready_test_short_queue() above,
@@ -753,11 +872,11 @@ nxt_port_ready_test(nxt_thread_t *thr)
     nxt_pid_t            isolated_pid;
     nxt_task_t           *task;
     nxt_int_t            ret;
-    nxt_port_t           *port, *queueless_port;
+    nxt_port_t           *port, *queueless_port, *nofd_port;
     nxt_runtime_t        *rt, *saved_rt;
     nxt_process_t        *process;
 #if (NXT_HAVE_MEMFD_CREATE)
-    nxt_process_t        *queueless;
+    nxt_process_t        *queueless, *nofd;
 #endif
     nxt_port_recv_msg_t  msg;
 
@@ -784,6 +903,7 @@ nxt_port_ready_test(nxt_thread_t *thr)
     /* Defined before the first goto done: the cleanup there releases them. */
     port = NULL;
     queueless_port = NULL;
+    nofd_port = NULL;
 
     isolated_pid = nxt_pid + 3;
 
@@ -985,6 +1105,48 @@ nxt_port_ready_test(nxt_thread_t *thr)
     ret = nxt_port_ready_test_queueless(thr, task, &msg, queueless,
                                         queueless_port);
 
+    /*
+     * Checked before the next case runs: its own assignment to ret would
+     * otherwise overwrite this failure and the suite would report a pass.
+     */
+    if (nxt_slow_path(ret != NXT_OK)) {
+        msg.port_msg.pid = process->pid;
+        goto done;
+    }
+
+    /*
+     * A second fresh record for the truncated-control case: the one above
+     * has its start_failed latch set, which would refuse the message before
+     * the arm under test is reached.
+     */
+    nofd = nxt_mp_zalloc(mp, sizeof(nxt_process_t));
+    if (nxt_slow_path(nofd == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    nofd->pid = nxt_pid + 6;
+    nofd->state = NXT_PROCESS_STATE_CREATING;
+    nxt_queue_init(&nofd->ports);
+
+    nxt_runtime_process_add(task, nofd);
+
+    nofd_port = nxt_port_new(task, 1, nofd->pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(nofd_port == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    nofd_port->pair[0] = -1;
+    nofd_port->pair[1] = -1;
+    nofd_port->socket.fd = -1;
+
+    nxt_queue_insert_tail(&nofd->ports, &nofd_port->link);
+
+    msg.port_msg.pid = nofd->pid;
+
+    ret = nxt_port_ready_test_no_queue_fd(thr, task, &msg, nofd, nofd_port);
+
     /* Restore the message for anything that runs after this case. */
     msg.port_msg.pid = process->pid;
 #if (NXT_USE_CMSG_PID)
@@ -1026,6 +1188,10 @@ done:
 
     if (queueless_port != NULL) {
         nxt_port_close(task, queueless_port);
+    }
+
+    if (nofd_port != NULL) {
+        nxt_port_close(task, nofd_port);
     }
 
     thr->runtime = saved_rt;

--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -35,6 +35,8 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/wait.h>
+#include <signal.h>
 
 #if (NXT_HAVE_MEMFD_CREATE)
 #include <linux/memfd.h>
@@ -411,7 +413,21 @@ nxt_port_ready_test_short_queue(nxt_thread_t *thr, nxt_task_t *task,
     msg->fd[0] = fd;
     msg->fd[1] = -1;
 
+    nxt_port_test_broadcasts = 0;
+
     nxt_port_process_ready_handler(task, msg);
+
+    /*
+     * The positive half of the broadcast assertion in the queueless case:
+     * refusing a replacement is not a failed start, so this message still
+     * reaches the announcement.  Without this, "not broadcast" there would
+     * pass on a handler that never broadcasts at all.
+     */
+    if (nxt_port_test_broadcasts == 0) {
+        nxt_log_alert(thr->log, "port ready test: a kept queue was not "
+                      "broadcast");
+        return NXT_ERROR;
+    }
 
     if (port->queue != prev_queue || port->queue_fd != prev_fd) {
         nxt_log_alert(thr->log, "port ready test: short queue replaced the "
@@ -439,6 +455,294 @@ nxt_port_ready_test_short_queue(nxt_thread_t *thr, nxt_task_t *task,
     return NXT_OK;
 }
 
+/*
+ * Issue #231: a first PROCESS_READY whose queue cannot be mapped.
+ *
+ * This is a different arm from nxt_port_ready_test_short_queue() above,
+ * and the distinction is the whole point.  That case runs after a queue
+ * has been installed, so the handler keeps the working mapping and the
+ * process stays ready -- refusing a replacement is not a failed start.
+ * Here the port has no queue at all, so there is nothing to fall back to:
+ * the worker is unreachable on this port forever, and the start has to
+ * fail rather than be marked ready.
+ *
+ * The kill target is a real forked child, never nxt_pid + N.  The suite
+ * runs as root in CI, so a made-up pid is a live process on the machine;
+ * only the pid fork() returned is known to be ours to signal.
+ */
+static nxt_int_t
+nxt_port_ready_test_queueless(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_process_t *process, nxt_port_t *port)
+{
+    int        status;
+    pid_t      child, reaped;
+    nxt_fd_t   fd;
+    nxt_uint_t i;
+
+    if (nxt_slow_path(port->queue != NULL)) {
+        nxt_log_alert(thr->log, "port ready test: the queueless case needs a "
+                      "port with no queue");
+        return NXT_ERROR;
+    }
+
+    /*
+     * A child that only waits to be killed.  _exit() rather than return so
+     * that a child which somehow escapes pause() cannot run the rest of the
+     * test suite as a second process.
+     */
+    child = fork();
+    if (child == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to fork the kill "
+                      "target");
+        return NXT_ERROR;
+    }
+
+    if (child == 0) {
+        for ( ;; ) {
+            pause();
+        }
+
+        _exit(0);
+    }
+
+    process->isolated_pid = child;
+
+#if (NXT_USE_CMSG_PID)
+    /* The sender gate compares against isolated_pid, which is now the child. */
+    msg->cmsg_pid = child;
+#endif
+
+    fd = syscall(SYS_memfd_create, "nxt_port_ready_test", MFD_CLOEXEC);
+    if (fd == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to create the queue");
+        goto fail;
+    }
+
+    /* One page: every byte past it faults, so the mapping must be refused. */
+    if (ftruncate(fd, nxt_pagesize) == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to size the queue");
+        (void) close(fd);
+        goto fail;
+    }
+
+    msg->fd[0] = fd;
+    msg->fd[1] = -1;
+
+    nxt_port_test_broadcasts = 0;
+
+    nxt_port_process_ready_handler(task, msg);
+
+    if (msg->fd[0] != -1 || nxt_port_ready_test_fd_is_open(fd)) {
+        nxt_log_alert(thr->log, "port ready test: the refused queue leaked "
+                      "its descriptor");
+        goto fail;
+    }
+
+    if (port->queue != NULL || port->queue_fd != -1) {
+        nxt_log_alert(thr->log, "port ready test: a refused queue was "
+                      "installed anyway");
+        goto fail;
+    }
+
+#if (NXT_USE_CMSG_PID)
+
+    /*
+     * Never announce a port nothing can be delivered on: every peer would
+     * hold the same unreachable copy, and a QUIT could never arrive.  The
+     * kept-queue case above is what stops this passing vacuously.
+     */
+    if (nxt_port_test_broadcasts != 0) {
+        nxt_log_alert(thr->log, "port ready test: a refused queue was "
+                      "broadcast anyway");
+        goto fail;
+    }
+
+    /*
+     * Not ready: nothing about this worker ever became usable, and the
+     * prototype's SIGCHLD notifies the others for any state but CREATING,
+     * so leaving it at CREATED still reaches the start's failure.
+     */
+    if (process->state == NXT_PROCESS_STATE_READY) {
+        nxt_log_alert(thr->log, "port ready test: a refused queue still "
+                      "marked the process ready");
+        goto fail;
+    }
+
+    if (!process->start_failed) {
+        nxt_log_alert(thr->log, "port ready test: a refused queue did not "
+                      "mark the start as failed");
+        goto fail;
+    }
+
+    /*
+     * The fixture enters at CREATING, as a worker whose WHOAMI has not been
+     * handled yet would.  Killing it while it is still CREATING would leave
+     * the prototype's SIGCHLD silent (nxt_application.c:907) and the start
+     * pending -- the wedge, reached by a different road.
+     */
+    if (process->state != NXT_PROCESS_STATE_CREATED) {
+        nxt_log_alert(thr->log, "port ready test: a refused queue left the "
+                      "process at CREATING, so nothing will notify its death");
+        goto fail;
+    }
+
+    /*
+     * Polled rather than blocking: a handler that never signalled would
+     * otherwise hang the suite instead of failing it.
+     */
+    for (i = 0; i < 100; i++) {
+        reaped = waitpid(child, &status, WNOHANG);
+
+        if (reaped == child) {
+            break;
+        }
+
+        if (reaped == -1) {
+            nxt_log_alert(thr->log, "port ready test: waitpid() failed %E",
+                          nxt_errno);
+            goto fail;
+        }
+
+        nxt_nanosleep(10 * 1000000);   /* 10ms, so at most a second. */
+    }
+
+    if (reaped != child) {
+        nxt_log_alert(thr->log, "port ready test: the process whose queue "
+                      "was refused was not killed");
+        goto fail;
+    }
+
+    if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGKILL) {
+        nxt_log_alert(thr->log, "port ready test: the killed process did not "
+                      "die of SIGKILL (status %d)", status);
+        return NXT_ERROR;
+    }
+
+    /*
+     * The latch, tested for what it is actually for.  A retransmitted
+     * PROCESS_READY must not signal a second time: the first pid has been
+     * reaped and may by now name an unrelated process.  Pointing
+     * isolated_pid at a second, live child makes that concrete -- without
+     * the latch the handler re-enters the failure arm and kills it, so the
+     * child's survival is the assertion.  Re-checking the first pid would
+     * prove nothing, since it is already dead.
+     */
+    child = fork();
+    if (child == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to fork the second "
+                      "kill target");
+        return NXT_ERROR;
+    }
+
+    if (child == 0) {
+        for ( ;; ) {
+            pause();
+        }
+
+        _exit(0);
+    }
+
+    process->isolated_pid = child;
+    msg->cmsg_pid = child;
+
+    fd = syscall(SYS_memfd_create, "nxt_port_ready_test", MFD_CLOEXEC);
+    if (fd == -1 || ftruncate(fd, nxt_pagesize) == -1) {
+        nxt_log_alert(thr->log, "port ready test failed to re-create the "
+                      "queue");
+        if (fd != -1) {
+            (void) close(fd);
+        }
+        goto fail;
+    }
+
+    msg->fd[0] = fd;
+    msg->fd[1] = -1;
+
+    nxt_port_process_ready_handler(task, msg);
+
+    if (msg->fd[0] != -1 || nxt_port_ready_test_fd_is_open(fd)) {
+        nxt_log_alert(thr->log, "port ready test: the retransmitted READY "
+                      "leaked its descriptor");
+        goto fail;
+    }
+
+    if (process->state == NXT_PROCESS_STATE_READY) {
+        nxt_log_alert(thr->log, "port ready test: the retransmitted READY "
+                      "marked the process ready");
+        goto fail;
+    }
+
+    /*
+     * Still running: the latch refused the arm before it reached the kill.
+     *
+     * SIGKILL is delivered asynchronously, so a single WNOHANG poll here
+     * would race a handler that did signal and read as "survived" -- the
+     * assertion has to give a kill time to land before concluding none
+     * happened.  Verified by removing the latch check: without this window
+     * the mutation passes, with it the child is reaped and the test fails.
+     */
+    for (i = 0; i < 20; i++) {
+        reaped = waitpid(child, &status, WNOHANG);
+
+        if (reaped != 0) {
+            nxt_log_alert(thr->log, "port ready test: a retransmitted READY "
+                          "killed again");
+            return NXT_ERROR;
+        }
+
+        nxt_nanosleep(10 * 1000000);   /* 10ms, so 200ms in total. */
+    }
+
+    (void) kill(child, SIGKILL);
+    (void) waitpid(child, &status, 0);
+
+#else
+
+    /*
+     * With no kernel-validated sender pid the start cannot be failed
+     * safely, so the handler keeps the pre-#231 behaviour and announces the
+     * process on a port that cannot be reached.  Asserting that here is what
+     * keeps the guard honest: a change that quietly enabled the destructive
+     * arm on an unauthenticated platform fails this.
+     */
+    (void) i;
+    (void) reaped;
+
+    if (process->state != NXT_PROCESS_STATE_READY
+        || nxt_port_test_broadcasts == 0)
+    {
+        nxt_log_alert(thr->log, "port ready test: a platform with no sender "
+                      "credential did not keep the announcing behaviour");
+        goto fail;
+    }
+
+    if (process->start_failed) {
+        nxt_log_alert(thr->log, "port ready test: a platform with no sender "
+                      "credential latched a failed start");
+        goto fail;
+    }
+
+    /* Nothing signalled it, so the child is ours to clean up. */
+    (void) kill(child, SIGKILL);
+
+    if (waitpid(child, &status, 0) != child) {
+        nxt_log_alert(thr->log, "port ready test failed to reap the kill "
+                      "target");
+        return NXT_ERROR;
+    }
+
+#endif
+
+    return NXT_OK;
+
+fail:
+
+    (void) kill(child, SIGKILL);
+    (void) waitpid(child, &status, 0);
+
+    return NXT_ERROR;
+}
+
 #endif
 
 
@@ -449,9 +753,12 @@ nxt_port_ready_test(nxt_thread_t *thr)
     nxt_pid_t            isolated_pid;
     nxt_task_t           *task;
     nxt_int_t            ret;
-    nxt_port_t           *port;
+    nxt_port_t           *port, *queueless_port;
     nxt_runtime_t        *rt, *saved_rt;
     nxt_process_t        *process;
+#if (NXT_HAVE_MEMFD_CREATE)
+    nxt_process_t        *queueless;
+#endif
     nxt_port_recv_msg_t  msg;
 
     nxt_thread_time_update(thr);
@@ -474,8 +781,9 @@ nxt_port_ready_test(nxt_thread_t *thr)
 
 #endif
 
-    /* Defined before the first goto done: the cleanup there releases it. */
+    /* Defined before the first goto done: the cleanup there releases them. */
     port = NULL;
+    queueless_port = NULL;
 
     isolated_pid = nxt_pid + 3;
 
@@ -642,6 +950,51 @@ nxt_port_ready_test(nxt_thread_t *thr)
         goto done;
     }
 
+    /*
+     * Issue #231 needs its own fixture: the process above is ready and its
+     * port has a working queue, which is exactly the case that must NOT
+     * fail a start.  A fresh record, never announced, is the only way to
+     * reach the first-mapping arm.
+     */
+    queueless = nxt_mp_zalloc(mp, sizeof(nxt_process_t));
+    if (nxt_slow_path(queueless == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    queueless->pid = nxt_pid + 5;
+    queueless->state = NXT_PROCESS_STATE_CREATING;
+    nxt_queue_init(&queueless->ports);
+
+    nxt_runtime_process_add(task, queueless);
+
+    queueless_port = nxt_port_new(task, 1, queueless->pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(queueless_port == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    queueless_port->pair[0] = -1;
+    queueless_port->pair[1] = -1;
+    queueless_port->socket.fd = -1;
+
+    nxt_queue_insert_tail(&queueless->ports, &queueless_port->link);
+
+    msg.port_msg.pid = queueless->pid;
+
+    ret = nxt_port_ready_test_queueless(thr, task, &msg, queueless,
+                                        queueless_port);
+
+    /* Restore the message for anything that runs after this case. */
+    msg.port_msg.pid = process->pid;
+#if (NXT_USE_CMSG_PID)
+    msg.cmsg_pid = process->isolated_pid;
+#endif
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
 #if (NXT_USE_CMSG_PID)
 
     /*
@@ -669,6 +1022,10 @@ done:
      */
     if (port != NULL) {
         nxt_port_close(task, port);
+    }
+
+    if (queueless_port != NULL) {
+        nxt_port_close(task, queueless_port);
     }
 
     thr->runtime = saved_rt;

--- a/src/test/nxt_router_remove_pid_soak_test.c
+++ b/src/test/nxt_router_remove_pid_soak_test.c
@@ -1,0 +1,423 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Accounting soak for the route a refused worker start really travels
+ * (issue #231).  When a worker never becomes usable, nothing cancels its
+ * start RPC directly: the prototype reaps the child and sends REMOVE_PID
+ * carrying the stream the start was registered under, and the router turns
+ * that into the start failure.
+ *
+ * The chain this exercises, in the router's own order:
+ *
+ *   nxt_router_remove_pid_handler()  retypes a last-marked REMOVE_PID that
+ *                                    carries a non-zero stream into
+ *                                    _NXT_PORT_MSG_RPC_ERROR
+ *     -> nxt_port_rpc_handler()      finds and deletes the registration
+ *     -> nxt_router_app_port_error() the RPC is a worker start, so ->proto
+ *                                    is 0 and the count is 1
+ *     -> nxt_router_app_start_failed()  gives that one slot back
+ *
+ * The handler is private to src/nxt_router.c; it is reached the way the
+ * port dispatcher reaches it, through the router's published handler table
+ * in nxt_router_process.
+ *
+ * Every iteration arms a real start through
+ * nxt_router_start_app_process_handler(), takes the stream from the
+ * START_PROCESS message that start actually queued for the prototype --
+ * the very stream a prototype would echo back -- and requires
+ * pending_processes at its baseline afterwards.  A leak leaves baseline+1
+ * and a double release leaves baseline-1; both are caught without
+ * nxt_assert, so the check survives a non-debug build.
+ *
+ * The baselines alternate between 0 and a non-zero value because an
+ * over-release at baseline 0 is the case that hides: nxt_router.c clamps
+ * the count to pending_processes rather than letting it wrap, so the
+ * counter simply stays at 0 and an equality check against 0 cannot tell
+ * the difference.  At a non-zero baseline the same bug shows up plainly.
+ *
+ * The counter app->proto_port_requests is required to stay 0 throughout.
+ * A worker start cannot touch it -- ->proto is set from the same condition
+ * that increments it, and this route never arms a prototype -- so the check
+ * is a guard against the fixture drifting into the prototype path, not a
+ * failure this route can produce.
+ *
+ * A stream nothing registered is delivered too, so the release above
+ * cannot be credited to anything other than the RPC registration.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_rpc.h>
+#include <nxt_runtime.h>
+#include <nxt_router.h>
+#include <nxt_main_process.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+
+#define NXT_ROUTER_REMOVE_PID_SOAK_N  1000
+
+
+/* File scope: the handler hands the application to the router's
+   reference-counting helpers, so its storage must outlive the frame. */
+static nxt_app_t  nxt_router_remove_pid_soak_test_app;
+
+
+/*
+ * The stream a start put on the wire.  nxt_port_socket_write2() queues the
+ * START_PROCESS message at the tail of the destination port, so the newest
+ * one is this iteration's; returns 0, which the caller rejects, if the
+ * write did not queue anything.
+ */
+
+static uint32_t
+nxt_router_remove_pid_soak_stream(nxt_port_t *dport)
+{
+    nxt_queue_link_t     *link;
+    nxt_port_send_msg_t  *msg;
+
+    if (nxt_slow_path(nxt_queue_is_empty(&dport->messages))) {
+        return 0;
+    }
+
+    link = nxt_queue_last(&dport->messages);
+    msg = nxt_queue_link_data(link, nxt_port_send_msg_t, link);
+
+    return msg->port_msg.stream;
+}
+
+
+/*
+ * A REMOVE_PID as the prototype sends it: the reaped worker's pid as the
+ * whole payload, the start stream, and last set so the registration is
+ * deleted rather than merely looked up.  Modelled on the message
+ * nxt_port_rpc_remove_peer() synthesises for the same purpose.
+ */
+
+static void
+nxt_router_remove_pid_soak_msg(nxt_port_recv_msg_t *msg, nxt_buf_t *buf,
+    nxt_port_t *port, nxt_pid_t *pid, uint32_t stream)
+{
+    nxt_memzero(msg, sizeof(nxt_port_recv_msg_t));
+    nxt_memzero(buf, sizeof(nxt_buf_t));
+
+    buf->mem.pos = (u_char *) pid;
+    buf->mem.free = (u_char *) (pid + 1);
+
+    msg->fd[0] = -1;
+    msg->fd[1] = -1;
+    msg->buf = buf;
+    msg->port = port;
+
+    msg->port_msg.stream = stream;
+    msg->port_msg.pid = nxt_pid;
+    msg->port_msg.type = _NXT_PORT_MSG_REMOVE_PID;
+    msg->port_msg.last = 1;
+}
+
+
+nxt_int_t
+nxt_router_remove_pid_soak_test(nxt_thread_t *thr)
+{
+    nxt_mp_t             *mp;
+    nxt_app_t            *app;
+    nxt_buf_t            buf;
+    nxt_pid_t            worker_pid;
+    nxt_int_t            ret;
+    uint32_t             baseline, stream;
+    nxt_uint_t           i;
+    nxt_bool_t           app_mutex;
+    nxt_task_t           *task;
+    nxt_port_t           *router_port, *dport;
+    nxt_router_t         router, *saved_router;
+    nxt_runtime_t        *rt, *saved_rt;
+    nxt_app_joint_t      *joint;
+    nxt_event_engine_t   engine, *saved_engine;
+    nxt_port_recv_msg_t  msg;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "router remove pid soak test started");
+
+    ret = NXT_ERROR;
+    router_port = NULL;
+    dport = NULL;
+    joint = NULL;
+    app_mutex = 0;
+    app = &nxt_router_remove_pid_soak_test_app;
+
+    /*
+     * No process by this pid is registered, so nxt_port_remove_pid() finds
+     * nothing to tear down and the message carries the stream alone -- the
+     * part of REMOVE_PID this test is about.
+     */
+    worker_pid = nxt_pid + 1;
+
+    task = thr->task;
+    task->thread = thr;
+
+    if (nxt_slow_path(nxt_port_rpc_init() != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    joint = nxt_mp_zalloc(mp, sizeof(nxt_app_joint_t));
+    if (nxt_slow_path(rt == NULL || joint == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * Only the members the reached code touches are set; see
+     * src/test/nxt_router_new_port_test.c.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    /*
+     * nxt_router_remove_pid_handler() forwards the removal to every router
+     * engine before it reaches the RPC, and dereferences the nxt_router
+     * global to find them.  An empty list is the honest arrangement here:
+     * this fixture runs no worker engines, and what the forwarding does --
+     * dropping the dead process from each engine's app port hash -- is not
+     * part of the pending_processes accounting under test.
+     */
+    nxt_memzero(&router, sizeof(nxt_router_t));
+    nxt_queue_init(&router.engines);
+
+    saved_router = nxt_router;
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+    nxt_router = &router;
+    thr->runtime = rt;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    /* The port the handler registers its RPC on, and REMOVE_PID arrives on. */
+
+    router_port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    /*
+     * nxt_port_rpc_register_handler_ex() asserts on a live pair[0]; the
+     * descriptor is never touched here, so borrow the nxt_port_fail_test()
+     * convention of a placeholder that is reset before the port is freed.
+     */
+    router_port->pair[0] = 0;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * The prototype the start addresses.  No queue and write_ready unset,
+     * so nxt_port_socket_write2() takes the nxt_port_msg_chk_insert() path
+     * and the START_PROCESS message is simply queued: the write succeeds,
+     * the RPC stays armed, and the queued message is where the stream is
+     * read back from.
+     */
+
+    dport = nxt_port_new(task, 1, nxt_pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(dport == NULL)) {
+        goto done;
+    }
+
+    dport->pair[0] = -1;
+    dport->pair[1] = -1;
+    dport->socket.fd = -1;
+
+    nxt_memzero(app, sizeof(nxt_app_t));
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&app->mutex) != NXT_OK)) {
+        goto done;
+    }
+
+    app_mutex = 1;
+
+    nxt_queue_init(&app->ports);
+    nxt_queue_init(&app->spare_ports);
+    nxt_queue_init(&app->idle_ports);
+    nxt_queue_init(&app->ack_waiting_req);
+
+    nxt_str_set(&app->name, "remove-pid-soak-test");
+
+    app->joint = joint;
+    joint->app = app;
+    joint->use_count = 1;
+
+    app->max_processes = 8;
+    app->max_pending_processes = 4;
+
+    /* A prototype port is present, so every start is a worker start. */
+    app->proto_port = dport;
+
+    /* One process alive, so the failure path has no requests to fail. */
+    app->processes = 1;
+
+    /* Set once: a worker start must leave this alone.  See the file head. */
+    app->proto_port_requests = 0;
+
+    for (i = 0; i < NXT_ROUTER_REMOVE_PID_SOAK_N; i++) {
+        baseline = (i % 2) ? 2 : 0;
+
+        /* What a real initiator leaves behind: the slot and the work's use. */
+        app->pending_processes = baseline + 1;
+        app->use_count = 2;
+
+        nxt_router_start_app_process_handler(task, router_port, app);
+
+        if (app->pending_processes != baseline + 1 || joint->use_count != 2
+            || app->use_count != 1)
+        {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui armed "
+                          "start left pending %uD joint %uD app use %d "
+                          "(expected %uD, 2 and 1)",
+                          i, app->pending_processes, joint->use_count,
+                          (int) app->use_count, baseline + 1);
+            goto done;
+        }
+
+        stream = nxt_router_remove_pid_soak_stream(dport);
+
+        if (nxt_slow_path(stream == 0)) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui start "
+                          "queued no START_PROCESS message to read a stream "
+                          "from", i);
+            goto done;
+        }
+
+        /*
+         * A stream no start registered: the handler must find no
+         * registration and change nothing.  Without this the release below
+         * could be credited to any bookkeeping REMOVE_PID happens to do.
+         */
+
+        nxt_router_remove_pid_soak_msg(&msg, &buf, router_port, &worker_pid,
+                                       stream + 1);
+
+        nxt_router_process.port_handlers->remove_pid(task, &msg);
+
+        if (app->pending_processes != baseline + 1 || joint->use_count != 2) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui "
+                          "unregistered stream released pending %uD joint %uD "
+                          "(expected %uD and 2)",
+                          i, app->pending_processes, joint->use_count,
+                          baseline + 1);
+            goto done;
+        }
+
+        /* The real one: the worker died before it ever reported ready. */
+
+        nxt_router_remove_pid_soak_msg(&msg, &buf, router_port, &worker_pid,
+                                       stream);
+
+        nxt_router_process.port_handlers->remove_pid(task, &msg);
+
+        if (msg.port_msg.type != _NXT_PORT_MSG_RPC_ERROR
+            || msg.u.removed_pid != worker_pid)
+        {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui "
+                          "REMOVE_PID was not turned into an RPC error for "
+                          "pid %PI, type %d pid %PI",
+                          i, worker_pid, (int) msg.port_msg.type,
+                          msg.u.removed_pid);
+            goto done;
+        }
+
+        if (app->pending_processes != baseline) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui "
+                          "pending_processes %uD (expected %uD)",
+                          i, app->pending_processes, baseline);
+            goto done;
+        }
+
+        if (app->proto_port_requests != 0) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui worker "
+                          "start touched proto_port_requests %uD (expected 0)",
+                          i, app->proto_port_requests);
+            goto done;
+        }
+
+        if (joint->use_count != 1 || app->use_count != 1) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: iteration %ui joint "
+                          "use_count %uD app use_count %d (expected 1 and 1)",
+                          i, joint->use_count, (int) app->use_count);
+            goto done;
+        }
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "router remove pid soak test passed: %d starts failed "
+                  "through REMOVE_PID", NXT_ROUTER_REMOVE_PID_SOAK_N);
+
+    ret = NXT_OK;
+
+done:
+
+    if (dport != NULL) {
+        app->proto_port = NULL;
+
+        /*
+         * Every start queued its START_PROCESS message rather than writing
+         * it, and nxt_port_msg_chk_insert() takes a port reference for each.
+         * Left alone the port never reaches nxt_port_mp_cleanup(), so its
+         * pool and messages leak and the assertions there never run -- which
+         * would quietly hollow out this test under a debug build.
+         */
+        nxt_port_test_run_error_handler(task, dport);
+
+        if (!nxt_queue_is_empty(&dport->messages)) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router remove pid soak test: prototype port still "
+                          "holds queued messages after teardown");
+            ret = NXT_ERROR;
+        }
+
+        nxt_port_use(task, dport, -1);
+    }
+
+    if (router_port != NULL) {
+        router_port->pair[0] = -1;
+
+        nxt_port_use(task, router_port, -1);
+    }
+
+    thr->engine = saved_engine;
+    thr->runtime = saved_rt;
+    nxt_router = saved_router;
+
+    if (app_mutex) {
+        nxt_thread_mutex_destroy(&app->mutex);
+    }
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -213,6 +213,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_router_remove_pid_soak_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -77,6 +77,7 @@ nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_proto_wedge_test(nxt_thread_t *thr);
+nxt_int_t nxt_router_remove_pid_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);


### PR DESCRIPTION
Closes #231 (the behavioural half; the log/comment half was #232, the sender authentication was #253).

A worker whose shared-memory queue cannot be mapped used to be marked READY, broadcast to every peer, and left running — reachable by nobody: the READ_SOCKET marker is only emitted by queue-holding senders, so every private-port message to it is suspended until `too many port socket messages` kills it, and its start slot stays parked (the PR #212 log-rotation repro). Now the start fails instead:

- The failure arm (behind `#if (NXT_USE_CMSG_PID)`, i.e. only where #253's sender authentication exists — a signalling arm without an authenticated sender would be a remote-SIGKILL primitive) alerts, closes the received descriptor, latches the process (`start_failed`, so a retransmitted READY logs and returns instead of killing twice), advances a still-CREATING record to CREATED, and SIGKILLs by `isolated_pid` (guarded `> 0`; the receiver-visible pid — the global pid can miss inside a PID namespace).
- READY and the NEW_PORT broadcast now happen only on the success path; fd −1 senders (router/controller/prototype announcing to main) are unaffected.
- No new plumbing: the prototype's SIGCHLD (gated `state != CREATING`, hence the advance) sends REMOVE_PID carrying the start stream, the router retypes it to RPC_ERROR, and `nxt_router_app_start_failed()` releases the slot exactly (#255's count contract). Retry is request-driven — same class as any startup crash, no autonomous loop.
- The CREATING-at-READY window is real but narrow: a worker's PROCESS_CREATED can be stranded in `port->messages` by EAGAIN (the worker enters `init->start` and never returns to flush it) while libunit's READY goes through after switching the fd to blocking. Static-traced, not observed; pid-isolated workers can't reach the arm at CREATING at all (their record isn't in the hash until the CREATED handler adds it). The CREATING-silence is specific to this path: the prototype's reaper gates on state (`nxt_application.c:907`) while main's calls `nxt_port_remove_notify_others()` unconditionally (`nxt_main_process.c:1146`) — a record main reaps needs no advance.

Tests: a fresh no-queue fixture driving the failure arm (the pre-existing short-queue case exercises the *replacement* arm, which is pinned unchanged: a working worker whose re-announce fails is not killed); a real broadcast observer with a positive control; kill target asserted via a forked sleeper reaped with `WTERMSIG == SIGKILL`; a 1000-iteration soak through `nxt_router_remove_pid_handler()` asserting `pending_processes` returns to baseline, fixtures draining their ports (#258/#262 pattern). Four negative controls each turn the suite red (arm removed, master's handler, latch disabled, CREATING advance removed). `-Werror` clean with `NXT_HAVE_UCRED` and with `NXT_HAVE_MEMFD_CREATE` unset — on the former the destructive arm is compiled out (verified on the object). C suite green normal and `--debug`; PHP regression 62 passed incl. SIGUSR1 rotation and reconfigure.

Codex: three rounds, last clean; the two earlier findings (credentialless-platform propagation, the CREATING advance) are fixed in this commit. Independent review trail in plan-231-queueless-port.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

