### PR TITLE
router: close the listening socket before acknowledging its removal

### DIFF
--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4096,10 +4096,13 @@ nxt_router_worker_thread_exit(nxt_task_t *task)
  *
  *   Accepting -> Draining: nxt_router_listen_socket_close() (phase 1)
  *                          disarms accept(2), marks lev->draining = 1.
+ *                          If connections are in flight it also posts the
+ *                          close_job back to the configuration thread, so
+ *                          the control request does not wait for them.
  *   Draining  -> Closed:   nxt_router_listen_socket_close_finish() (phase 2)
  *                          runs once lev->count == 1 (no in-flight accepted
- *                          connections), releases the FD and posts the
- *                          close_job back to the configuration thread.
+ *                          connections), releases the FD and then posts the
+ *                          close_job if phase 1 did not already.
  *
  * The intermediate state lets in-flight TLS handshakes and accepted-but-
  * not-yet-handled connections complete cleanly instead of being RST when
@@ -4153,30 +4156,35 @@ nxt_router_listen_socket_close(nxt_task_t *task, void *obj, void *data)
     }
 
     /*
-     * Configuration is ready once accept(2) has been disarmed.  The
-     * listener FD and old socket configuration stay alive below until
-     * accepted connections release their listener refs, but the control
-     * request must not wait for idle client timing.
-     */
-    nxt_router_listen_socket_close_ready(joint);
-
-    /*
      * Phase 2 gating: wait for accepted connections to release their
      * refs.  lev->count == 1 means only the original listener ref
      * remains (see nxt_listen_event() and nxt_conn_accept()).
      *
-     * Known limitation: the listening FD stays bound until the drain
-     * completes (nxt_router_listen_socket_release() closes it on the
-     * last engine's phase 2), so a configuration that re-adds the same
-     * address while the old listener drains fails with EADDRINUSE at
-     * bind time in the main process -- a visible, retryable config
-     * error.  Closing the FD in phase 1 instead requires reworking the
-     * ls->count contract across engines and the nxt_process_quit()
-     * listen-queue walk; that belongs to the full-drain follow-up.
+     * When connections are still in flight the configuration is
+     * acknowledged here, before the FD is released: the control request
+     * must not wait for idle client timing.  The listening FD then stays
+     * bound until the drain completes
+     * (nxt_router_listen_socket_release() closes it on the last engine's
+     * phase 2), so a configuration that re-adds the same address while
+     * the old listener drains can fail with EADDRINUSE at bind time in
+     * the main process -- a visible, retryable config error.  Closing
+     * the FD in phase 1 instead requires reworking the ls->count
+     * contract across engines and the nxt_process_quit() listen-queue
+     * walk; that belongs to the full-drain follow-up.
+     *
+     * With nothing in flight there is no drain to wait for, so the reply
+     * is deferred to nxt_router_listen_socket_close_finish() below,
+     * which sends it after the descriptor is closed.  That keeps the
+     * pre-drain contract -- a successful reconfiguration means the port
+     * is free -- for every listener that has no accepted connection on
+     * it.
      */
     if (lev->count > 1) {
         nxt_debug(task, "engine %p: listen socket %d drain pending, "
                   "in-flight: %D", engine, lev->socket.fd, lev->count - 1);
+
+        nxt_router_listen_socket_close_ready(joint);
+
         return;
     }
 
@@ -4217,12 +4225,32 @@ nxt_router_listen_socket_close_finish(nxt_task_t *task,
     joint = lev->socket.data;
     lev->socket.data = NULL;
 
-    nxt_router_listen_socket_close_ready(joint);
-
     /* 'task' refers to lev->task and we cannot use after nxt_free() */
     task = &task->thread->engine->task;
 
     nxt_router_listen_socket_release(task, joint->socket_conf);
+
+    /*
+     * Acknowledge only now.  nxt_router_listen_socket_release() above
+     * drops this engine's reference to the listen socket, and on the
+     * last engine to reach phase 2 it performs the single
+     * nxt_socket_close() of the descriptor.  The configuration is not
+     * reported successful until every engine has acknowledged
+     * (nxt_router_conf_ready()), so acknowledging after the release --
+     * rather than before it, as this function used to -- puts the reply
+     * strictly after the close for a listener with nothing in flight.
+     *
+     * A listener that did have connections to drain acknowledged early
+     * in phase 1 and left joint->close_job NULL, so this is the no-op it
+     * has always been on that path, and the still-bound descriptor
+     * documented there remains its known limitation.
+     *
+     * The joint outlives the call: its listener reference is dropped by
+     * nxt_router_listen_event_release() below, and
+     * nxt_router_listen_socket_release() frees the nxt_listen_socket_t,
+     * not the socket configuration the joint points at.
+     */
+    nxt_router_listen_socket_close_ready(joint);
 
     nxt_router_listen_event_release(task, lev, joint);
 }


### PR DESCRIPTION
Splits the product half out of #266, which raised this as its open question: whether the right answer to the `test_listeners_port_release` flake is a bind retry in the test, or closing the descriptor before acknowledging the configuration. This is the latter. The TLS half is #277.

## What

Since the two-phase listener drain (`9ae96c38`, 1.36.0) a configuration that removes a listener is acknowledged as soon as `accept(2)` has been disarmed. The controller can therefore report success while the listening descriptor is still bound, and a client that re-binds the address on seeing that success gets `EADDRINUSE`.

That is the intended trade for a listener with connections to drain. It was applied to every listener, including those with nothing in flight, where there is nothing to wait for.

## Mechanism

- `nxt_router_listen_socket_close()` (`src/nxt_router.c:4116`) called `nxt_router_listen_socket_close_ready()` **before** its `lev->count > 1` check, so the reply was posted even when phase 2 was about to run in the same call.
- `nxt_router_listen_socket_close_finish()` (`src/nxt_router.c:4212`) posted it again **ahead of** `nxt_router_listen_socket_release()`, which performs the single `nxt_socket_close()` of the descriptor on the last engine to reach phase 2 (`src/nxt_router.c:4250-4308`).
- Before `9ae96c38` the order in that function was release, then post. The drain moved the post ahead of the close for every listener, not only for the ones being drained.

The fix acknowledges in phase 1 only when the drain is real (`lev->count > 1`), and lets phase 2 acknowledge after the descriptor is closed otherwise. The early acknowledgement the drain feature exists for is untouched.

**Liveness.** Every listener close is armed by `nxt_router_listen_socket_delete()`, the only writer of `joint->close_job` (`src/nxt_router.c:4054`). `close()` has exactly two exits, `close_finish()` has none, and the drain-completion path in `nxt_router_listen_event_release()` (`src/nxt_router.c:4325-4345`) is reachable only after a phase 1 that saw `count > 1` and already posted, so its `close_finish()` finds `joint->close_job` NULL and returns early (`src/nxt_router.c:4197`). Exactly one post per engine — a missed one would hang the control request, a double one would underflow `tmcf->count`.

**Joint lifetime.** The joint outlives the moved call: its listener reference is dropped by `nxt_router_listen_event_release()` at the tail of `close_finish()`, and `nxt_router_listen_socket_release()` frees the `nxt_listen_socket_t`, not the socket configuration.

**Scope of the guarantee.** Per engine, the acknowledgement follows that engine's release. End to end it holds because `nxt_router_conf_ready()` waits for every engine and the closing engine's post is ordered after its `nxt_socket_close()`.

**Checked for interaction, no change:** `c44f43ff` (engine port close on worker exit) runs in `nxt_router_thread_exit_handler` on the main engine and is independent of this post. #186 (`tmcf->mem_pool` released while joint jobs are queued) is neither fixed nor widened here — the pool is released strictly later than before, by the cost of one `nxt_socket_close()`.

## Validation

Docker, `debian:trixie-slim`, `--openssl --tests --debug` + python module, default engine count (8 on this host), 16× CPU load. 250 runs of `test_listeners_port_release` per tree (each run = 10 bind attempts). Every failure classified by whether the router's `close(2)` preceded the controller's reply in the debug log.

| under 16× load, 250 runs | master | this branch |
| --- | --- | --- |
| **acknowledged before close** (this defect) | **10** | **0** |
| other cause, ordering correct (4 vs 2 is not a difference at n=250; same rate) | 4 | 2 |
| harness startup error | 1 | 1 |

| other cells | master | this branch |
| --- | --- | --- |
| `test_listeners_port_release`, 100× idle | 100 pass | 100 pass |
| `test_configuration.py` (full, idle) | 33 passed, 5 skipped | 33 passed, 5 skipped |
| `test_tls_session.py` (full, idle) | 3 passed | 3 passed |
| `test_listener_drain.py` (full, idle) | 2 passed, 1 skipped | 2 passed, 1 skipped |

`test_listener_drain.py` passing matters specifically: `test_listener_drain_no_dropped_accepted_connection` holds an accepted idle connection and asserts `'success'` on the reconfigure, which only the retained phase-1 early ack can deliver.

**Honest caveat.** This does not make the test deterministic under that synthetic load. The residual failures on both trees have the descriptor closed and the reply posted in the correct order, and occur at the same rate on master, so they are a second, pre-existing window that this change neither fixes nor introduces. It deserves its own issue. `test_listeners_port_release` is deliberately left unmodified as the strict guard it has always been.

## Drafted CHANGES entry

```
    *) Bugfix: a configuration that removed a listener was acknowledged
       before the listening socket was closed when no connections were in
       flight, so a client that re-bound the address on seeing "success"
       could fail with EADDRINUSE. The early acknowledgement now applies
       only to a listener that still has connections to drain.
```

Supersedes #266 together with #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
