### PR TITLE
isolation: reject "rootfs" + credential ns without a mount ns

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -257,6 +257,12 @@ static nxt_int_t nxt_conf_vldt_rootfs_path(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 #endif
 
+#if (NXT_HAVE_ISOLATION_ROOTFS) && (NXT_HAVE_CLONE_NEWUSER) \
+    && (NXT_HAVE_CLONE_NEWNS)
+static nxt_int_t nxt_conf_vldt_isolation_mounts(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t *value, nxt_app_lang_module_t *lang);
+#endif
+
 #if (NXT_HAVE_NJS)
 static nxt_int_t nxt_conf_vldt_js_module(nxt_conf_validation_t *vldt,
      nxt_conf_value_t *value, void *data);
@@ -3469,7 +3475,17 @@ nxt_conf_vldt_app(nxt_conf_validation_t *vldt, nxt_str_t *name,
         return ret;
     }
 
-    return types[lang->type].validator(vldt, value, types[lang->type].members);
+    ret = types[lang->type].validator(vldt, value, types[lang->type].members);
+    if (ret != NXT_OK) {
+        return ret;
+    }
+
+#if (NXT_HAVE_ISOLATION_ROOTFS) && (NXT_HAVE_CLONE_NEWUSER) \
+    && (NXT_HAVE_CLONE_NEWNS)
+    return nxt_conf_vldt_isolation_mounts(vldt, value, lang);
+#else
+    return NXT_OK;
+#endif
 }
 
 
