### PR TITLE
application: report a worker that dies before it is created

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,13 @@ Changes with FreeUnit 1.36.2                                     30 Aug 2026
        the "credential" namespace, and applications run as unitd's own uid.
        Every other capget() failure remains fatal.
 
+    *) Bugfix: the main process did not answer a START_PROCESS request it
+       could not carry out -- an unknown router port, a sender that is not
+       the router, or an allocation that failed -- so the start stayed
+       pending. The application then parked every later start on a
+       prototype that was not coming, and the requests waiting on it were
+       never failed.
+
     *) Bugfix: an application worker that died before it finished starting
        was reported to nobody, so the start it was forked for stayed pending
        forever. Once the application reached its "processes" maximum it

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,12 @@ Changes with FreeUnit 1.36.2                                     30 Aug 2026
        the "credential" namespace, and applications run as unitd's own uid.
        Every other capget() failure remains fatal.
 
+    *) Bugfix: an application worker that died before it finished starting
+       was reported to nobody, so the start it was forked for stayed pending
+       forever. Once the application reached its "processes" maximum it
+       started no further process, and because an application's "timeout"
+       defaults to 0 the requests waiting on it hung instead of failing.
+
     *) Security: application processes no longer inherit unitd's
        capabilities. A unitd started as a non-root user that had been
        granted capabilities -- systemd "AmbientCapabilities=", file

--- a/auto/sources
+++ b/auto/sources
@@ -189,6 +189,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_remove_pid_soak_test.c \
     src/test/nxt_main_start_process_reply_test.c \
     src/test/nxt_main_file_store_test.c \
+    src/test/nxt_proto_creating_wedge_test.c \
     src/test/nxt_port_change_file_test.c \
     src/test/nxt_port_ctrunc_test.c \
     src/test/nxt_port_fd_test.c \

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -35,6 +35,16 @@ remains fatal.
 
 <change type="bugfix">
 <para>
+the main process did not answer a START_PROCESS request it could not carry
+out -- an unknown router port, a sender that is not the router, or an
+allocation that failed -- so the start stayed pending.  The application then
+parked every later start on a prototype that was not coming, and the
+requests waiting on it were never failed.
+</para>
+</change>
+
+<change type="bugfix">
+<para>
 an application worker that died before it finished starting was reported to
 nobody, so the start it was forked for stayed pending forever.  Once the
 application reached its "processes" maximum it started no further process,

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -33,6 +33,16 @@ remains fatal.
 </para>
 </change>
 
+<change type="bugfix">
+<para>
+an application worker that died before it finished starting was reported to
+nobody, so the start it was forked for stayed pending forever.  Once the
+application reached its "processes" maximum it started no further process,
+and because an application's "timeout" defaults to 0 the requests waiting on
+it hung instead of failing.
+</para>
+</change>
+
 <change type="security">
 <para>
 application processes no longer inherit unitd's capabilities.  A unitd

--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -807,7 +807,16 @@ nxt_proto_start_process_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     process->user_cred = &rt->user_cred;
 
     process->data.app = nxt_app_conf;
+
+    /*
+     * Remember who to answer, not just which stream: the RPC is registered on
+     * the initiator's port, and by the time this child is reaped the message
+     * that named it is long gone.  nxt_proto_child_exited() is then the only
+     * thing left that can report a child which died before it was announced.
+     */
     process->stream = msg->port_msg.stream;
+    process->stream_pid = msg->port_msg.pid;
+    process->stream_port = msg->port_msg.reply_port;
 
     init->siblings = &nxt_proto_children;
 
@@ -1174,9 +1183,7 @@ nxt_proto_sigchld_handler(nxt_task_t *task, void *obj, void *data)
             port = nxt_process_port_first(process);
         }
 
-        if (process->state != NXT_PROCESS_STATE_CREATING) {
-            nxt_port_remove_notify_others(task, process);
-        }
+        nxt_proto_child_exited(task, process);
 
         nxt_process_close_ports(task, process);
 
@@ -1189,6 +1196,236 @@ nxt_proto_sigchld_handler(nxt_task_t *task, void *obj, void *data)
             return;
         }
     }
