### PR TITLE
router: hold a temp conf reference for the engine quit job

### DIFF
--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -1377,6 +1377,26 @@ nxt_router_conf_wait(nxt_task_t *task, void *obj, void *data)
 }
 
 
+/*
+ * Hand a joint job's temporary configuration reference back to the
+ * configuration thread.  Resetting work.next is not optional: the job was
+ * chained on recf->jobs when it was built, and posting a work item that still
+ * points at its old neighbour silently splices that neighbour into the target
+ * engine's locked queue.  The job must not be touched after the post -- the
+ * configuration thread may run nxt_router_conf_wait() and release the pool the
+ * job lives in at any point from here on.
+ */
+
+nxt_inline void
+nxt_router_conf_wait_post(nxt_joint_job_t *job)
+{
+    job->work.next = NULL;
+    job->work.handler = nxt_router_conf_wait;
+
+    nxt_event_engine_post(job->tmcf->engine, &job->work);
+}
+
+
 static void
 nxt_router_conf_ready(nxt_task_t *task, nxt_router_temp_conf_t *tmcf)
 {
@@ -3670,9 +3690,15 @@ nxt_router_engine_quit(nxt_router_temp_conf_t *tmcf,
     job->task = tmcf->engine->task;
     job->work.handler = nxt_router_worker_thread_quit;
     job->work.task = &job->task;
-    job->work.obj = NULL;
+    job->work.obj = job;
     job->work.data = NULL;
-    job->tmcf = NULL;
+    job->tmcf = tmcf;
+
+    /*
+     * The job outlives this call on the target engine's locked queue, so hold
+     * the pool it lives in, as the joints create/delete jobs do.
+     */
+    tmcf->count++;
 
     return NXT_OK;
 }
@@ -3963,10 +3989,7 @@ nxt_router_listen_socket_create(nxt_task_t *task, void *obj, void *data)
     ls->count++;
     nxt_thread_spin_unlock(lock);
 
-    job->work.next = NULL;
-    job->work.handler = nxt_router_conf_wait;
-
-    nxt_event_engine_post(job->tmcf->engine, &job->work);
+    nxt_router_conf_wait_post(job);
 }
 
 
@@ -4017,10 +4040,7 @@ nxt_router_listen_socket_update(nxt_task_t *task, void *obj, void *data)
     lev->socket.data = joint;
     lev->listen = joint->socket_conf->listen;
 
-    job->work.next = NULL;
-    job->work.handler = nxt_router_conf_wait;
-
-    nxt_event_engine_post(job->tmcf->engine, &job->work);
+    nxt_router_conf_wait_post(job);
 
     /*
      * The task is allocated from configuration temporary
@@ -4063,16 +4083,27 @@ nxt_router_listen_socket_delete(nxt_task_t *task, void *obj, void *data)
 static void
 nxt_router_worker_thread_quit(nxt_task_t *task, void *obj, void *data)
 {
+    nxt_joint_job_t     *job;
     nxt_event_engine_t  *engine;
 
     nxt_debug(task, "router worker thread quit");
+
+    job = obj;
 
     engine = task->thread->engine;
 
     engine->shutdown = 1;
 
+    /*
+     * Give the reference nxt_router_engine_quit() took back.  The task this
+     * handler was called with is allocated from the same pool as the job, so
+     * the exit below has to continue on the engine's own task.
+     */
+
+    nxt_router_conf_wait_post(job);
+
     if (nxt_queue_is_empty(&engine->joints)) {
-        nxt_router_worker_thread_exit(task);
+        nxt_router_worker_thread_exit(&engine->task);
     }
 }
 
@@ -4196,10 +4227,7 @@ nxt_router_listen_socket_close_ready(nxt_socket_conf_joint_t *joint)
 
     joint->close_job = NULL;
 
-    job->work.next = NULL;
-    job->work.handler = nxt_router_conf_wait;
-
-    nxt_event_engine_post(job->tmcf->engine, &job->work);
+    nxt_router_conf_wait_post(job);
 }
 
 

--- a/test/test_listen_threads.py
+++ b/test/test_listen_threads.py
@@ -103,3 +103,44 @@ def test_listen_threads_engine_fds():
         f'router leaked {after - before} descriptors over a listen_threads'
         f' {THREADS} -> 1 -> {THREADS} cycle ({before} before, {after} after)'
     )