@@ -4049,6 +4065,179 @@ nxt_conf_vldt_isolation(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 {
     return nxt_conf_vldt_object(vldt, value, data);
 }
+
+
+#if (NXT_HAVE_ISOLATION_ROOTFS) && (NXT_HAVE_CLONE_NEWUSER) \
+    && (NXT_HAVE_CLONE_NEWNS)
+
+static nxt_bool_t
+nxt_conf_vldt_boolean_member(nxt_conf_value_t *object, const nxt_str_t *name,
+    nxt_bool_t dflt)
+{
+    nxt_conf_value_t  *member;
+
+    if (object == NULL) {
+        return dflt;
+    }
+
+    member = nxt_conf_get_object_member(object, name, NULL);
+
+    if (member == NULL || nxt_conf_type(member) != NXT_CONF_BOOLEAN) {
+        return dflt;
+    }
+
+    return nxt_conf_get_boolean(member);
+}
+
+
+/*
+ * A prototype that enters a new user namespace (CLONE_NEWUSER, from
+ * "namespaces": {"credential": true}) without a new mount namespace
+ * (CLONE_NEWNS, from "namespaces": {"mount": true}) stays in the parent's
+ * mount namespace, which is owned by the initial user namespace.  mount(2)
+ * there requires CAP_SYS_ADMIN in *that* namespace, which the child does not
+ * have, so the automount loop in nxt_isolation_prepare_rootfs()
+ * (src/nxt_isolation.c:926) fails with EPERM at src/nxt_fs_mount.c:93 and the
+ * prototype dies before it can serve -- with only "Failed to apply new
+ * configuration." on the control API.  This is a kernel invariant, so refuse
+ * the combination here instead.
+ *
+ * The rootfs switch itself does not need CLONE_NEWNS:
+ * nxt_isolation_change_root() (src/nxt_isolation.c:1058) falls back to
+ * chroot(2), which needs only CAP_SYS_CHROOT in the new user namespace.  So
+ * refuse only the configurations that have a mount to perform: the "tmpfs"
+ * and "procfs" automounts (unconditional builtins, added in
+ * nxt_isolation_set_lang_mounts(), src/nxt_isolation.c:703 and :729), and the
+ * "language_deps" automount when the module declares language dependency
+ * mounts (every lang mount carries deps = 1, src/nxt_main_process.c:1768, and
+ * is skipped when "language_deps" is false, src/nxt_isolation.c:926).  A
+ * config that disables every applicable automount does start and serve, and
+ * stays valid.
+ *
+ * The "language_deps" arm asks what the module declares, not what the runtime
+ * would end up mounting: the same loop also skips a bind mount whose source is
+ * missing on the host (src/nxt_isolation.c:930), so a module whose every
+ * declared dependency happens to be absent -- copied into the rootfs already,
+ * say -- would in fact have started.  Answering that here would mean stat()ing
+ * host paths from the validator, which runs in the controller as the unitd
+ * user while the prototype mounts as root, so it would be wrong in the other
+ * direction just as easily.  Declared-but-absent is therefore the line: it
+ * needs no filesystem access, it does not change under the app's feet, and the
+ * error names the automount to switch off.
+ */
+static nxt_int_t
+nxt_conf_vldt_isolation_mounts(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t *value, nxt_app_lang_module_t *lang)
+{
+    u_char            *p, *q;
+    u_char            names_buf[64], disable_buf[96];
+    nxt_str_t         names, disable;
+    nxt_uint_t        i, n;
+    nxt_conf_value_t  *isolation, *namespaces, *automount;
+    const nxt_str_t   *enabled[3];
+
+    static const nxt_str_t  isolation_str = nxt_string("isolation");
+    static const nxt_str_t  namespaces_str = nxt_string("namespaces");
+    static const nxt_str_t  automount_str = nxt_string("automount");
+    static const nxt_str_t  rootfs_str = nxt_string("rootfs");
+    static const nxt_str_t  credential_str = nxt_string("credential");
+    static const nxt_str_t  mount_str = nxt_string("mount");
+    static const nxt_str_t  tmpfs_str = nxt_string("tmpfs");
+    static const nxt_str_t  procfs_str = nxt_string("procfs");
+    static const nxt_str_t  langdeps_str = nxt_string("language_deps");
+
+    isolation = nxt_conf_get_object_member(value, &isolation_str,
+                                           NULL);
+    if (isolation == NULL
+        || nxt_conf_type(isolation) != NXT_CONF_OBJECT
+        || nxt_conf_get_object_member(isolation, &rootfs_str,
+                                      NULL) == NULL)
+    {
+        return NXT_OK;
+    }
+
+    namespaces = nxt_conf_get_object_member(isolation,
+                                            &namespaces_str,
+                                            NULL);
+    if (namespaces == NULL || nxt_conf_type(namespaces) != NXT_CONF_OBJECT) {
+        return NXT_OK;
+    }
+
+    if (!nxt_conf_vldt_boolean_member(namespaces, &credential_str, 0)
+        || nxt_conf_vldt_boolean_member(namespaces, &mount_str, 0))
+    {
+        return NXT_OK;
+    }
+
+    automount = nxt_conf_get_object_member(isolation,
+                                           &automount_str, NULL);
+    if (automount != NULL && nxt_conf_type(automount) != NXT_CONF_OBJECT) {
+        automount = NULL;
+    }
+
+    /*
+     * Collect every automount that would be attempted, so that one error
+     * names them all and the operator can turn them off in a single edit.
+     */
+
+    n = 0;
+
+    if (nxt_conf_vldt_boolean_member(automount, &procfs_str, 1)) {
+        enabled[n++] = &procfs_str;
+    }
+
+    if (nxt_conf_vldt_boolean_member(automount, &tmpfs_str, 1)) {
+        enabled[n++] = &tmpfs_str;
+    }
+
+    if (nxt_conf_vldt_boolean_member(automount, &langdeps_str, 1)
+        && lang->mounts != NULL && lang->mounts->nelts > 0)
+    {
+        enabled[n++] = &langdeps_str;
+    }
+
+    if (n == 0) {
+        return NXT_OK;
+    }
+
+    p = names_buf;
+    q = disable_buf;
+
+    for (i = 0; i < n; i++) {
+        p = nxt_sprintf(p, names_buf + sizeof(names_buf), "%s\"%V\"",
+                        (i == 0) ? (u_char *) "" :
+                        (i + 1 == n) ? (u_char *) " and " : (u_char *) ", ",
+                        enabled[i]);
+
+        q = nxt_sprintf(q, disable_buf + sizeof(disable_buf),
+                        "%s\"%V\": false",
+                        (i == 0) ? (u_char *) "" : (u_char *) ", ",
+                        enabled[i]);
+    }
+
+    names.start = names_buf;
+    names.length = p - names_buf;
+
+    disable.start = disable_buf;
+    disable.length = q - disable_buf;
+
+    return nxt_conf_vldt_error(vldt,
+                               "The \"isolation\" object sets \"rootfs\" with "
+                               "\"namespaces\": {\"credential\": true} but "
+                               "without \"namespaces\": {\"mount\": true}; a "
+                               "process in a new user namespace but in the "
+                               "parent mount namespace cannot mount the %V "
+                               "%s (EPERM), so the application could never "
+                               "start.  Set \"namespaces\": {\"mount\": true}, "
+                               "drop \"namespaces\": {\"credential\": true}, "
+                               "or set \"automount\": {%V}.",
+                               &names,
+                               (n == 1) ? (u_char *) "automount"
+                                        : (u_char *) "automounts",
+                               &disable);
+}
+
+#endif
 
 
 #if (NXT_HAVE_CLONE_NEWUSER)

--- a/test/test_php_isolation.py
+++ b/test/test_php_isolation.py
@@ -83,3 +83,131 @@ def test_php_isolation_rootfs_extensions(is_su, require, temp_dir):
 
     assert 'json' in extensions, 'json in extensions list'
     assert 'unit' in extensions, 'unit in extensions list'
+
+
+def test_php_isolation_rootfs_credential_without_mount(is_su, require,
+                                                       temp_dir):
+    if not is_su:
+        require(
+            {'features': {'isolation': ['unprivileged_userns_clone', 'user']}}
+        )
+    else:
+        require({'features': {'isolation': ['user']}})
+
+    client.load('phpinfo')
+
+    # A new user namespace without a new mount namespace cannot mount
+    # anything: the child stays in the parent's mount namespace, owned by
+    # the initial user namespace.  The automounts default to on, so this
+    # config could never start; it must be refused at configuration time.
+    resp = client.conf(
+        {'rootfs': temp_dir, 'namespaces': {'credential': True}},
+        'applications/phpinfo/isolation',
+    )
+
+    assert 'error' in resp, 'credential without mount rejected'
+
+    detail = resp.get('detail', '')
+
+    assert 'rootfs' in detail, 'detail names rootfs'
+    assert 'credential' in detail, 'detail names credential'
+    assert 'mount' in detail, 'detail names mount'
+    assert 'automount' in detail, 'detail names automount'
+
+    # The remedy must name the knobs to turn off, not just "the automount
+    # options".  "procfs" and "tmpfs" are unconditional builtins, so both
+    # arms fire here whatever the module declares.
+    assert '"procfs": false' in detail, 'detail names the procfs knob'
+    assert '"tmpfs": false' in detail, 'detail names the tmpfs knob'
+
+    # An explicit "mount": false is the same thing.
+    resp = client.conf(
+        {
+            'rootfs': temp_dir,
+            'namespaces': {'credential': True, 'mount': False},
+        },
+        'applications/phpinfo/isolation',
+    )
+
+    assert 'error' in resp, 'explicit mount false rejected'
+
+    # Without "credential" the config is fine -- the prototype keeps the
+    # main process' privileges and mounts in the parent mount namespace.
+    assert 'success' in client.conf(
+        {'rootfs': temp_dir, 'namespaces': {'credential': False}},
+        'applications/phpinfo/isolation',
+    ), 'no credential accepted'
+
+
+def test_php_isolation_rootfs_credential_with_mount(is_su, require, temp_dir):
+    require(
+        {
+            'features': {
+                'isolation': (
+                    ['user', 'mnt', 'pid']
+                    if is_su
+                    else ['unprivileged_userns_clone', 'user', 'mnt', 'pid']
+                )
+            }
+        }
+    )
+
+    client.load(
+        'phpinfo',
+        isolation={
+            'rootfs': temp_dir,
+            'namespaces': {'credential': True, 'mount': True, 'pid': True},
+        },
+    )
+
+    assert 'success' in client.conf(
+        '"/app/php/phpinfo"', 'applications/phpinfo/root'
+    )
+    assert 'success' in client.conf(
+        '"/app/php/phpinfo"', 'applications/phpinfo/working_directory'
+    )
+
+    assert client.get()['status'] == 200, 'credential + mount serves'
+
+
+def test_php_isolation_rootfs_credential_no_automount(is_su, require,
+                                                      temp_dir):
+    require(
+        {
+            'features': {
+                'isolation': (
+                    ['user']
+                    if is_su
+                    else ['unprivileged_userns_clone', 'user']
+                )
+            }
+        }
+    )
+
+    # With every automount disabled nothing is mounted: the rootfs switch
+    # falls back to chroot(2), which needs only CAP_SYS_CHROOT in the new
+    # user namespace.  This works, so the validator must keep accepting it.
+    #
+    # "language_deps" is off here too, so the case stays valid whether or
+    # not the PHP module declares dependency mounts of its own.
+    client.load(
+        'phpinfo',
+        isolation={
+            'rootfs': temp_dir,
+            'namespaces': {'credential': True},
+            'automount': {
+                'procfs': False,
+                'tmpfs': False,
+                'language_deps': False,
+            },
+        },
+    )
+
+    assert 'success' in client.conf(
+        '"/app/php/phpinfo"', 'applications/phpinfo/root'
+    )
+    assert 'success' in client.conf(
+        '"/app/php/phpinfo"', 'applications/phpinfo/working_directory'
+    )
+
+    assert client.get()['status'] == 200, 'no automount serves'

--- a/test/test_python_isolation.py
+++ b/test/test_python_isolation.py
@@ -127,6 +127,56 @@ def test_python_isolation_rootfs_no_language_deps(require, temp_dir):
     ), 'language_deps unmount'
 
 
