### PR TITLE
main: reply to every START_PROCESS that cannot start a process

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -183,6 +183,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_start_fail_soak_test.c \
     src/test/nxt_router_proto_wedge_test.c \
     src/test/nxt_router_remove_pid_soak_test.c \
+    src/test/nxt_main_start_process_reply_test.c \
     src/test/nxt_port_change_file_test.c \
     src/test/nxt_port_fd_test.c \
 "

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -67,6 +67,42 @@ static nxt_int_t nxt_main_file_store(nxt_task_t *task, const char *tmp_name,
 static void nxt_main_port_access_log_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 
+#if (NXT_TESTS)
+static nxt_uint_t  nxt_main_test_process_new_failure_count;
+
+
+void
+nxt_main_test_process_new_failures(nxt_uint_t failures)
+{
+    nxt_main_test_process_new_failure_count = failures;
+}
+
+
+/*
+ * nxt_process_new() with an allocation-failure hook in front of it, in the
+ * shape of nxt_port_test_msg_alloc_failures() (src/nxt_port_socket.c): the
+ * count is decremented per call, so one armed failure fires once and the
+ * handler then behaves exactly as it does when the process record cannot
+ * be allocated.  The wrapper stands in front of the call rather than in
+ * place of the branch that follows it, so the code the test reaches stays
+ * the handler's own -- however this file happens to spell its response to
+ * a NULL process.
+ */
+nxt_inline nxt_process_t *
+nxt_main_process_new(nxt_runtime_t *rt)
+{
+    if (nxt_slow_path(nxt_main_test_process_new_failure_count != 0)) {
+        nxt_main_test_process_new_failure_count--;
+        return NULL;
+    }
+
+    return nxt_process_new(rt);
+}
+
+#else
+#define nxt_main_process_new(rt)  nxt_process_new(rt)
+#endif
+
 const nxt_sig_event_t  nxt_main_process_signals[] = {
     nxt_event_signal(SIGHUP,  nxt_main_process_signal_handler),
     nxt_event_signal(SIGINT,  nxt_main_process_sigterm_handler),
@@ -473,28 +509,41 @@ nxt_main_start_process_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
     rt = task->thread->runtime;
 
+    /*
+     * Every exit below the fork() is either the successful one, which lets
+     * the new process answer for itself, or "failed:", which answers for it.
+     * Nothing may leave this handler in between: START_PROCESS carries the
+     * stream of an RPC the router has already armed
+     * (nxt_router_start_app_process_handler()), and only a reply retires it.
+     * A silent return leaves that RPC outstanding forever -- neither
+     * nxt_router_app_port_ready() nor nxt_router_app_port_error() ever runs,
+     * so app->proto_port_requests is never cleared, every later start for
+     * the application parks on the prototype that is not coming, and the
+     * requests waiting on it are never failed.  See issue #257.
+     */
+    process = NULL;
+
     port = rt->port_by_type[NXT_PROCESS_ROUTER];
     if (nxt_slow_path(port == NULL)) {
         nxt_alert(task, "router port not found");
-        goto close_fds;
+        goto failed;
     }
 
     if (nxt_slow_path(port->pid != nxt_recv_msg_cmsg_pid(msg))) {
         nxt_alert(task, "process %PI cannot start processes",
                   nxt_recv_msg_cmsg_pid(msg));
 
-        goto close_fds;
+        goto failed;
     }
 
-    process = nxt_process_new(rt);
+    process = nxt_main_process_new(rt);
     if (nxt_slow_path(process == NULL)) {
-        goto close_fds;
+        goto failed;
     }
 
     process->mem_pool = nxt_mp_create(1024, 128, 256, 32);
     if (process->mem_pool == NULL) {
-        nxt_process_use(task, process, -1);
-        goto close_fds;
+        goto failed;
     }
 
     process->parent_port = rt->port_by_type[NXT_PROCESS_MAIN];
@@ -622,17 +671,41 @@ nxt_main_start_process_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 
 failed:
 
-    nxt_process_use(task, process, -1);
+    if (process != NULL) {
+        nxt_process_use(task, process, -1);
+    }
 
-    port = nxt_runtime_port_find(rt, msg->port_msg.pid,
+    /*
+     * Answer on the port of the process the kernel says sent this, not the
+     * one the message claims to come from: msg->port_msg.pid is filled in by
+     * the sender (nxt_port_socket_write2()) and is not authenticated, and
+     * the two branches above now reach this reply before the router identity
+     * check has run -- or after it has failed.  Keyed on the credential, the
+     * RPC_ERROR can only ever retire an RPC of the sender's own, so a worker
+     * that forges a START_PROCESS cannot use main to cancel a stream of the
+     * router's choosing.  For a legitimate sender the two pids are equal,
+     * because nxt_port_socket_write2() sets port_msg.pid to its own nxt_pid;
+     * where SCM_CREDENTIALS is unavailable nxt_recv_msg_cmsg_pid() is
+     * defined as port_msg.pid, so the lookup is unchanged there.
+     */
+    port = nxt_runtime_port_find(rt, nxt_recv_msg_cmsg_pid(msg),
                                  msg->port_msg.reply_port);
 
     if (nxt_fast_path(port != NULL)) {
-        nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
-                              -1, msg->port_msg.stream, 0, NULL);
-    }
+        (void) nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
+                                     -1, msg->port_msg.stream, 0, NULL);
 
-close_fds:
+    } else {
+        /*
+         * Nothing to answer on: the sender is gone, or never had the port it
+         * named.  A dead sender's RPCs die with it, so this is only worth a
+         * diagnostic -- but a silent drop here is exactly the shape of the
+         * defect above, so it is not left silent.
+         */
+        nxt_alert(task, "cannot report a failed start back: reply port %d of "
+                  "process %PI not found", (int) msg->port_msg.reply_port,
+                  nxt_recv_msg_cmsg_pid(msg));
+    }
 
     nxt_fd_close(msg->fd[0]);
     msg->fd[0] = -1;
