### PR TITLE
test(tls): stop asserting that a session resumes in the same instant

### DIFF
--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,4 +1,5 @@
 import socket
+import time
 
 import pytest
 
@@ -332,8 +333,14 @@ def test_listeners_addr_error_2(skip_alert):
 
 
 def test_listeners_port_release():
+    # Since the two-phase listener drain (1.36.0) a successful
+    # configuration means accept has been disarmed, not that the
+    # descriptor is closed: it stays bound until the drain completes, so
+    # rebinding straight away can lose a race with it.  The documented
+    # behaviour is at src/nxt_router.c, in nxt_router_listen_socket_close().
+    # Retry rather than assume, so the test still fails if the port is
+    # never released.
     for _ in range(10):
-        fail = False
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
@@ -346,14 +353,19 @@ def test_listeners_port_release():
 
             resp = client.conf({"listeners": {}, "applications": {}})
 
-            try:
-                s.bind(('127.0.0.1', 8080))
-                s.listen()
+            bound = False
 
-            except OSError:
-                fail = True
+            for _ in range(50):
+                try:
+                    s.bind(('127.0.0.1', 8080))
+                    s.listen()
+                    bound = True
+                    break
 
-            if fail:
+                except OSError:
+                    time.sleep(0.1)
+
+            if not bound:
                 pytest.fail('cannot bind or listen to the address')
 
             assert 'success' in resp, 'port release'

--- a/test/test_tls_session.py
+++ b/test/test_tls_session.py
@@ -73,6 +73,33 @@ def connect(ctx=None, session=None):
     )
 
 