+def test_python_isolation_rootfs_credential_language_deps(
+    is_su, require, temp_dir
+):
+    if not is_su:
+        require(
+            {'features': {'isolation': ['unprivileged_userns_clone', 'user']}}
+        )
+    else:
+        require({'features': {'isolation': ['user']}})
+
+    client.load('empty')
+
+    # A new user namespace without a new mount namespace cannot mount
+    # anything.  With "procfs" and "tmpfs" off the only mounts left are the
+    # language dependencies, which this module always declares (auto/modules/
+    # python emits at least the stdlib directory), so the config still could
+    # never start and must be refused -- naming "language_deps", and only
+    # "language_deps", as the automount to switch off.
+    resp = client.conf(
+        {
+            'rootfs': temp_dir,
+            'namespaces': {'credential': True},
+            'automount': {'procfs': False, 'tmpfs': False},
+        },
+        'applications/empty/isolation',
+    )
+
+    assert 'error' in resp, 'language_deps automount rejected'
+
+    detail = resp.get('detail', '')
+
+    assert '"language_deps": false' in detail, 'detail names the knob'
+    assert 'procfs' not in detail, 'disabled procfs not named'
+    assert 'tmpfs' not in detail, 'disabled tmpfs not named'
+
+    # Nothing left to mount, so the very same config becomes valid.
+    assert 'success' in client.conf(
+        {
+            'rootfs': temp_dir,
+            'namespaces': {'credential': True},
+            'automount': {
+                'procfs': False,
+                'tmpfs': False,
+                'language_deps': False,
+            },
+        },
+        'applications/empty/isolation',
+    ), 'every automount off accepted'
+
+
 def test_python_isolation_procfs(require, temp_dir):
     require({'privileged_user': True})
 