@@ -640,6 +713,25 @@ close_fds:
     nxt_fd_close(msg->fd[1]);
     msg->fd[1] = -1;
 }
+
+
+#if (NXT_TESTS)
+
+/*
+ * Public wrapper that lets src/test/nxt_main_start_process_reply_test.c
+ * invoke the static nxt_main_start_process_handler() directly with a
+ * synthesised runtime and message -- used to verify that every exit above
+ * the fork() answers the router's START_PROCESS RPC instead of returning
+ * silently and stranding it (issue #257).
+ */
+void
+nxt_main_test_run_start_process_handler(nxt_task_t *task,
+    nxt_port_recv_msg_t *msg)
+{
+    nxt_main_start_process_handler(task, msg);
+}
+
+#endif
 
 
 static void

--- a/src/nxt_main_process.h
+++ b/src/nxt_main_process.h
@@ -33,5 +33,11 @@ NXT_EXPORT extern const nxt_process_init_t  nxt_app_process;
 extern const nxt_sig_event_t  nxt_main_process_signals[];
 extern const nxt_sig_event_t  nxt_process_signals[];
 
+#if (NXT_TESTS)
+void nxt_main_test_process_new_failures(nxt_uint_t failures);
+void nxt_main_test_run_start_process_handler(nxt_task_t *task,
+    nxt_port_recv_msg_t *msg);
+#endif
+
 
 #endif /* _NXT_MAIN_PROCESS_H_INCLUDED_ */