+
+
+def test_listen_threads_shrink_grow_no_listeners():
+    # nxt_router_engine_quit() allocates its nxt_joint_job_t (the nxt_work_t
+    # *and* the nxt_task_t the work item points at) from tmcf->mem_pool but
+    # used to take no tmcf->count reference, so nxt_router_conf_ready() could
+    # release the pool while the job was still sitting on the dying engine's
+    # locked work queue.  The window is widest with no listeners configured:
+    # engine->joints is then empty, so nxt_router_worker_thread_quit() is the
+    # only thing standing between the post and nxt_thread_exit(), and there is
+    # no listen-socket delete job on the same queue to serialise behind.
+    #
+    # Each PUT is asserted, so a "Value doesn't exist." reply is never counted
+    # as a clean cycle, and the router pid is compared every cycle because the
+    # control API only reports the failed apply of the crashed generation, not
+    # the crash itself.
+    #
+    # 50 cycles, not fewer: the per-cycle crash probability is only ~3%, so the
+    # count is what buys the detection rate.  Measured on master, 10 runs each:
+    # 50 cycles caught it 8 times in 1.2 s per run, 20 cycles 4 times in 0.8 s.
+    # Halving the detection to save 0.4 s is not a trade worth making; the run
+    # time here is dominated by pytest and unitd start-up either way.
+    assert 'success' in client.conf(
+        {
+            "listeners": {},
+            "routes": [{"action": {"return": 200}}],
+        }
+    )
+
+    pid = pid_by_name('unit: router')
+
+    for i in range(50):
+        for threads in (8, 4, 8):
+            assert 'success' in client.conf(
+                {"listen_threads": threads}, 'settings'
+            ), f'cycle {i}: listen_threads {threads}'
+
+        assert pid_by_name('unit: router') == pid, (
+            f'router restarted during cycle {i}: the engine-quit job was'
+            ' freed with tmcf->mem_pool before the dying engine drained it'
+        )


### PR DESCRIPTION
Fixes #186.

## The bug

`nxt_router_engine_quit()` (`src/nxt_router.c:3657`) allocates its
`nxt_joint_job_t` from `tmcf->mem_pool`. That struct embeds both the
`nxt_work_t` and the `nxt_task_t` the work item points at. Unlike every other
joint job — `nxt_router_engine_joints_create()` (`:3628`) and
`nxt_router_engine_joints_delete()` (`:3707`) both do `tmcf->count++` — it set
`job->tmcf = NULL` and took no reference.

`nxt_router_engines_post()` (`:3786`) hands that work item to
`nxt_event_engine_post()` (`:3827`), i.e. onto the *dying* engine's locked post
queue, where it sits until that engine's thread drains it. Nothing holds the
temporary configuration, so `nxt_router_conf_ready()` (`:1381`) can reach
`nxt_mp_release(tmcf->mem_pool)` (`:1415`) first, and the worker then
dereferences freed memory two ways:

- `work->task->thread = thr` in `nxt_locked_work_queue_move()`
  (`src/nxt_work_queue.c:304`), and
- `task->log` in the `nxt_debug()` at the head of
  `nxt_router_worker_thread_quit()` (`:4064`).

Confirmed under ASan on this branch's base — the allocation frame names the
culprit directly:

```
==48677==ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 at 0x5190000a5100 thread T7
    #0 nxt_locked_work_queue_move      src/nxt_work_queue.c:304
    #1 nxt_event_engine_post_handler   src/nxt_event_engine.c:339
    #3 nxt_event_engine_start          src/nxt_event_engine.c:570
    #4 nxt_router_thread_start         src/nxt_router.c:3910
freed by thread T0 here:
    #2 nxt_mp_destroy                  src/nxt_mp.c:353
    #3 nxt_mp_release                  src/nxt_mp.c:303
    #4 nxt_router_conf_ready           src/nxt_router.c:1415
previously allocated by thread T0 here:
    #6 nxt_router_engine_quit          src/nxt_router.c:3662
    #7 nxt_router_engine_conf_delete   src/nxt_router.c:3585
    #8 nxt_router_engines_create       src/nxt_router.c:3493
```

## The fix

Take the reference at allocation, and give the handler the job back
(`job->work.obj = job`) so it can post an `nxt_router_conf_wait()` to the
configuration thread and hand the reference back — exactly the pattern
`nxt_router_listen_socket_create()` / `_update()` (`:3934` / `:3996`) already
use. Smallest change consistent with the surrounding code; the alternative
("do not reference pool memory from the posted job at all") is not available,
because `nxt_locked_work_queue_move()` walks the `nxt_work_t` itself, not just
`work->task`, so the whole job has to outlive the drain.

The post is the last use of the job: the configuration thread may release the
pool immediately afterwards, so the possible thread exit that follows continues
on the engine's own task (`nxt_router_thread_start()` sets `engine->task.thread`
at `:3874`) rather than on the pool-allocated one.

That re-post idiom then had four copies, and the `work.next = NULL` in it is
load-bearing — the job is still chained on `recf->jobs`, so posting without the
reset splices its old neighbour into the target engine's locked queue, silently.
Factored into `nxt_router_conf_wait_post()` (`:1390`, `nxt_inline` to match the
file's house style) and used at all four sites; no behaviour change.

## Reproducer

The window is widest with **no listeners configured**: `engine->joints` is then
empty, so `nxt_router_worker_thread_quit()` goes straight to
`nxt_router_worker_thread_exit()`, with no listen-socket delete job on the same
queue to serialise behind. `listen_threads` 8 → 4 → 8 with `"listeners": {}` is
enough — no language module, no load, no ASan needed.

Added as `test/test_listen_threads.py::test_listen_threads_shrink_grow_no_listeners`
(50 cycles, asserting every PUT and the router pid each cycle — the control API
only reports the failed apply of the crashed generation, not the crash).

**On the cycle count.** Reducing 50 → 20 was tried and measured rather than
assumed, and it does not hold: on master, 10 runs each, 50 cycles caught the
crash 8 times at 1.2 s per run, 20 cycles caught it 4 times at 0.8 s. The
per-cycle crash probability is only ~3 %, so the count is exactly what buys the
detection rate, and the run time is dominated by pytest and unitd start-up
either way. Halving detection to save 0.4 s is not a trade worth making, so the
test keeps 50 cycles and the measurement is recorded in its comment.

| build | master | this branch |
|---|---|---|
| `--debug`, pytest regression test, 10 runs | **8 failed** / 2 passed | 0 failed / **10 passed** |
| `--debug --tests` + ASan, same test, 10 runs | **10 failed** / 0 passed | 0 failed / **10 passed** |
| `--debug`, shell reproducer (fresh unitd × 15, 15 cycles each) | **3/15 crashed** | **0/15** |
| `./build/tests` (C suite, 41 subtests) | — | **exit 0** |

Failure on master is the issue's exact signature: `{"error": "Failed to apply new
configuration."}`, `process NNN exited on signal 11`, router respawned.

Test suites on the branch (`--debug --tests`, gcc 14.2, python module built),
Debian trixie / amd64:

| suite | result |
|---|---|
| `test_configuration.py` + `test_listener_drain.py` + `test_conn_recycle.py` + `test_listen_threads.py` | **37 passed, 8 skipped** |

Note `test_conn_recycle.py::test_conn_recycle_across_thread_churn` already loops
`listen_threads` 4 → 1 → 4 but never fails, because it always has `*:8080`
configured — the case that does not crash.

## Acknowledged, deliberately not changed

- The posted quit job's liveness depends on the dying engine reaching
  `nxt_event_engine_start()` and draining its queue. An engine that never got
  there would strand the reference — but that is pre-existing and identical for
  the joints-delete jobs, which have always held one. Informational; out of
  scope here.
- No `CHANGES` entry in this commit: `CHANGES` is written at release time. The
  proposed Bugfix wording is below for whoever cuts the release.

## Interaction with recent work

- **c44f43ff** (*router: close the engine port when a worker thread exits*)
  touches `nxt_router_thread_exit_handler()`, which runs on the configuration
  thread after `nxt_thread_wait()` on the departed worker. This change only
  affects what the worker does *before* `nxt_thread_exit()`, and the extra
  `nxt_router_conf_wait()` post is drained by the configuration engine
  independently of the thread-exit work item. No overlap.
- **#276** (`fix/listen-close-ack-order`) reorders
  `nxt_router_listen_socket_close_ready()` inside
  `nxt_router_listen_socket_close()` / `_close_finish()`. Disjoint functions;
  it moves *when* an already-referenced close job is posted back, while this
  change adds a reference for the quit job, which has no close-job path. Both
  end up funnelling through `nxt_router_conf_wait()`, and the counts are
  independent. Textually non-conflicting.

## CHANGES (Bugfix)

```
*) Bugfix: the router could crash with a use-after-free when
   "listen_threads" was decreased and then increased, because the
   engine quit job was allocated from the temporary configuration
   memory pool without holding a reference to it.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
