### PR TITLE
build: probe memfd_create() without the kernel UAPI header

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -221,13 +221,57 @@ jobs:
         run: make wasm-wasi-component
         if: matrix.compiler == 'gcc'
 
+  # Alpine without "linux-headers".  The full alpine-edge leg installs it (the
+  # Rust/bindgen and JDK steps are happier with the kernel UAPI headers around),
+  # and that is exactly what masked #273 for as long as it existed: the
+  # memfd_create() probe used to include <linux/memfd.h>, which Alpine ships in
+  # linux-headers rather than in musl-dev, so an ordinary "apk add build-base"
+  # build silently fell back to shm_open() and every isolation.rootfs app died.
+  # This leg is deliberately minimal -- core only, no modules -- so that it
+  # tests the probe and nothing else, and it asserts the probe result instead of
+  # trusting a green build, which would stay green with the fallback in place.
+  alpine-no-linux-headers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    container:
+      image: alpine:edge
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          apk update && apk upgrade
+          apk add gcc make musl-dev openssl-dev pcre2-dev
+          if apk info -e linux-headers; then
+            echo "linux-headers must not be installed on this leg" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v5
+
+      - name: configure unit
+        run: |
+          set -o pipefail
+          ./configure --openssl --tests | tee configure.log
+
+      - name: assert memfd_create() was detected
+        run: |
+          grep -q 'checking for memfd_create() \.\.\. found' configure.log || {
+            echo 'memfd_create() not detected without linux-headers (#273)' >&2
+            grep -n 'memfd' configure.log build/autoconf.err >&2 || true
+            exit 1
+          }
+
+      - name: make unit
+        run: make -j 4
+
   # A weekly red check that nobody caused is a check nobody reads, so a
   # scheduled failure is reported as a tracking issue instead, the same way
   # eol-check.yml handles its weekly run.
   report:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [ fedora-rawhide, alpine-edge ]
+    needs: [ fedora-rawhide, alpine-edge, alpine-no-linux-headers ]
     if: failure() && github.event_name == 'schedule'
 
     steps:

--- a/auto/shmem
+++ b/auto/shmem
@@ -109,12 +109,20 @@ fi
 
 # Linux
 
+# MFD_CLOEXEC and the memfd_create() declaration live in <sys/mman.h> under
+# _GNU_SOURCE on glibc >= 2.27 and on musl >= 1.1.20.  Probing <linux/memfd.h>
+# instead tests for the kernel UAPI headers package rather than for the
+# syscall: Alpine ships that header in "linux-headers", not in musl-dev, so a
+# plain "apk add build-base" build used to fall back to shm_open(), which then
+# fails inside an isolation.rootfs because /dev/shm does not exist there.
+
 nxt_feature="memfd_create()"
 nxt_feature_name=NXT_HAVE_MEMFD_CREATE
 nxt_feature_run=yes
 nxt_feature_incs=
 nxt_feature_libs=
-nxt_feature_test="#include <linux/memfd.h>
+nxt_feature_test="#define _GNU_SOURCE
+                  #include <sys/mman.h>
                   #include <unistd.h>
                   #include <sys/syscall.h>
 
@@ -128,6 +136,33 @@ nxt_feature_test="#include <linux/memfd.h>
                       return 0;
                   }"
 . auto/feature
+
+
+if [ $nxt_found = no ]; then
+
+    # Older libc: MFD_CLOEXEC is only in the kernel UAPI header.
+
+    nxt_feature="memfd_create() in <linux/memfd.h>"
+    nxt_feature_test="#include <linux/memfd.h>
+                      #include <unistd.h>
+                      #include <sys/syscall.h>
+
+                      int main(void) {
+                          static char name[] = \"/unit.configure\";
+
+                          int fd = syscall(SYS_memfd_create, name,
+                                           MFD_CLOEXEC);
+                          if (fd == -1)
+                              return 1;
+
+                          return 0;
+                      }"
+    . auto/feature
+
+    if [ $nxt_found = yes ]; then
+        nxt_have=NXT_HAVE_LINUX_MEMFD_H . auto/have
+    fi
+fi
 
 
 if [ "$nxt_shm_open_found$nxt_found" = nono ]; then

--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -8,7 +8,11 @@
 
 #if (NXT_HAVE_MEMFD_CREATE)
 
+#if (NXT_HAVE_LINUX_MEMFD_H)
 #include <linux/memfd.h>
+#else
+#include <sys/mman.h>
+#endif
 #include <unistd.h>
 #include <sys/syscall.h>
 

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -17,7 +17,11 @@
 #include "nxt_websocket.h"
 
 #if (NXT_HAVE_MEMFD_CREATE)
+#if (NXT_HAVE_LINUX_MEMFD_H)
 #include <linux/memfd.h>
+#else
+#include <sys/mman.h>
+#endif
 #endif
 
 #define NXT_UNIT_MAX_PLAIN_SIZE  1024

--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -38,8 +38,10 @@
 #include <sys/wait.h>
 #include <signal.h>
 
-#if (NXT_HAVE_MEMFD_CREATE)
+#if (NXT_HAVE_MEMFD_CREATE && NXT_HAVE_LINUX_MEMFD_H)
 #include <linux/memfd.h>
+#endif
+#if (NXT_HAVE_MEMFD_CREATE)
 #include <sys/syscall.h>
 #endif
 

--- a/src/test/nxt_router_new_port_test.c
+++ b/src/test/nxt_router_new_port_test.c
@@ -40,8 +40,10 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#if (NXT_HAVE_MEMFD_CREATE)
+#if (NXT_HAVE_MEMFD_CREATE && NXT_HAVE_LINUX_MEMFD_H)
 #include <linux/memfd.h>
+#endif
+#if (NXT_HAVE_MEMFD_CREATE)
 #include <sys/syscall.h>
 #endif
 

--- a/src/test/nxt_unit_port_recv_test.c
+++ b/src/test/nxt_unit_port_recv_test.c
@@ -44,7 +44,7 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 
-#if (NXT_HAVE_MEMFD_CREATE)
+#if (NXT_HAVE_MEMFD_CREATE && NXT_HAVE_LINUX_MEMFD_H)
 #include <linux/memfd.h>
 #endif
 

--- a/test/syscalls/README.md
+++ b/test/syscalls/README.md
@@ -90,11 +90,14 @@ would then fail on a language patch release, which is noise, not drift.
 Covering the module path is a separate job with a separate baseline; see the
 follow-ups in the pull request that added this.
 
-The two lists are not directly comparable with each other: 11 syscalls appear
-only in the glibc baseline and 6 only in the musl one, because the libcs pick
-different syscalls for the same operation (`epoll_create` vs `epoll_create1`,
-`clone3` vs `fork`, `openat` vs `open`, and `memfd_create` only on glibc).
-That is the reason both are captured.
+The two lists are not directly comparable with each other: 10 syscalls appear
+only in the glibc baseline (`access`, `clone3`, `epoll_create`, `epoll_wait`,
+`lseek`, `newfstatat`, `openat`, `prlimit64`, `rseq`, `set_robust_list`) and 6
+only in the musl one (`epoll_create1`, `epoll_pwait`, `fork`, `futex`,
+`membarrier`, `open`), because the libcs pick different syscalls for the same
+operation (`epoll_create` vs `epoll_create1`, `clone3` vs `fork`, `openat` vs
+`open`). `memfd_create` appears on both now that the probe finds it on musl
+without the kernel UAPI header. That is the reason both are captured.
 
 ## Guards
 

--- a/test/syscalls/baseline-linux-musl.txt
+++ b/test/syscalls/baseline-linux-musl.txt
@@ -34,6 +34,7 @@ gettid
 ioctl
 listen
 membarrier
+memfd_create
 mkdir
 mmap
 mprotect


### PR DESCRIPTION
## What

`auto/shmem` probed `memfd_create()` by including `<linux/memfd.h>`. That header is kernel UAPI,
shipped by Alpine in `linux-headers` rather than in `musl-dev`, so it tests for a packaging
choice rather than for the syscall. Probe `<sys/mman.h>` under `_GNU_SOURCE` instead (glibc ≥ 2.27
and musl ≥ 1.1.20 declare `memfd_create()` and `MFD_CLOEXEC` there), keeping the `<linux/memfd.h>`
variant as a fallback for older libc, recorded as `NXT_HAVE_LINUX_MEMFD_H`.

## Why / mechanism