--- a/src/test/nxt_main_start_process_reply_test.c
+++ b/src/test/nxt_main_start_process_reply_test.c
@@ -1,0 +1,508 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for issue #257: nxt_main_start_process_handler()
+ * (src/nxt_main_process.c) had exits above the fork() that returned
+ * without answering the router.
+ *
+ * START_PROCESS carries the stream of an RPC the router has already armed
+ * in nxt_router_start_app_process_handler(), having incremented
+ * app->proto_port_requests for it.  Only a reply retires that RPC: with
+ * none, neither nxt_router_app_port_ready() nor nxt_router_app_port_error()
+ * ever runs, the counter is never cleared, and every later start for the
+ * application parks on a prototype that is not coming.  The three exits
+ * covered here -- no router port, a sender that is not the router, and a
+ * process record that cannot be allocated -- all used to "goto close_fds",
+ * which closes the descriptors and returns in silence.
+ *
+ * The reply is observed rather than inferred: the fixture ports carry no
+ * queue and leave write_ready unset, so nxt_port_socket_write() takes the
+ * nxt_port_msg_chk_insert() path and the message stays on port->messages
+ * for the test to read -- the arrangement src/test/nxt_router_start_fail_
+ * test.c and src/test/nxt_router_proto_wedge_test.c already rely on.  Each
+ * case requires exactly one message, of type RPC_ERROR and on the stream
+ * the incoming message named: a handler that answered twice would retire
+ * an RPC that is no longer the caller's.
+ *
+ * The foreign-sender case additionally pins down where the answer goes.
+ * The reply port is looked up by the kernel-validated sender pid, not by
+ * the self-declared msg->port_msg.pid, so a forged START_PROCESS can only
+ * ever cancel a stream of the forger's own; that case gives the two pids
+ * different values and requires the router's port to stay untouched.
+ *
+ * Not covered: the nxt_mp_create() failure a few lines below the process
+ * allocation.  Arming it needs a malloc-failure hook that does not exist,
+ * and the sites are not independent -- both reach "failed:" through the
+ * same "goto", so the process-allocation case already exercises the reply
+ * they share.  What it does not exercise is the "process != NULL" guard at
+ * "failed:", which only the mem_pool site can reach.
+ */
+
+#include <nxt_main.h>
+#include <nxt_runtime.h>
+#include <nxt_port.h>
+#include <nxt_port_hash.h>
+#include <nxt_main_process.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+#include <fcntl.h>
+
+
+static nxt_bool_t
+nxt_main_start_process_reply_test_fd_is_open(nxt_fd_t fd)
+{
+    return fcntl(fd, F_GETFD) != -1;
+}
+
+
+/*
+ * Run the handler once and require that it answered: exactly one RPC_ERROR
+ * on reply_port, carrying the stream of the incoming message, and nothing
+ * at all on silent_port (which may be NULL when there is no second port to
+ * rule out).  Both ports are left drained, so the next case starts from
+ * empty queues.
+ */
+static nxt_int_t
+nxt_main_start_process_reply_test_case(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_recv_msg_t *msg, nxt_port_t *reply_port, nxt_port_t *silent_port,
+    const char *name)
+{
+    nxt_fd_t             fd0, fd1;
+    nxt_int_t            ret;
+    nxt_uint_t           n;
+    nxt_queue_link_t     *link;
+    nxt_port_send_msg_t  *sent;
+
+    ret = NXT_ERROR;
+    sent = NULL;
+    n = 0;
+
+    fd0 = open("/dev/null", O_RDONLY);
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (nxt_slow_path(fd0 == -1 || fd1 == -1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s failed to "
+                      "open the descriptors", name);
+        goto done;
+    }
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    nxt_main_test_run_start_process_handler(task, msg);
+
+    /*
+     * Both exits own the descriptors the message carried, and both spellings
+     * of the failure tail closed them -- so this is not what discriminates
+     * the fix, only a guard against the cleanup below closing a number that
+     * has already been reused.
+     */
+    if (msg->fd[0] == -1 && !nxt_main_start_process_reply_test_fd_is_open(fd0))
+    {
+        fd0 = -1;
+    }
+
+    if (msg->fd[1] == -1 && !nxt_main_start_process_reply_test_fd_is_open(fd1))
+    {
+        fd1 = -1;
+    }
+
+    if (nxt_slow_path(fd0 != -1 || fd1 != -1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s leaked a "
+                      "descriptor", name);
+        goto done;
+    }
+
+    for (link = nxt_queue_first(&reply_port->messages);
+         link != nxt_queue_tail(&reply_port->messages);
+         link = nxt_queue_next(link))
+    {
+        n++;
+        sent = nxt_queue_link_data(link, nxt_port_send_msg_t, link);
+    }
+
+    if (nxt_slow_path(n != 1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s left %ui "
+                      "replies on the reply port (expected 1) -- the "
+                      "START_PROCESS RPC is stranded", name, n);
+        goto done;
+    }
+
+    if (nxt_slow_path(sent->port_msg.type != _NXT_PORT_MSG_RPC_ERROR)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s answered "
+                      "with message type %d (expected %d, RPC_ERROR)", name,
+                      (int) sent->port_msg.type,
+                      (int) _NXT_PORT_MSG_RPC_ERROR);
+        goto done;
+    }
+
+    if (nxt_slow_path(sent->port_msg.last != 1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s answered "
+                      "with a non-final message, so the RPC stays armed",
+                      name);
+        goto done;
+    }
+
+    if (nxt_slow_path(sent->port_msg.stream != msg->port_msg.stream)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s answered "
+                      "on stream %uD (expected %uD)", name,
+                      sent->port_msg.stream, msg->port_msg.stream);
+        goto done;
+    }
+
+    if (silent_port != NULL && !nxt_queue_is_empty(&silent_port->messages)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s answered "
+                      "on a port of the process it was not sent by", name);
+        goto done;
+    }
+
+    ret = NXT_OK;
+
+done:
+
+    /*
+     * Close only what is still open: a consumed descriptor is gone already,
+     * and closing its number again could reach an unrelated file.
+     */
+    if (fd0 != -1 && nxt_main_start_process_reply_test_fd_is_open(fd0)) {
+        (void) close(fd0);
+    }
+
+    if (fd1 != -1 && nxt_main_start_process_reply_test_fd_is_open(fd1)) {
+        (void) close(fd1);
+    }
+
+    /*
+     * A queued message is malloc'd and takes a port reference
+     * (nxt_port_msg_chk_insert()).  Left alone the port never reaches
+     * nxt_port_mp_cleanup(), so its pool leaks and the assertions there
+     * never run -- the same teardown src/test/nxt_router_proto_wedge_test.c
+     * performs, and for the same reason.
+     */
+    nxt_port_test_run_error_handler(task, reply_port);
+
+    if (silent_port != NULL) {
+        nxt_port_test_run_error_handler(task, silent_port);
+    }
+
+    return ret;
+}
+
+
+/*
+ * Run the handler once where there is no port to answer on: the sender is a
+ * pid the runtime has never seen, so nxt_runtime_port_find() returns NULL
+ * and the handler can only log.  Nothing may be queued on any port, and the
+ * descriptors the message carried must still be released.
+ */
+static nxt_int_t
+nxt_main_start_process_reply_test_no_reply_case(nxt_thread_t *thr,
+    nxt_task_t *task, nxt_port_recv_msg_t *msg, nxt_port_t *port_a,
+    nxt_port_t *port_b, const char *name)
+{
+    nxt_fd_t   fd0, fd1;
+    nxt_int_t  ret;
+
+    ret = NXT_ERROR;
+
+    fd0 = open("/dev/null", O_RDONLY);
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (nxt_slow_path(fd0 == -1 || fd1 == -1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s failed to "
+                      "open the descriptors", name);
+        goto done;
+    }
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    nxt_main_test_run_start_process_handler(task, msg);
+
+    if (msg->fd[0] == -1 && !nxt_main_start_process_reply_test_fd_is_open(fd0))
+    {
+        fd0 = -1;
+    }
+
+    if (msg->fd[1] == -1 && !nxt_main_start_process_reply_test_fd_is_open(fd1))
+    {
+        fd1 = -1;
+    }
+
+    if (nxt_slow_path(fd0 != -1 || fd1 != -1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s leaked a "
+                      "descriptor", name);
+        goto done;
+    }
+
+    if (nxt_slow_path(!nxt_queue_is_empty(&port_a->messages)
+                      || (port_b != NULL
+                          && !nxt_queue_is_empty(&port_b->messages))))
+    {
+        nxt_log_alert(thr->log, "main start process reply test: %s answered "
+                      "on a port, but no port belongs to the sender", name);
+        goto done;
+    }
+
+    ret = NXT_OK;
+
+done:
+
+    if (fd0 != -1 && nxt_main_start_process_reply_test_fd_is_open(fd0)) {
+        (void) close(fd0);
+    }
+
+    if (fd1 != -1 && nxt_main_start_process_reply_test_fd_is_open(fd1)) {
+        (void) close(fd1);
+    }
+
+    nxt_port_test_run_error_handler(task, port_a);
+
+    if (port_b != NULL) {
+        nxt_port_test_run_error_handler(task, port_b);
+    }
+
+    return ret;
+}
+
+nxt_int_t
+nxt_main_start_process_reply_test(nxt_thread_t *thr)
+{
+    nxt_mp_t             *mp;
+    nxt_int_t            ret;
+    nxt_task_t           *task;
+    nxt_port_t           *router_port, *foreign_port;
+    nxt_runtime_t        *rt, *saved_rt;
+    nxt_event_engine_t   engine, *saved_engine;
+    nxt_port_recv_msg_t  msg;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "main start process reply test started");
+
+    ret = NXT_ERROR;
+    router_port = NULL;
+    foreign_port = NULL;
+
+    task = thr->task;
+    task->thread = thr;
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    if (nxt_slow_path(rt == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * Only the members the reached code touches are set; the engine is what
+     * the queued-message teardown needs (see src/test/nxt_router_new_port_
+     * test.c for the same fixture).
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+    thr->runtime = rt;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    /*
+     * The router's port: both the one the handler checks the sender
+     * against, and -- since the router is the sender in every case but the
+     * forgery below -- the one the reply is written to.  No queue and
+     * write_ready unset, so a reply is queued rather than written.
+     */
+
+    router_port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    router_port->pair[0] = -1;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * What nxt_runtime_port_add() does, spelled out: that helper is static
+     * to src/nxt_runtime.c, and it also takes a port reference the fixture
+     * would then have to give back.  The port stays owned by this frame.
+     */
+    rt->port_by_type[NXT_PROCESS_ROUTER] = router_port;
+
+    if (nxt_slow_path(nxt_port_hash_add(&rt->ports, router_port) != NXT_OK)) {
+        goto done;
+    }
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    msg.port_msg.pid = nxt_pid;
+    msg.port_msg.reply_port = router_port->id;
+    msg.port_msg.type = _NXT_PORT_MSG_START_PROCESS;
+#if (NXT_USE_CMSG_PID)
+    msg.cmsg_pid = nxt_pid;
+#endif
+
+    /*
+     * No router port at all.  The runtime still knows the sender's port, so
+     * there is something to answer on -- the handler used to return without
+     * doing so.
+     */
+
+    rt->port_by_type[NXT_PROCESS_ROUTER] = NULL;
+
+    msg.port_msg.stream = 0x11111111;
+
+    ret = nxt_main_start_process_reply_test_case(thr, task, &msg, router_port,
+                                                 NULL, "a missing router "
+                                                 "port");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    rt->port_by_type[NXT_PROCESS_ROUTER] = router_port;
+
+#if (NXT_USE_CMSG_PID)
+
+    /*
+     * A sender that is not the router.  The message claims to come from the
+     * router -- port_msg.pid is filled in by the sender and is not
+     * authenticated -- while the credential the kernel attached names
+     * somebody else.  The start is refused, and the refusal has to be
+     * reported to the process that actually sent it: answering the pid the
+     * message claimed would let a worker cancel a stream of the router's
+     * choosing.
+     */
+
+    foreign_port = nxt_port_new(task, router_port->id, nxt_pid + 1,
+                                NXT_PROCESS_APP);
+    if (nxt_slow_path(foreign_port == NULL)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    foreign_port->pair[0] = -1;
+    foreign_port->pair[1] = -1;
+    foreign_port->socket.fd = -1;
+
+    if (nxt_slow_path(nxt_port_hash_add(&rt->ports, foreign_port) != NXT_OK)) {
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    msg.cmsg_pid = nxt_pid + 1;
+    msg.port_msg.stream = 0x22222222;
+
+    ret = nxt_main_start_process_reply_test_case(thr, task, &msg,
+                                                 foreign_port, router_port,
+                                                 "a foreign sender");
+
+    msg.cmsg_pid = nxt_pid;
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+#endif
+
+    /*
+     * The process record cannot be allocated.  This is the exit furthest
+     * into the handler that still owes the router an answer, and the one
+     * that leaves "process" NULL for the guard at "failed:".
+     */
+
+    nxt_main_test_process_new_failures(1);
+
+    msg.port_msg.stream = 0x33333333;
+
+    ret = nxt_main_start_process_reply_test_case(thr, task, &msg, router_port,
+                                                 foreign_port,
+                                                 "a failed process "
+                                                 "allocation");
+
+    nxt_main_test_process_new_failures(0);
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * Nothing to answer on.  The sender is a pid the runtime knows no port
+     * for, so the reply-port lookup fails; the handler logs and must leave
+     * every queue untouched rather than answering somebody else.  Both pid
+     * fields move together so the case holds however
+     * nxt_recv_msg_cmsg_pid() is defined.
+     */
+
+    msg.port_msg.pid = nxt_pid + 2;
+#if (NXT_USE_CMSG_PID)
+    msg.cmsg_pid = nxt_pid + 2;
+#endif
+    msg.port_msg.stream = 0x44444444;
+
+    ret = nxt_main_start_process_reply_test_no_reply_case(thr, task, &msg,
+                                                          router_port,
+                                                          foreign_port,
+                                                          "an unknown "
+                                                          "sender");
+
+    msg.port_msg.pid = nxt_pid;
+#if (NXT_USE_CMSG_PID)
+    msg.cmsg_pid = nxt_pid;
+#endif
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "main start process reply test passed");
+
+    ret = NXT_OK;
+
+done:
+
+    /* Whatever a failed case left armed must not follow the test out. */
+    nxt_main_test_process_new_failures(0);
+
+    if (foreign_port != NULL) {
+        (void) nxt_port_hash_remove(&rt->ports, foreign_port);
+
+        nxt_port_use(task, foreign_port, -1);
+    }
+
+    if (router_port != NULL) {
+        (void) nxt_port_hash_remove(&rt->ports, router_port);
+
+        nxt_port_use(task, router_port, -1);
+    }
+
+    thr->engine = saved_engine;
+    thr->runtime = saved_rt;
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -217,6 +217,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_main_start_process_reply_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -78,6 +78,7 @@ nxt_int_t nxt_router_start_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_proto_wedge_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_remove_pid_soak_test(nxt_thread_t *thr);
+nxt_int_t nxt_main_start_process_reply_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);


### PR DESCRIPTION
## The problem

`START_PROCESS` carries the stream of an RPC the router has already armed in
`nxt_router_start_app_process_handler()`. Only a reply retires it. Five exits
from `nxt_main_start_process_handler()` return without one:

| # | site (origin/master) | condition | reply |
|---|---|---|---|
| 1 | `nxt_main_process.c:477-480` | router port not in the runtime | **none** |
| 2 | `:482-487` | sender's `SCM_CREDENTIALS` pid is not the router's | **none** |
| 3 | `:489-492` | `nxt_process_new()` NULL | **none** |
| 4 | `:494-498` | `nxt_mp_create()` NULL | **none** |
| 5 | `:630-633` | `failed:` write guarded by `if (port != NULL)`, no `else` | **none** |

When one fires, the router never learns. Neither `nxt_router_app_port_ready()`
nor `nxt_router_app_port_error()` runs, so `app->proto_port_requests` keeps the
count incremented at `nxt_router.c:434` and `:482`; every later start for that
application parks on a prototype that is never coming, and the requests waiting
on it are never failed.

Nothing recovers it. The router's `app_joint_rpc` registers **no peer**
(`nxt_router.c:477-480`), so neither `nxt_port_rpc_remove_peer()` nor
`nxt_port_rpc_close()` can reach the stream once main has returned in silence.

#255 cleared the counter when a prototype start *fails*. This is the other
half: main exiting before there is a start to fail.

**Scope: only the exits above the `fork()`.** A process that dies *after* it is
already answered for — main's SIGCHLD reaper zeroes `process->stream` only for
a process that reached READY (`nxt_main_process.c:1108-1110`) and then notifies
unconditionally, so a death while CREATING sends `REMOVE_PID` still carrying
the router's stream (`nxt_port.c:854`), and `nxt_router_remove_pid_handler()`
rewrites that into `RPC_ERROR` (`nxt_router.c:1128-1133`). That chain is why a
failing `working_directory` already produces prompt 503s rather than a wedge.

## The change

Route the four early exits into `failed:`, which already writes `RPC_ERROR` —
initialise `process` to `NULL`, guard the `nxt_process_use()` there, and delete
the now-unreachable `close_fds:` label, so a future early `return` can only
escape by stepping over the label that would have answered for it. Give the
port lookup an `else` that logs; a dead sender's RPCs die with it, but a silent
drop is the shape of the defect above.

**One hardening is load-bearing, not opportunistic.** Paths 1 and 2 now reach
the reply *before* the router-identity check has run, so the lookup is re-keyed
from `msg->port_msg.pid` — filled in by the sender, unauthenticated — to
`nxt_recv_msg_cmsg_pid(msg)`. Otherwise any process able to write to main's
port could name the router as reply target and cancel a stream of the router's
choosing. Keyed on the credential, an `RPC_ERROR` can only retire an RPC of the
sender's own.

This is a no-op for legitimate senders: `nxt_port_socket.c:213` is the only
production site that sets `port_msg.pid`, and it sets `nxt_pid`; every
pre-existing reply path sits after the identity check that already requires the
two to be equal; and where `SCM_CREDENTIALS` is unavailable
`nxt_recv_msg_cmsg_pid()` *is* `port_msg.pid` (`nxt_port.h:242`).

The router needs no change — #255's `nxt_router_app_port_error()` already
handles the `RPC_ERROR` on receipt.

A second beneficiary that was not the target: a prototype start begun by
prefork arms `nxt_router_app_prefork_error()` (`nxt_router.c:3431`) instead of
the app-port path, and it too was waiting on a reply that never came. A
configuration apply that hit one of these exits hung rather than failing.

## Verification

- **C suite green** in both `--tests` and `--tests --debug` (live `nxt_assert`),
  41 tests, including the new `nxt_main_start_process_reply_test.c`.
- **Red on the unfixed handler**: exit 1, `a missing router port left 0 replies
  on the reply port (expected 1) -- the START_PROCESS RPC is stranded`.
- **Path 5 is covered too**: a sender the runtime knows no port for must leave
  every queue untouched. The case is non-vacuous — the handler's new
  `cannot report a failed start back: reply port 0 of process <pid> not found`
  appears in the run, so the `else` really executes.
- **Red again under a negative control**: suppressing only the `RPC_ERROR`
  write (`if (0 && port != NULL)`) reproduces that failure, so the test is not
  passing vacuously.
- **End to end**, two unitd binaries from the same tree with a fault injected
  at path 3, PHP application with `spare: 0`: unfixed → both requests hit a 10 s
  client timeout with nothing logged; fixed → both return **503** immediately.
  The *second* request returning 503 is the discriminating part: it shows
  `proto_port_requests` was actually cleared, not merely one request unblocked.

## Known gaps, stated rather than glossed

- Path 4 (`nxt_mp_create` failure) is compiled but **untested** — there is no
  malloc-failure hook for it, so the `if (process != NULL)` guard that only it
  reaches is unexercised. Both allocation failures share one `goto failed`, so
  the untested text is the two-line NULL guard.
- The pid-namespace reasoning (`isolation.namespaces.pid`, double-fork,
  namespace-local vs global pid) is **on paper only**; no namespaced
  configuration was run.

Closes #257.