+def resume(ctx, session, tries=5, delay=0.1):
+    """Reconnect until the session is served from the cache.
+
+    OpenSSL adds a session to the server cache after flushing its Finished
+    message, so a resume attempted in the same instant the handshake
+    completed can arrive before the insert.  With more than one router
+    engine the reconnect may be accepted by an engine that has not seen it
+    yet, and a full handshake results.
+
+    Unit does not promise that a session is resumable in the instant it is
+    established -- only that an unexpired one resumes -- so poll for the
+    property that actually holds instead of racing the one that does not.
+    A miss on the first attempt is the whole of the effect in practice;
+    the retries are bounded low because every full handshake inserts a
+    session of its own and would otherwise churn a small cache.
+    """
+    for _ in range(tries):
+        _, _, _, reused = connect(ctx, session)
+
+        if reused:
+            return True
+
+        time.sleep(delay)
+
+    return False
+
+
 @pytest.mark.skipif(
     not hasattr(_lib, 'SSL_session_reused'),
     reason='session reuse is not supported',
@@ -89,11 +116,9 @@ def test_tls_session():
     _, sess, ctx, reused = connect()
     assert not reused, 'new connection cache'
 
-    _, _, _, reused = connect(ctx, sess)
-    assert reused, 'cache'
+    assert resume(ctx, sess), 'cache'
 
-    _, _, _, reused = connect(ctx, sess)
-    assert reused, 'cache 2'
+    assert resume(ctx, sess), 'cache 2'
 
     # check that at least one session of four is not reused
 
@@ -110,8 +135,7 @@ def test_tls_session():
     conns = [connect() for _ in range(4)]
     assert True not in [c[-1] for c in conns], 'cache big all new'
 
-    conns_again = [connect(c[2], c[1]) for c in conns]
-    assert False not in [c[-1] for c in conns_again], 'cache big reuse'
+    assert all(resume(c[2], c[1]) for c in conns), 'cache big reuse'
 
 
 @pytest.mark.skipif(
@@ -119,19 +143,28 @@ def test_tls_session():
     reason='session reuse is not supported',
 )
 def test_tls_session_timeout():
-    # OpenSSL evaluates session expiry in whole seconds (time_t), so a 1s
-    # timeout leaves barely over one second of real slack for the resume
-    # below and evicts the session early under CI load, making the "no
-    # timeout" assertion flaky.  Use a comfortable window and sleep past it.
-    assert 'success' in add_session(cache_size=5, timeout=4)
+    # The two halves are configured separately rather than fitted into one
+    # window.  "Still cached" only needs a timeout no run can outlast, and
+    # "evicted" only needs one every run outlasts; sharing a window makes
+    # each assertion depend on the other's margin, which is what made this
+    # flaky.  Slow machines make the eviction half more certain, not less.
+
+    assert 'success' in add_session(cache_size=5, timeout=300)
 
     _, sess, ctx, reused = connect()
     assert not reused, 'new connection'
 
-    _, _, _, reused = connect(ctx, sess)
-    assert reused, 'no timeout'
+    assert resume(ctx, sess), 'no timeout'
 
-    time.sleep(6)
+    assert 'success' in add_session(cache_size=5, timeout=1)
+
+    # The reconfiguration above rebuilds the TLS context and with it the
+    # session cache, so the session that outlives the timeout has to be
+    # established after it.
+    _, sess, ctx, reused = connect()
+    assert not reused, 'new connection timeout'
+
+    time.sleep(3)
 
     _, _, _, reused = connect(ctx, sess)
     assert not reused, 'timeout'


### PR DESCRIPTION
Draft — the TLS half is verified by local reproduction; the port-release half is not (see below).

Fixes the flakes tracked in #51, which has been open since 1.35.4 with "restarted now" as the only response. [Diagnosis and evidence in the issue comment.](https://github.com/freeunitorg/freeunit/issues/51#issuecomment-5485966568)

## Why the tests fail

Unit keeps no session cache of its own: `nxt_ssl_session_cache()` (`src/nxt_openssl.c:789-802`) sets the mode, size and timeout on one shared `SSL_CTX`. OpenSSL adds a session to the server cache **after** flushing its Finished message, so the insert lands fractionally after the client's handshake completes.

With one router engine the event loop serialises "finish handshake → add → accept next" and the window cannot be observed. With several, the client's immediate reconnect can be accepted by an engine that has not seen the insert yet, and a full handshake results.

That is OpenSSL's ordering, not a defect worth working around in Unit — a miss costs one extra handshake, and no real client reconnects a millisecond after its last handshake. But the tests assert that a session is resumable *in the instant it is established*, which Unit does not guarantee and which only ever passed because single-engine accept timing hid the window.

## It is not expiry, and not architecture

Alpine pipeline 468345 is a **retry** of a red run. The failures moved instead of clearing — `armv7` went green, `armhf` picked up `test_listeners_port_release`, and `aarch64` switched to `test_tls_session`, failing at the immediate resume where the session is configured with **no timeout** and the 300-second default applies. No expiry window is being raced.

The replaced comment claimed OpenSSL evaluates expiry in whole seconds. That has not been true since OpenSSL 3.2 (microsecond `OSSL_TIME`), and the flake it widened the window for was almost certainly this same race, mislabelled — which is why no timeout value ever fixed it.

## What changed

- `resume()` reconnects until the session is served from the cache, bounded. A genuine failure to resume still fails the test. The retry count is deliberately low, because every missed attempt is itself a full handshake that inserts a session and would churn a small cache.
- `test_tls_session_timeout` stops fitting both halves into one window. It used `timeout=4` with `sleep(6)`, so "still cached" and "evicted" each depended on the other's margin. They are configured separately now — which also makes the eviction half *more* certain on a slow machine, not less. The session that must expire is established after that reconfiguration, since rebuilding the TLS context flushes the cache.
- `test_listeners_port_release` gets a bind retry. Since the two-phase listener drain in 1.36.0 (`9ae96c38`) a successful configuration means accept has been disarmed, not that the descriptor is closed — it stays bound until the drain completes, and the `EADDRINUSE` consequence is documented in `nxt_router_listen_socket_close()`. The test still pinned the pre-1.36 contract.

## Verification

Reproduced locally rather than waiting on CI. Default engine count, 16× CPU load:

| | idle | under load |
| --- | --- | --- |
| current tests | pass | **3 of 6 runs fail** — `AssertionError: cache`, `AssertionError: no timeout` |
| this branch | pass | **6 of 6 pass** |

Those are the same two signatures Alpine reports.

**The port-release half is not reproduced here:** 33 runs, 330 bind attempts under the same load, no failure. That change rests on the documented drain behaviour and on CI, where it has now failed on two different architectures in two consecutive pipelines. Flagging it explicitly rather than implying both halves carry equal evidence.

## Open question for review

Whether the bind retry is the right answer for `test_listeners_port_release`, or whether the product should close the descriptor before acknowledging the configuration when no connections are in flight. The latter restores "success means the port is free" at no cost to the drain feature, but touches listener lifetime ordering; the former documents a behaviour change that shipped in 1.36.0 without release notes. I have taken the test-side fix here because it is contained, but the product-side answer may be the one you want.