### PR DESCRIPTION
## What

Refuse, at configuration time, an application that sets `isolation.rootfs` together with
`isolation.namespaces.credential: true` but no `isolation.namespaces.mount: true`, whenever an
automount would actually be attempted.

Before, such a config was accepted and the prototype then died at every start, with the control API
saying only `Failed to apply new configuration.` (or nothing at all, when the app is started lazily).

## Why

The child unshares `CLONE_NEWUSER` without `CLONE_NEWNS` (`src/nxt_isolation.c:438-466`,
`unshare(2)` at `src/nxt_process.c:526`), so it holds capabilities in a new user namespace while
still living in the parent's mount namespace — which is owned by the *initial* user namespace.
`mount(2)` requires `CAP_SYS_ADMIN` in the user namespace owning the mount namespace, so every
automount in `nxt_isolation_prepare_rootfs()` (`src/nxt_isolation.c:926`) gets `EPERM` at
`src/nxt_fs_mount.c:93`. That is a kernel invariant; nothing Unit can do at runtime. The only
useful fix is to name the cause at config time.

## The rule, and why this one

The refusal is deliberately **narrower** than "rootfs + credential":

* The rootfs switch itself needs no mount namespace — `nxt_isolation_change_root()`
  (`src/nxt_isolation.c:1058`) falls back to `chroot(2)`, which needs only `CAP_SYS_CHROOT` in the
  new user namespace. So a config that mounts nothing does start and serve; the issue observed this
  (`procfs:false` + `tmpfs:false` → `200`), and `test_php_isolation_rootfs_credential_no_automount`
  pins it.
* Therefore the check fires only when a mount would be attempted:
  * `automount.procfs` or `automount.tmpfs` enabled — unconditional builtins added in
    `nxt_isolation_set_lang_mounts()` (`src/nxt_isolation.c:700`, `:740`);
  * `automount.language_deps` enabled **and** the language module declares language dependency
    mounts. Every lang mount carries `deps = 1` (`src/nxt_main_process.c:1768`) and is skipped when
    `language_deps` is false (`src/nxt_isolation.c:926`), so `lang->mounts->nelts` is the predicate.