On a plain `apk add build-base` Alpine build, `./configure` reported
`checking for memfd_create() ... not found`. libunit then compiled the `shm_open()` fallback
(`src/nxt_unit.c:4098-4109`). `shm_open()` resolves through `/dev/shm`, which does not exist inside
an `isolation.rootfs` and which Unit never automounts, so every rootfs application died in
`nxt_unit_init()` (`src/nxt_unit.c:605-608`):

```
[unit] shm_open(/unit.6137.0x7051a6c0baf0) failed: No such file or directory (2)
[notice] app process 6137 exited with code 1
[alert]  failed to apply new conf
```

The router's twin `nxt_shm_open()` (`src/nxt_port_memory.c:468`) never fails, because the router is
not chrooted — that asymmetry is the whole bug.

The probe fix is not self-contained: `src/nxt_port_memory.c` and `src/nxt_unit.c` (plus three C
tests that call `SYS_memfd_create` directly) also included `<linux/memfd.h>` under
`NXT_HAVE_MEMFD_CREATE`, so making the probe pass on Alpine without switching those includes would
turn a silent misconfiguration into a compile error. They now select the same header the probe
validated. `nxt_port_memory.c` inherits `_GNU_SOURCE` from `nxt_main.h` → `src/nxt_unix.h:26-27`;
`nxt_unit.c` includes `nxt_main.h` first, so it does too (verified by building it on musl).

CI could not have caught this: the `alpine-edge` leg installs `linux-headers`
(`.github/workflows/build-distros.yml:161`). This PR adds a minimal `alpine-no-linux-headers` leg
(core only, no modules) that refuses to run if the package is present and **asserts the
`checking for memfd_create() ... found` line** — a build using the `shm_open()` fallback is
otherwise perfectly green. It is a separate job rather than a matrix axis on `alpine-edge`, so the
Rust/bindgen, JDK and wasm steps there keep the kernel headers they may want.

## Verification

All runs `--platform linux/amd64`, on `alpine:3.22` (musl 1.2.5) and `debian:trixie`.

### Configure result

| tree | image | `linux-headers` | `checking for memfd_create()` |
|---|---|---|---|
| master | alpine:3.22 | no | **`... not found`** (`build/autoconf.err`: `fatal error: linux/memfd.h: No such file or directory`) |
| this PR | alpine:3.22 | no | `... found` |
| master | alpine:3.22 | yes | `... found` |
| this PR | alpine:3.22 | yes | `... found` |
| master | debian:trixie | n/a (`linux-libc-dev`) | `... found` |
| this PR | debian:trixie | n/a | `... found` |

`shm_open() ... found` / `shm_open(SHM_ANON) ... not found` in every Linux cell, unchanged.

Fallback branch, forced by breaking the `<sys/mman.h>` probe on alpine + `linux-headers`:

```
checking for memfd_create() ... not found
checking for memfd_create() in <linux/memfd.h> ... found
build/include/nxt_auto_config.h:  #define NXT_HAVE_LINUX_MEMFD_H  1
make -j4 → OK
```

### Behaviour (alpine:3.22, no `linux-headers`, PHP 8.4.16 module, `--privileged`)

Same config as the issue: `isolation.rootfs` with `automount.language_deps=false, procfs=false`.

| build | PUT /config/ | GET / | log |
|---|---|---|---|
| master | `"Failed to apply new configuration."` | no listener | `shm_open(/unit.6137.0x...) failed: No such file or directory (2)`, `app process 6137 exited with code 1` |
| this PR | `"Reconfiguration done."` | **HTTP 200**, body `OK-273` | `"app" application started`, no alerts |

`test/test_php_isolation.py` in the same container: **2 failed on master**
(`test_php_isolation_rootfs`: `503 == 200`, `test_php_isolation_rootfs_extensions`) → **2 passed on
this branch**. (Both runs also report teardown `PermissionError` on `/tmp/unit-test-*/proc/net`, a
container artifact of the suite's `chmod` walk over a procfs mount, unrelated to the change.)

## Out of scope

The issue's second defect stands: the `shm_open()` fallback remains incompatible with
`isolation.rootfs` wherever it is compiled in (older kernels, non-Linux, DragonFly's
`NXT_SHM_PREFIX="/tmp/"`). Automounting `/dev/shm`, or passing the fd from the router, is a
behavioural change that deserves its own PR; this one removes the only way the fallback was being
reached on a mainstream platform. #273 should stay open for it, or be split.

Fixes #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