+}
+
+
+/*
+ * Report a reaped child of the prototype.  Every child is forked to satisfy a
+ * START_PROCESS request, and that request has an RPC handler armed on the
+ * initiator's port; something has to retire it when the child dies or the
+ * initiator waits forever.  This closes the case where the child dies.
+ *
+ * The case where the *prototype* dies part-way through an on-demand start is
+ * closed elsewhere and no longer belongs on this list:
+ * nxt_router_start_app_process_handler() keys that RPC on the prototype
+ * (nxt_port_rpc_ex_set_peer(), src/nxt_router.c), so the REMOVE_PID for the
+ * prototype reaches nxt_port_rpc_remove_peer() and fails the start, releasing
+ * the app->pending_processes slot with it.
+ *
+ * What that leaves is this function's case alone: a child that dies before
+ * PROCESS_CREATED, which no REMOVE_PID describes, because until the handshake
+ * completes the prototype does not necessarily know a globally valid pid for
+ * it.
+ *
+ * A child that got as far as PROCESS_CREATED is reported by REMOVE_PID, which
+ * carries ->stream: nxt_router_remove_pid_handler() turns a stream-bearing
+ * REMOVE_PID into an RPC error.  A child still in the CREATING state cannot be
+ * announced that way.  The pid is the whole content of REMOVE_PID, and until
+ * the PROCESS_CREATED exchange completes the prototype does not necessarily
+ * know a globally valid one: under pid isolation ->pid is still the
+ * namespace-local pid nxt_process_create() got from fork(), and the global pid
+ * only arrives with PROCESS_CREATED (see nxt_proto_process_created_handler()
+ * and 900828cc, which is why such a process is deliberately kept out of the
+ * global pid hash).  Broadcasting that pid would ask every receiver to remove
+ * whatever unrelated process happens to hold it.
+ *
+ * So the gate stays exactly as it was, and the CREATING case is answered
+ * directly instead: an RPC error to the port the start request came from,
+ * addressed by ->stream_pid/->stream_port rather than by any pid of the dead
+ * child.  It is the same message nxt_proto_start_process_handler() sends when
+ * the fork itself fails.
+ *
+ * Answering the initiator is not the whole job, though, because the initiator
+ * is not the only process left holding the child.  A worker that got as far as
+ * WHOAMI made main create a process record and a port for it, with main's end
+ * of the worker's port socket in it (nxt_main_process_whoami_handler()), and
+ * linked that record into the prototype's ->children.  REMOVE_PID is what
+ * retires it -- nxt_proc_remove_notify_matrix pairs a dying APP with MAIN --
+ * so a CREATING child that is only answered on the RPC leaves main holding a
+ * record and an fd until the prototype itself exits.  Before this whole fix
+ * that leak was capped by the wedge: the application stopped starting
+ * processes, so at most one could leak.  Now that the start RPC is retired and
+ * requests retry, a worker that keeps dying in that window costs main one
+ * record and one descriptor per attempt, without bound.
+ *
+ * The pid problem is the same one the gate exists for, so the answer is the
+ * same test the rest of the code already uses for "is this pid a usable global
+ * key": rt->is_pid_isolated, which nxt_process_create() consults to decide
+ * whether a forked child may go into the runtime hash at all.  When it is
+ * clear, the prototype shares main's pid namespace, ->pid is the fork() return
+ * in that namespace, and it is by construction the same number main read from
+ * SCM_CREDENTIALS on the WHOAMI message -- so REMOVE_PID is safe.  The
+ * notification is deliberately made after ->stream has been cleared, so it
+ * carries no stream: the initiator has already been answered directly, and a
+ * stream-bearing REMOVE_PID would make nxt_router_remove_pid_handler() fail
+ * the same RPC a second time.
+ *
+ * Ordering is not a race even though the two messages come from two processes:
+ * the worker's WHOAMI and the prototype's REMOVE_PID are both written to the
+ * single write end of main's port socketpair, inherited by every descendant,
+ * so they share one kernel queue.  The worker's WHOAMI write completes before
+ * it exits, and the prototype writes only after waitpid() has reaped it.  If
+ * the WHOAMI never reached the socket it died with the worker, and main has no
+ * record to retire.
+ *
+ * When rt->is_pid_isolated is set there is no safe pid to send: ->pid is the
+ * namespace-local one, and the global pid main and the router keyed their
+ * records on cannot be derived from it here.  Sending it anyway would ask
+ * every receiver to remove whatever unrelated process holds that number -- and
+ * a prototype's namespace-local counter climbs with each worker it forks, so
+ * it walks into the range the daemon's own pids occupy.  Removing a live
+ * sibling's ports drops requests, which is worse than the leak, so that case
+ * is left alone and logged.
+ *
+ * Closing it belongs on the other side.  The prototype cannot map its
+ * namespace-local pid to a global one, but main can map the other way without
+ * trusting anybody: it holds the global pid from SCM_CREDENTIALS at WHOAMI
+ * time, and the last entry of /proc/<pid>/status NSpid is that process's pid
+ * in its own namespace (Linux 4.1+).  Recording that as a second key, plus a
+ * REMOVE_PID variant scoped to one prototype's children, would close it with
+ * no sender-supplied pid to authenticate.  msg->port_msg.pid on the WHOAMI
+ * message happens to carry the same number, but it is chosen by the sender and
+ * would need the authentication NSpid makes unnecessary.
+ */
+
+void
+nxt_proto_child_exited(nxt_task_t *task, nxt_process_t *process)
+{
+    nxt_int_t      ret;
+    nxt_uint_t     level;
+    nxt_port_t     *port;
+    nxt_runtime_t  *rt;
+
+    if (process->state != NXT_PROCESS_STATE_CREATING) {
+        nxt_port_remove_notify_others(task, process);
+
+        return;
+    }
+
+    rt = task->thread->runtime;
+
+    /*
+     * A CREATING child whose initiator is already gone is the expected shape
+     * of a teardown rather than an anomaly of one, and the record leak noted
+     * below is moot once the prototype itself is on its way out.
+     */
+    level = nxt_proto_exiting ? NXT_LOG_WARN : NXT_LOG_ALERT;
+
+    if (process->stream != 0) {
+        port = nxt_runtime_port_find(rt, process->stream_pid,
+                                     process->stream_port);
+
+        if (nxt_slow_path(port == NULL)) {
+            if (rt->is_pid_isolated) {
+                nxt_log(task, level, "app process (isolated %PI) died before "
+                        "it was created and its start initiator %PI port %d "
+                        "is gone (stream %uD)", process->isolated_pid,
+                        process->stream_pid, (int) process->stream_port,
+                        process->stream);
+
+            } else {
+                nxt_log(task, level, "app process %PI died before it was "
+                        "created and its start initiator %PI port %d is gone "
+                        "(stream %uD)", process->pid, process->stream_pid,
+                        (int) process->stream_port, process->stream);
+            }
+
+            /* Nothing can carry the answer; do not leave it armed. */
+            process->stream = 0;
+
+        } else {
+            ret = nxt_port_socket_write(task, port, NXT_PORT_MSG_RPC_ERROR,
+                                        -1, process->stream, 0, NULL);
+
+            /*
+             * One answer per start request: nxt_port_rpc_handler() drops a
+             * stream it no longer knows, but the identifiers come from a
+             * shared counter and are reused, so a second error for a retired
+             * stream could land on somebody else's RPC.  So ->stream is
+             * cleared only once the answer has actually been written or
+             * queued, which is what makes the REMOVE_PID below streamless.
+             *
+             * The failure that reaches this call site is an allocation
+             * failure, and it leaves no message behind.  The prototype maps
+             * no queue for a router port -- nxt_app_new_port_handler()
+             * closes the queue descriptor every NEW_PORT carries, and main
+             * maps a queue only for an application port -- so
+             * nxt_port_socket_write2() never takes the shared-ring path that
+             * answers NXT_AGAIN, and what is left is
+             * nxt_port_msg_chk_insert() failing to allocate.  Keeping
+             * ->stream then lets the REMOVE_PID carry it, and
+             * nxt_router_remove_pid_handler() turns that into the same RPC
+             * error -- the fallback the CREATED path has always used.
+             * Clearing it regardless would leave the start RPC armed and
+             * rebuild the wedge this function exists to close, silently.
+             *
+             * That fallback is a second chance, not a guarantee: the
+             * REMOVE_PID allocates a buffer and a message of its own from
+             * the same pools and can fail the same way, and then only the
+             * application's "limits.start_timeout" retires the start.  The
+             * alert below is what makes that case visible instead of silent.
+             * NXT_OK is not a delivery receipt either, and that shape is
+             * the one this function cannot cover.  When the port is writable
+             * the message goes out inline; if sendmsg() answers EAGAIN and
+             * it then cannot be queued for later, it is dropped and only the
+             * port's error handler is scheduled -- while the caller reads
+             * NXT_OK.  The REMOVE_PID below does not rescue that, and not
+             * because it is streamless: the EAGAIN cleared the port's
+             * write_ready, so it is queued rather than sent, and the error
+             * handler drains the whole queue when it runs.  The router is
+             * told nothing at all.  That is the port layer answering for a
+             * message it dropped, which reaches every RPC reply in the
+             * daemon rather than this function alone; it is filed as #335,
+             * and the fix there -- reporting the drop -- is what this
+             * function's failure branch above already knows how to use.
+             */
+            if (nxt_fast_path(ret == NXT_OK)) {
+                process->stream = 0;
+
+            } else if (rt->is_pid_isolated) {
+                nxt_log(task, level, "app process (isolated %PI) died before "
+                        "it was created and could not be reported to its "
+                        "start initiator %PI port %d (stream %uD)",
+                        process->isolated_pid, process->stream_pid,
+                        (int) process->stream_port, process->stream);
+
+            } else {
+                nxt_log(task, level, "app process %PI died before it was "
+                        "created and could not be reported to its start "
+                        "initiator %PI port %d (stream %uD); the REMOVE_PID "
+                        "that follows carries the report unless it cannot be "
+                        "allocated either", process->pid, process->stream_pid,
+                        (int) process->stream_port, process->stream);
+            }
+        }
+    }
+
+    /*
+     * Under pid isolation the direct answer is the only vehicle: ->pid is the
+     * namespace-local one, so no REMOVE_PID may be sent for this child at
+     * all.  When that answer could not be allocated above, the start RPC is
+     * therefore left armed.  What retires it then is the prototype's own
+     * death -- the router keys that RPC on the process it sent START_PROCESS
+     * to (nxt_port_rpc_ex_set_peer(), src/nxt_router.c), so main's REMOVE_PID
+     * for the prototype reaches nxt_port_rpc_remove_peer() -- or, sooner and
+     * per application, "limits": {"start_timeout"}, which defaults to none.
+     * Closing it here needs an answer that cannot fail to allocate, which
+     * this layer has no way to reserve; tracked with the record leak in #310.
+     */
+
+    if (nxt_slow_path(rt->is_pid_isolated)) {
+        nxt_log(task, level, "app process (isolated %PI) died before it was "
+                "created; it has no globally valid pid to broadcast, so a "
+                "record the main or router process may hold for it stays "
+                "until the prototype exits", process->isolated_pid);
+
+        /* No REMOVE_PID will carry it; do not leave it armed. */
+        process->stream = 0;
+
+        return;
+    }
+
+    nxt_port_remove_notify_others(task, process);
 }
 
 

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -209,4 +209,7 @@ NXT_EXPORT nxt_int_t nxt_unit_default_init(nxt_task_t *task,
 
 NXT_EXPORT nxt_int_t nxt_app_set_logs(void);
 
+/* Reports a reaped child of the prototype; see nxt_proto_sigchld_handler(). */
+void nxt_proto_child_exited(nxt_task_t *task, nxt_process_t *process);
+
 #endif /* _NXT_APPLICATION_H_INCLIDED_ */

--- a/src/nxt_process.h
+++ b/src/nxt_process.h
@@ -144,7 +144,17 @@ struct nxt_process_s {
     const char               *name;
     nxt_port_t               *parent_port;
 
+    /*
+     * The start request this process was forked to satisfy: ->stream is the
+     * initiator's RPC stream, and ->stream_pid/->stream_port address the port
+     * that RPC is registered on.  A creator that can be left holding the only
+     * armed handler for a child records all three -- the prototype does, in
+     * nxt_proto_start_process_handler() -- so that a child which dies before
+     * anything else can report it still gets answered.
+     */
     uint32_t                 stream;
+    nxt_pid_t                stream_pid;
+    nxt_port_id_t            stream_port;
 
     nxt_mp_t                 *mem_pool;
     nxt_credential_t         *user_cred;

--- a/src/test/nxt_proto_creating_wedge_test.c
+++ b/src/test/nxt_proto_creating_wedge_test.c
@@ -1,0 +1,594 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for the CREATING-state start wedge: an application worker
+ * that died between fork() and PROCESS_CREATED was never reported to anyone,
+ * so the START_PROCESS RPC it was forked for stayed armed forever and the
+ * record the main process had already made for it was never retired.
+ *
+ * Every child of the prototype exists to satisfy a START_PROCESS request, and
+ * the router arms an RPC handler for each one.  A child that got as far as
+ * PROCESS_CREATED is reported by REMOVE_PID, which carries ->stream, and
+ * nxt_router_remove_pid_handler() turns a stream-bearing REMOVE_PID into an
+ * RPC error.  A child still in the CREATING state took neither path:
+ * nxt_proto_sigchld_handler() skipped the notification for it -- rightly,
+ * since REMOVE_PID says nothing but a pid and under pid isolation the
+ * prototype does not yet know a globally valid one -- and nothing else
+ * answered instead.
+ *
+ * The prototype's own death is covered: the router keys that RPC on the
+ * prototype (nxt_router_start_app_process_handler() calls
+ * nxt_port_rpc_ex_set_peer(), src/nxt_router.c), so REMOVE_PID for the
+ * prototype reaches nxt_port_rpc_remove_peer() and fails the start.  A child
+ * that dies while CREATING has no such backstop: the armed handler owns an
+ * app->pending_processes slot, and a leaked slot makes
+ * nxt_router_app_can_start() false for good once the application's max is
+ * reached -- the application never starts another process, and a reload
+ * recovers only if its own config text changed.
+ *
+ * Answering the initiator is not the whole job.  A worker that got as far as
+ * WHOAMI made main create a process record and a port holding main's end of
+ * the worker's port socket (nxt_main_process_whoami_handler()), and REMOVE_PID
+ * is the only thing that retires it -- nxt_proc_remove_notify_matrix pairs a
+ * dying APP with MAIN.  Once the start RPC is retired and requests retry, a
+ * worker that keeps dying in that window costs main one record and one
+ * descriptor per attempt.  So the CREATING case must both answer the initiator
+ * and send a streamless REMOVE_PID: streamless because the initiator has
+ * already been answered, and a stream-bearing one would fail the same RPC
+ * twice.
+ *
+ * That REMOVE_PID may only be sent when the pid in it is a usable global key,
+ * which is what rt->is_pid_isolated says -- the same test nxt_process_create()
+ * uses to decide whether a forked child may enter the runtime hash at all.
+ * The pid-isolated case is exercised here too, and it asserts the opposite:
+ * nothing at all must reach main, because sending a namespace-local pid would
+ * ask main to remove whatever unrelated process holds that number.
+ *
+ * The answer itself can fail to be written -- a full port queue or a failed
+ * allocation, neither of which leaves anything for the initiator -- and then
+ * ->stream must survive so that the REMOVE_PID carries it and the router turns
+ * it into the RPC error the way it always has for a CREATED child.  Clearing
+ * it regardless would rebuild the wedge, silently.
+ *
+ * All four cases are driven against one router port and one main port,
+ * because the point is the split between them.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_runtime.h>
+#include <nxt_application.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+
+#define NXT_PROTO_WEDGE_CREATING_STREAM  0x0BADF00D
+#define NXT_PROTO_WEDGE_ISOLATED_STREAM  0x0BADF00E
+#define NXT_PROTO_WEDGE_UNSENT_STREAM    0x0BADF00F
+#define NXT_PROTO_WEDGE_STUCK_STREAM     0x0BADF010
+#define NXT_PROTO_WEDGE_CREATED_STREAM   0x0C0FFEE1
+
+
+typedef struct {
+    nxt_uint_t  type;
+    uint32_t    stream;
+    nxt_pid_t   pid;      /* REMOVE_PID payload; 0 for a message without one */
+} nxt_proto_wedge_msg_t;
+
+
+/*
+ * The ports are never write_ready here, so nxt_port_msg_chk_insert() queues
+ * whatever the handler writes instead of sending it -- which is exactly what
+ * this test wants to read back.
+ */
+
+static nxt_int_t
+nxt_proto_wedge_expect(nxt_thread_t *thr, nxt_port_t *port,
+    const nxt_proto_wedge_msg_t *expect, nxt_uint_t n, const char *label,
+    const char *whom)
+{
+    nxt_pid_t                    pid;
+    nxt_uint_t                   i;
+    nxt_queue_link_t             *link;
+    nxt_port_send_msg_t          *msg;
+    const nxt_proto_wedge_msg_t  *e;
+
+    link = nxt_queue_first(&port->messages);
+
+    for (i = 0; i < n; i++) {
+        e = &expect[i];
+
+        if (link == nxt_queue_tail(&port->messages)) {
+            nxt_log_alert(thr->log, "proto creating wedge test: %s: nothing "
+                          "more was written to the %s, expected message %d of "
+                          "%d (type %d stream %uxD)", label, whom, (int) i + 1,
+                          (int) n, (int) e->type, e->stream);
+            return NXT_ERROR;
+        }
+
+        msg = nxt_queue_link_data(link, nxt_port_send_msg_t, link);
+
+        if (msg->port_msg.type != e->type || msg->port_msg.stream != e->stream)
+        {
+            nxt_log_alert(thr->log, "proto creating wedge test: %s: the %s got "
+                          "message %d of type %d stream %uxD (expected type %d "
+                          "stream %uxD)", label, whom, (int) i + 1,
+                          (int) msg->port_msg.type, msg->port_msg.stream,
+                          (int) e->type, e->stream);
+            return NXT_ERROR;
+        }
+
+        if (e->pid != 0) {
+            if (msg->buf == NULL
+                || nxt_buf_used_size(msg->buf) != sizeof(nxt_pid_t))
+            {
+                nxt_log_alert(thr->log, "proto creating wedge test: %s: the %s "
+                              "got a REMOVE_PID carrying no pid", label, whom);
+                return NXT_ERROR;
+            }
+
+            nxt_memcpy(&pid, msg->buf->mem.pos, sizeof(nxt_pid_t));
+
+            if (pid != e->pid) {
+                nxt_log_alert(thr->log, "proto creating wedge test: %s: the %s "
+                              "was told to remove pid %PI (expected %PI)",
+                              label, whom, pid, e->pid);
+                return NXT_ERROR;
+            }
+        }
+
+        link = nxt_queue_next(link);
+    }
+
+    if (link != nxt_queue_tail(&port->messages)) {
+        msg = nxt_queue_link_data(link, nxt_port_send_msg_t, link);
+
+        nxt_log_alert(thr->log, "proto creating wedge test: %s: the %s got an "
+                      "extra message of type %d stream %uxD after the %d "
+                      "expected", label, whom, (int) msg->port_msg.type,
+                      msg->port_msg.stream, (int) n);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+static void
+nxt_proto_wedge_drain(nxt_task_t *task, nxt_port_t *port)
+{
+    /*
+     * Queued messages hold a port reference each; nxt_port_test_run_error
+     * _handler() is how the other port tests give them back, and it is what
+     * lets the pool cleanup assertions run under a debug build.
+     */
+    nxt_port_test_run_error_handler(task, port);
+}
+
+
+nxt_int_t
+nxt_proto_creating_wedge_test(nxt_thread_t *thr)
+{
+    nxt_mp_t               *mp;
+    nxt_int_t              ret;
+    nxt_task_t             *task;
+    nxt_port_t             *router_port, *main_port, *app_port;
+    nxt_runtime_t          *rt, *saved_rt;
+    nxt_process_t          *process;
+    nxt_event_engine_t     engine, *saved_engine;
+    nxt_proto_wedge_msg_t  expect[2];
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "proto creating wedge test started");
+
+    ret = NXT_ERROR;
+    app_port = NULL;
+    main_port = NULL;
+    router_port = NULL;
+
+    task = thr->task;
+    task->thread = thr;
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    if (nxt_slow_path(rt == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * nxt_port_remove_notify_others() allocates its payload from
+     * task->thread->engine->mem_pool; only the members the reached code
+     * touches are set, as in src/test/nxt_router_new_port_test.c.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+    thr->runtime = rt;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    /*
+     * The port the start request came from.  Its pid must differ from
+     * nxt_pid: nxt_port_remove_notify_others() skips the sender's own
+     * process, so a router sharing this process's pid would make the
+     * CREATED case pass for the wrong reason.
+     */
+
+    router_port = nxt_runtime_process_port_create(task, rt, nxt_pid + 1, 0,
+                                                  NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    router_port->pair[0] = -1;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * The process that answered the worker's WHOAMI and is holding a record
+     * and a descriptor for it.  nxt_proc_remove_notify_matrix pairs a dying
+     * APP with MAIN, so this is the port the streamless REMOVE_PID has to
+     * reach.
+     */
+
+    main_port = nxt_runtime_process_port_create(task, rt, nxt_pid + 3, 0,
+                                                NXT_PROCESS_MAIN);
+    if (nxt_slow_path(main_port == NULL)) {
+        goto done;
+    }
+
+    main_port->pair[0] = -1;
+    main_port->pair[1] = -1;
+    main_port->socket.fd = -1;
+
+    /* The child being reaped.  Deliberately not in rt->processes: a
+       CREATING child under pid isolation is kept out of the global pid hash,
+       and the CREATED case does not need to find itself there either. */
+
+    process = nxt_mp_zalloc(mp, sizeof(nxt_process_t));
+    if (nxt_slow_path(process == NULL)) {
+        goto done;
+    }
+
+    process->pid = nxt_pid + 2;
+    process->isolated_pid = nxt_pid + 2;
+    nxt_queue_init(&process->ports);
+    nxt_queue_init(&process->children);
+
+    /* nxt_process_type() reads the first port, and the notify matrix pairs
+       NXT_PROCESS_APP with NXT_PROCESS_ROUTER and NXT_PROCESS_MAIN. */
+
+    app_port = nxt_port_new(task, 0, process->pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(app_port == NULL)) {
+        goto done;
+    }
+
+    app_port->pair[0] = -1;
+    app_port->pair[1] = -1;
+    app_port->socket.fd = -1;
+
+    nxt_queue_insert_tail(&process->ports, &app_port->link);
+
+    /*
+     * A child that died before PROCESS_CREATED, with the prototype in main's
+     * pid namespace.  The old code left this silent, so the initiator's RPC
+     * stayed armed for the router's lifetime and main kept the record and the
+     * descriptor it made at WHOAMI time until the prototype exited.
+     */
+
+    process->state = NXT_PROCESS_STATE_CREATING;
+    process->stream = NXT_PROTO_WEDGE_CREATING_STREAM;
+    process->stream_pid = router_port->pid;
+    process->stream_port = router_port->id;
+
+    nxt_proto_child_exited(task, process);
+
+    /*
+     * The initiator is answered directly, and only then told to drop the pid
+     * -- streamless, or nxt_router_remove_pid_handler() would fail the same
+     * RPC a second time.
+     */
+
+    expect[0].type = _NXT_PORT_MSG_RPC_ERROR;
+    expect[0].stream = NXT_PROTO_WEDGE_CREATING_STREAM;
+    expect[0].pid = 0;
+    expect[1].type = _NXT_PORT_MSG_REMOVE_PID;
+    expect[1].stream = 0;
+    expect[1].pid = process->pid;
+
+    ret = nxt_proto_wedge_expect(thr, router_port, expect, 2,
+                                 "a child that died while creating",
+                                 "start initiator");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    ret = nxt_proto_wedge_expect(thr, main_port, &expect[1], 1,
+                                 "a child that died while creating",
+                                 "main process");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * One answer per start request.  Stream identifiers come from a shared
+     * counter and are reused, so a second error for a stream already retired
+     * could land on an unrelated RPC.
+     */
+
+    if (nxt_slow_path(process->stream != 0)) {
+        nxt_log_alert(thr->log, "proto creating wedge test: the answered "
+                      "start request is still armed on the process");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    nxt_proto_wedge_drain(task, router_port);
+    nxt_proto_wedge_drain(task, main_port);
+
+    /*
+     * The same child under pid isolation.  ->pid is then the namespace-local
+     * pid fork() returned, and main keyed its record on the global pid it
+     * read from SCM_CREDENTIALS, so there is no pid to send: the initiator is
+     * still answered, and nothing at all may reach main.  Sending the
+     * namespace-local pid would ask main to remove whatever unrelated process
+     * happens to hold that number, which is worse than the leak this closes.
+     */
+
+    rt->is_pid_isolated = 1;
+
+    process->state = NXT_PROCESS_STATE_CREATING;
+    process->stream = NXT_PROTO_WEDGE_ISOLATED_STREAM;
+
+    nxt_proto_child_exited(task, process);
+
+    expect[0].type = _NXT_PORT_MSG_RPC_ERROR;
+    expect[0].stream = NXT_PROTO_WEDGE_ISOLATED_STREAM;
+    expect[0].pid = 0;
+
+    ret = nxt_proto_wedge_expect(thr, router_port, expect, 1,
+                                 "a pid-isolated child that died while "
+                                 "creating", "start initiator");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    ret = nxt_proto_wedge_expect(thr, main_port, expect, 0,
+                                 "a pid-isolated child that died while "
+                                 "creating", "main process");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    rt->is_pid_isolated = 0;
+
+    nxt_proto_wedge_drain(task, router_port);
+    nxt_proto_wedge_drain(task, main_port);
+
+    /*
+     * The same child, but the RPC error cannot be written.  The prototype
+     * maps no queue for a router port, so nxt_port_socket_write() answers
+     * NXT_ERROR here -- nxt_port_msg_chk_insert() failing to allocate -- and
+     * leaves nothing behind for the initiator.  Clearing ->stream regardless
+     * would send a streamless REMOVE_PID and restore the wedge with no
+     * diagnostic at all.  The stream must survive the failed write instead,
+     * so that the REMOVE_PID carries it and nxt_router_remove_pid_handler()
+     * turns it into the RPC error -- the fallback the CREATED case below has
+     * always relied on.  Only the allocation failure can be injected here; it
+     * exercises the same discarded return.
+     */
+
+    process->state = NXT_PROCESS_STATE_CREATING;
+    process->stream = NXT_PROTO_WEDGE_UNSENT_STREAM;
+
+    nxt_port_test_msg_alloc_failures(1);
+
+    nxt_proto_child_exited(task, process);
+
+    nxt_port_test_msg_alloc_failures(0);
+
+    expect[0].type = _NXT_PORT_MSG_REMOVE_PID;
+    expect[0].stream = NXT_PROTO_WEDGE_UNSENT_STREAM;
+    expect[0].pid = process->pid;
+
+    ret = nxt_proto_wedge_expect(thr, router_port, expect, 1,
+                                 "a child whose start error could not be "
+                                 "written", "start initiator");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    ret = nxt_proto_wedge_expect(thr, main_port, expect, 1,
+                                 "a child whose start error could not be "
+                                 "written", "main process");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    nxt_proto_wedge_drain(task, router_port);
+    nxt_proto_wedge_drain(task, main_port);
+
+    /*
+     * Both at once: pid-isolated, and the RPC error cannot be written.  This
+     * is the one combination nothing can recover locally -- the direct answer
+     * is the only vehicle under isolation, and the REMOVE_PID that covers the
+     * failed write otherwise cannot be sent, because ->pid is the
+     * namespace-local one.
+     *
+     * What must not happen is a repair that looks like one: broadcasting that
+     * pid anyway would ask main and the router to remove whatever unrelated
+     * process holds the number, and a prototype's namespace-local counter
+     * climbs straight into the range the daemon's own pids occupy.  So the
+     * assertion is an absence on both ports, and it is what turns red if a
+     * later change decides to send something here.
+     *
+     * The start RPC is left armed, which the code says out loud.  It is
+     * retired when the prototype itself dies -- the router keys that RPC on
+     * the prototype (nxt_port_rpc_ex_set_peer(), src/nxt_router.c), so the
+     * REMOVE_PID main sends for it reaches nxt_port_rpc_remove_peer() --
+     * or sooner by "limits": {"start_timeout"} where the application sets
+     * one.  ->stream is still cleared, since nothing may carry it later.
+     */
+
+    rt->is_pid_isolated = 1;
+
+    process->state = NXT_PROCESS_STATE_CREATING;
+    process->stream = NXT_PROTO_WEDGE_STUCK_STREAM;
+
+    nxt_port_test_msg_alloc_failures(1);
+
+    nxt_proto_child_exited(task, process);
+
+    nxt_port_test_msg_alloc_failures(0);
+
+    ret = nxt_proto_wedge_expect(thr, router_port, expect, 0,
+                                 "a pid-isolated child whose start error "
+                                 "could not be written", "start initiator");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    ret = nxt_proto_wedge_expect(thr, main_port, expect, 0,
+                                 "a pid-isolated child whose start error "
+                                 "could not be written", "main process");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    if (nxt_slow_path(process->stream != 0)) {
+        nxt_log_alert(thr->log, "proto creating wedge test: a pid-isolated "
+                      "child whose start error could not be written left the "
+                      "start request armed on the process");
+        ret = NXT_ERROR;
+        goto done;
+    }
+
+    rt->is_pid_isolated = 0;
+
+    nxt_proto_wedge_drain(task, router_port);
+    nxt_proto_wedge_drain(task, main_port);
+
+    /*
+     * A child that reached PROCESS_CREATED keeps the path it always had:
+     * REMOVE_PID carrying the stream, which the router turns into an RPC
+     * error of its own, and which retires main's record as it always did.
+     */
+
+    process->state = NXT_PROCESS_STATE_CREATED;
+    process->stream = NXT_PROTO_WEDGE_CREATED_STREAM;
+
+    nxt_proto_child_exited(task, process);
+
+    expect[0].type = _NXT_PORT_MSG_REMOVE_PID;
+    expect[0].stream = NXT_PROTO_WEDGE_CREATED_STREAM;
+    expect[0].pid = process->pid;
+
+    ret = nxt_proto_wedge_expect(thr, router_port, expect, 1,
+                                 "a child that died after it was created",
+                                 "start initiator");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    ret = nxt_proto_wedge_expect(thr, main_port, expect, 1,
+                                 "a child that died after it was created",
+                                 "main process");
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    nxt_proto_wedge_drain(task, router_port);
+    nxt_proto_wedge_drain(task, main_port);
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "proto creating wedge test passed");
+
+    ret = NXT_OK;
+
+done:
+
+    /*
+     * Drain first, then hand each port back the way its owner would: these
+     * two were made by nxt_runtime_process_port_create() and carry pools of
+     * their own, which the fixture's pool does not cover.  Through the
+     * ownership path rather than by destroying those pools directly --
+     * nxt_port_mp_cleanup() asserts the descriptors are gone and the use
+     * count is zero, so nxt_mp_destroy() here would abort a debug build while
+     * looking clean in a release one.  nxt_port_close() is a no-op on the
+     * -1 descriptors the fixture set; nxt_runtime_port_remove() drops the
+     * rt->ports reference, which is the last one, and frees the port.
+     */
+
+    if (router_port != NULL) {
+        nxt_proto_wedge_drain(task, router_port);
+
+        if (!nxt_queue_is_empty(&router_port->messages)) {
+            nxt_log_alert(thr->log, "proto creating wedge test: the router "
+                          "port still holds queued messages after teardown");
+            ret = NXT_ERROR;
+        }
+
+        nxt_port_close(task, router_port);
+        nxt_runtime_port_remove(task, router_port);
+    }
+
+    if (main_port != NULL) {
+        nxt_proto_wedge_drain(task, main_port);
+
+        if (!nxt_queue_is_empty(&main_port->messages)) {
+            nxt_log_alert(thr->log, "proto creating wedge test: the main "
+                          "port still holds queued messages after teardown");
+            ret = NXT_ERROR;
+        }
+
+        nxt_port_close(task, main_port);
+        nxt_runtime_port_remove(task, main_port);
+    }
+
+    if (app_port != NULL) {
+        nxt_queue_remove(&app_port->link);
+
+        /*
+         * nxt_queue_remove() nulls the link only in a debug build
+         * (src/nxt_queue.h:130-148).  nxt_port_release() reads a non-NULL
+         * link.next as "this port belongs to a process" and dereferences
+         * port->process, which nxt_port_new() never set -- guarded by an
+         * nxt_assert() that compiles out of a release build, so the test
+         * would segfault in teardown there and nowhere else.
+         */
+        app_port->link.next = NULL;
+        app_port->link.prev = NULL;
+
+        nxt_port_use(task, app_port, -1);
+    }
+
+    thr->engine = saved_engine;
+    thr->runtime = saved_rt;
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -241,6 +241,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_proto_creating_wedge_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -84,6 +84,7 @@ nxt_int_t nxt_router_start_timeout_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_remove_pid_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_main_start_process_reply_test(nxt_thread_t *thr);
 nxt_int_t nxt_main_file_store_test(nxt_thread_t *thr);
+nxt_int_t nxt_proto_creating_wedge_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_ctrunc_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);


### PR DESCRIPTION
## The wedge

An application worker is a child of the **prototype**, so
`nxt_proto_sigchld_handler()` reaps it — and that reaper says nothing about a
child still in the `CREATING` state (`src/nxt_application.c:907` on master).

Nothing else covers it. The router keys the on-demand start RPC on the process
it sent `START_PROCESS` to — `nxt_port_rpc_ex_set_peer(task, port,
app_joint_rpc, dport->pid)`, `src/nxt_router.c:651` — which is the
**prototype**, and the prototype is alive and well; only the worker died. Main
is not the parent and gets no `SIGCHLD`. Before `PROCESS_CREATED` there is no
port to the worker.

So the start RPC stays armed forever and `app->pending_processes` keeps its
slot. Once the application reaches its `max`, `nxt_router_app_can_start()` is
false for good: the application never starts another process, and a reload only
recovers if the application's own configuration text changed. And because an
application's `timeout` defaults to 0, the requests waiting on it do not fail —
**they hang.**

## What actually triggers it

Not an ordinary application failure. `nxt_app_setup()` runs **after** the
`PROCESS_CREATED` write — injecting `_exit()` immediately after that write and
driving 20 starts hit the CREATING branch **0/20 times**. The reachable trigger
is a kill landing strictly inside the WHOAMI → `PROCESS_CREATED` window, which
measures under a millisecond on an idle box: the OOM killer, a seccomp
`SIGSYS`, or an external signal. Rare per start — but the consequence is
permanent for the application, and before this change nothing recovered it.

## Reproduction

One-shot fault injection in `nxt_process_whoami_ok()`, latched immediately
before vs. immediately after the `PROCESS_CREATED` write. Same binary, same
application (`processes: {max: 1, spare: 0}`); the only variable is which side
of that write the worker dies on.

| worker dies | req 1 | `processes.starting` | req 2 | req 3 |
|---|---|---|---|---|
| **before** `PROCESS_CREATED` | **hangs**, 20 s client timeout | **1, forever** | **hangs** | **hangs** |
| after `PROCESS_CREATED` | 503 in 0.59 s | 0 | **200** | — |

The prototype stayed healthy throughout; `requests.active` climbed 1→2→3 and
nothing ever followed "http application handler" in the log. With the fix and
the identical injection: req 1 → 503 in 45 ms, `starting` → 0, req 2/3 → 200.

## The change

**The gate stays.** It exists because the pid is the entire content of
`REMOVE_PID`, and until the `PROCESS_CREATED` exchange completes the prototype
does not necessarily know a globally valid one — under pid isolation
`process->pid` is still the namespace-local pid `fork()` returned (`900828cc`).
Broadcasting it would ask every receiver to remove whatever unrelated process
holds that number.

So the initiator is answered **directly** instead. `nxt_proto_child_exited()`
keeps the existing `REMOVE_PID` path verbatim for a child that was announced,
and for one that was not it writes an `RPC_ERROR` to the port the start request
came from, addressed by new `process->stream_pid` / `->stream_port` fields
recorded from the `START_PROCESS` message beside `->stream` — never by any pid
of the dead child. It is the same message the fork-failure path already sends.

The reply address is deliberately keyed on `msg->port_msg.pid` rather than the
credential, unlike #257's change to main: the lookup must match the runtime
port hash, which is keyed on the **global** pid, and under a pid-isolated
prototype the router's cmsg pid is unmappable (`src/nxt_port.c:484-492`).

## Verification

- New `src/test/nxt_proto_creating_wedge_test.c` drives both states against one
  router port and requires a message to reach the initiator for each.
- **Red without the fix**: reverting `nxt_proto_child_exited()` to master's
  behaviour gives `a child that died while creating: nothing more was written
  to the start initiator, expected message 1 of 2 (type 1 stream badf00d)`,
  exit 1.
- **Green in release and debug**: `--tests` exit 0 / 49 tests, `--tests
  --debug` exit 0 / 49 tests — exit codes read
  **unpiped**, which matters here: an earlier revision of this test passed,
  printed `passed`, and *then* segfaulted in teardown, which a piped run
  reports as success.
- `pytest test_php_application.py` — 49 passed.
- Rebased onto `4b6a77e6`. The three red python legs on the previous head were
  the stale-router-pid bug in `test/conftest.py` that `747a0b53` (#317) fixes on
  master, not this change: `AssertionError: one router / assert 2 == 1`.

## Review rounds

`codex` raised the discarded `nxt_port_socket_write()` return twice: first that
clearing `->stream` regardless leaves the start RPC armed (**fixed** — the
stream is cleared only on `NXT_OK`, so the `REMOVE_PID` carries it otherwise),
then that a full port queue answering `NXT_AGAIN` would drop both messages and
rebuild the wedge. That second one is **not reachable from here**: the
prototype maps no queue for a router port — `nxt_app_new_port_handler()` closes
the queue descriptor every `NEW_PORT` carries, and main maps a queue only for
an application port (`src/nxt_main_process.c:468-476`) — so
`nxt_port_socket_write2()` never takes the shared-ring path. What is reachable
is an allocation failure, and the `REMOVE_PID` allocates from the same pools
and can fail alike; that case is alerted, and `limits.start_timeout` is what
retires the start then. The comment and the commit message said `NXT_AGAIN`;
both now say what is actually reachable.

A later round raised the one combination the first four legs did not cover:
**pid-isolated *and* the direct reply fails to allocate**. Under isolation the
direct answer is the only vehicle — `->pid` is namespace-local, so no
`REMOVE_PID` may be sent — so that start RPC is left armed. It is not stranded
forever: the router keys the RPC on the process it sent `START_PROCESS` to
(`nxt_port_rpc_ex_set_peer()`, `src/nxt_router.c:651`), so main's `REMOVE_PID`
for the **prototype** reaches `nxt_port_rpc_remove_peer()` and fails it; and
`limits: {start_timeout}` retires it sooner where an application sets one
(default `NXT_APP_START_TIMEOUT` is 0, `src/nxt_router.h:124`). Closing it at
the point of failure needs a reply that cannot fail to allocate, which this
layer has no way to reserve — filed with the record leak under #310.

What ships here instead is the **fifth test leg** for that quadrant, asserting
an *absence* on both ports: the thing that must not happen is a repair that
broadcasts the namespace-local pid, since a prototype's ns-local counter climbs
into the range the daemon's own pids occupy. Mutation-checked — making the
isolated failure path call `nxt_port_remove_notify_others()` turns it red with
`the start initiator got an extra message of type 21 stream badf010 after the 0
expected`. The same round found the fixture leaking its two
`nxt_runtime_process_port_create()` ports, which have pools of their own; they
are now closed and removed the way `nxt_router_new_port_test.c` does, verified
under a `--debug` build where `nxt_port_mp_cleanup()`'s assertions are live.

A later round found a second way the answer can be lost, and it is **not**
specific to this function: when the router port is writable the reply goes out
inline, and if `sendmsg()` answers `EAGAIN` and the message then cannot be
queued, it is dropped while `nxt_port_socket_write2()` still returns `NXT_OK`
(`src/nxt_port_socket.c:319-322`, `:622-628`). The `REMOVE_PID` that follows
does not rescue it either — the `EAGAIN` cleared the port's `write_ready`
(`src/nxt_socketpair.c:132`), so that message is queued rather than sent, and
the error handler scheduled by the drop drains the whole queue when it runs.
The port itself stays open: `nxt_port_error_handler()` completes buffers and
fixes the use count, and neither closes the socket nor removes the port. This
reaches every RPC reply in the daemon, including the `CREATED` path that
predates this PR, so it is filed at the port layer as **#335** — and the fix
there (report the drop instead of `NXT_OK`) is what this function's existing
failure branch already knows how to use. The comment here says exactly that;
no behaviour in this PR depends on the wrong version of it.

To be plain about what is and is not closed here: this PR removes the wedge for
every `CREATING` death that can be reported. What remains is a start RPC left
armed when the reply itself cannot be delivered — under pid isolation with a
failed allocation (#310), or through the inline-drop path above (#335). Both
need an answer whose delivery does not depend on an allocation at the moment of
failure, which is a port-layer change rather than one belonging in this commit.

A second commit adds the `CHANGES` entry for `3e3ce864` ("main: reply to every
`START_PROCESS` that cannot start a process"), which landed without one. It is
the other half of the same wedge and 1.36.2 is not released yet.

## Known follow-ups, not in this PR

- `->stream` is left set for a child that reached `READY`, so a routine worker
  exit still asks the router to fail whatever RPC now holds that number —
  harmless until the shared 32-bit stream counter wraps. Zeroing it here (as
  main does at `nxt_main_process.c:1108-1110`) was drafted and **deliberately
  dropped from this PR**: `nxt_port_process_ready_handler()` sets `READY` and
  only then calls `nxt_port_send_new_port()`, ignoring its return, so in that
  window `->stream` is the sole remaining way to fail a start RPC that was
  never retired. Removing that fallback inside the PR that exists to remove a
  wedge is the wrong trade; it needs its own change, zeroing only once the RPC
  is known complete.
- **Under `isolation.namespaces.pid` only**, main's and the router's records for
  the dead worker still cannot be retired — the prototype holds a
  namespace-local pid, and broadcasting it would ask receivers to remove an
  unrelated process. Measured: 10 failing starts leak 10 descriptors and log 10
  alerts naming ns-local pids 11, 12, 13 — exactly the numbers a naive fix would
  have broadcast. Left alone deliberately (dropping a live sibling's ports loses
  requests, which is worse than the leak) and logged. The router side is
  correct even there — the start RPC is retired and the `start_timeout` reaper
  drains — so what remains is main holding one record and one fd per failed
  attempt, until the prototype exits. The closure belongs on main's side, which
  can map global → namespace-local itself via the `NSpid` line of
  `/proc/<pid>/status`, with no sender-supplied pid to authenticate. Tracked as
  **#310**.