That last arm asks what the module *declares*, not what the runtime would end up mounting, and it is
not exact: the same loop also skips a bind mount whose source is missing on the host
(`src/nxt_isolation.c:930`), so a module whose every declared dependency happens to be absent —
copied into the rootfs already, say — would in fact have started. Answering that here would mean
`stat()`ing host paths from the validator, which would be the first filesystem access in
`nxt_conf_validation.c` and which runs in the controller as the *unitd* user while the prototype
mounts as *root* — so it would be wrong in the other direction just as easily. Declared-but-absent is
therefore the line: it needs no filesystem access, it does not change under the app's feet, and the
error names the automount to switch off.

Making the `language_deps` arm ask about `lang->mounts` at all is why the check runs from
`nxt_conf_vldt_app()` after the language module is resolved rather than from
`nxt_conf_vldt_isolation()`. The controller inherits a fully populated `rt->languages` — it is filled
from the discovery message before the controller is forked (`src/nxt_main_process.c:1782-1790`) — and
the validator already resolves the module there (`nxt_conf_vldt_app_type()`).

Rejecting on the automount *defaults* alone (the issue's suggested rule) would have broken the
`procfs:false` + `tmpfs:false` config that works today.

## The message

The error names **every** automount that would be attempted, and spells out the `automount` object
that turns them off, so the operator fixes the config in one edit instead of one round trip per
automount. Verbatim, for a python app with the automount defaults (all three arms):

```
PUT /config/  {"isolation":{"rootfs":"/work/rootfs","namespaces":{"credential":true}}}

{
    "error": "Invalid configuration.",
    "detail": "The \"isolation\" object sets \"rootfs\" with \"namespaces\": {\"credential\": true} but without \"namespaces\": {\"mount\": true}; a process in a new user namespace but in the parent mount namespace cannot mount the \"procfs\", \"tmpfs\" and \"language_deps\" automounts (EPERM), so the application could never start.  Set \"namespaces\": {\"mount\": true}, drop \"namespaces\": {\"credential\": true}, or set \"automount\": {\"procfs\": false, \"tmpfs\": false, \"language_deps\": false}.",
    "location": { "path": "/applications/app" }
}
```

The list shrinks to exactly the applicable arms, singular included:

| config | `... cannot mount ...` | `... or set "automount": ...` |
|---|---|---|
| defaults | `the "procfs", "tmpfs" and "language_deps" automounts` | `{"procfs": false, "tmpfs": false, "language_deps": false}` |
| `procfs:false` | `the "tmpfs" and "language_deps" automounts` | `{"tmpfs": false, "language_deps": false}` |
| `procfs:false`, `tmpfs:false` | `the "language_deps" automount` | `{"language_deps": false}` |

On `master` the same PUT answers `{"error": "Failed to apply new configuration."}`.

## Tests

Three cases added to `test/test_php_isolation.py`:

| test | branch | master |
|---|---|---|
| `test_php_isolation_rootfs_credential_without_mount` (rejection + `mount:false` + no-credential control) | PASS | **FAIL** (`assert 'error' in {'success': 'Reconfiguration done.'}`) |
| `test_php_isolation_rootfs_credential_with_mount` (accepted, serves 200) | PASS | PASS |
| `test_php_isolation_rootfs_credential_no_automount` (automounts off → accepted, serves 200) | PASS | PASS |
| existing `test_php_isolation.py` + `test_configuration.py` | 5 passed, 38 skipped | 4 passed, 1 failed (the new one), 38 skipped |
| `make tests && ./build/tests` | rc=0 | rc=0 |

Run as root in `php:8.4-cli-trixie` (`--platform linux/amd64 --privileged --security-opt
apparmor=unconfined`), `./configure --debug --tests && ./configure php && make -j4`.

`test/test_python_isolation.py::test_python_isolation_rootfs_credential_language_deps` is new: it
covers the `language_deps` arm, which the PHP tests cannot reach on this branch (`nxt_app_module` in
`src/nxt_php_sapi.c:387-388` declares `NULL, 0`). It also pins that the disabled arms are *not*
named. `test_php_isolation_rootfs_credential_no_automount` now also sets `language_deps: false`, so
it stays valid once #265 gives the PHP module a tzdata mount.

## CHANGES entry (not committed here)

```
Bugfix: an application with "isolation.rootfs" and "namespaces.credential" but no
"namespaces.mount" was accepted and could never start; it is now refused with an
error naming the automounts to disable.  The check fires only when a mount would
be attempted: "automount.procfs" or "automount.tmpfs" enabled, or
"automount.language_deps" enabled when the module declares language dependency
mounts.
```

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh

