### PR TITLE
http: release the application's buffers after compressing a response

### DIFF
--- a/src/nxt_http_compression.c
+++ b/src/nxt_http_compression.c
@@ -18,6 +18,9 @@
 
 #define NXT_COMP_LEVEL_UNSET               INT8_MIN
 
+/* Headroom for the flush marker a compressor emits per call. */
+#define NXT_HTTP_COMP_FLUSH_SLACK          64
+
 
 typedef enum nxt_http_comp_scheme_e        nxt_http_comp_scheme_t;
 typedef struct nxt_http_comp_type_s        nxt_http_comp_type_t;
@@ -174,7 +177,7 @@ nxt_http_comp_compress_app_response(nxt_task_t *task, nxt_http_request_t *r,
     bool                 last;
     size_t               buf_len;
     ssize_t              cbytes;
-    nxt_buf_t            *buf;
+    nxt_buf_t            *in, *next, *buf, *out, **tail;
     nxt_off_t            in_len;
     nxt_http_comp_ctx_t  *ctx = nxt_http_comp_ctx();
 
@@ -182,51 +185,103 @@ nxt_http_comp_compress_app_response(nxt_task_t *task, nxt_http_request_t *r,
         return NXT_OK;
     }
 
-    if (!nxt_buf_is_port_mmap(*b)) {
-        return NXT_OK;
+    /*
+     * What arrives here is a chain, not a single buffer:
+     * nxt_port_mmap_read() (src/nxt_port_memory.c) makes one nxt_buf_t per
+     * nxt_port_mmap_msg_t, the call site links it into r->out with
+     * nxt_buf_chain_add(), and a sync buffer may sit at the tail.  Walk it.
+     *
+     * The previous version compressed the head and then replaced the whole
+     * chain with that one output buffer, so anything behind the head was
+     * dropped from the response and never released, and ctx->clen_sent
+     * counted only the head -- which is what decides whether the compressor
+     * is told it is finishing the stream.
+     */
+
+    out = NULL;
+    tail = &out;
+
+    for (in = *b; in != NULL; in = next) {
+        next = in->next;
+        in->next = NULL;
+
+        /*
+         * Buffers that did not come through shared memory are passed
+         * through untouched: the trailing sync/last buffer carries no data,
+         * and a plain-mode response is not compressed at all (the same
+         * condition the single-buffer version tested on the head).
+         */
+        if (!nxt_buf_is_port_mmap(in)) {
+            *tail = in;
+            tail = &in->next;
+            continue;
+        }
+
+        in_len = in->mem.free - in->mem.pos;
+
+        last = ctx->clen_sent + in_len == ctx->resp_clen;
+
+        if (in_len == 0 && !last) {
+            goto release;
+        }
+
+        /*
+         * The per-call flush marker each compressor emits after the input
+         * is not part of what bound() promises for the input alone, so the
+         * output buffer gets a small fixed margin on top.
+         */
+        buf_len = nxt_http_comp_bound(in_len) + NXT_HTTP_COMP_FLUSH_SLACK;
+
+        buf = nxt_buf_mem_ts_alloc(task, in->data, buf_len);
+        if (nxt_slow_path(buf == NULL)) {
+            goto fail;
+        }
+
+        cbytes = nxt_http_comp_compress(buf->mem.start, buf_len,
+                                        in->mem.pos, in_len, last);
+        if (nxt_slow_path(cbytes == -1)) {
+            nxt_buf_free(buf->data, buf);
+            goto fail;
+        }
+
+        buf->mem.free += cbytes;
+
+        ctx->clen_sent += in_len;
+
+        *tail = buf;
+        tail = &buf->next;
+
+    release:
+
+        /*
+         * The compressed bytes have been copied out, so the shared memory
+         * chunk can go back to the application.  This has to run the
+         * buffer's own completion handler -- nxt_buf_free() is a plain pool
+         * free, and using it here (as the single-buffer version did) leaked
+         * the chunk, the mmap_handler reference and the port mem_pool
+         * reference on every compressed response.  in->next was cleared
+         * above because nxt_port_mmap_buf_completion() walks the chain.
+         */
+        nxt_work_queue_add(&task->thread->engine->fast_work_queue,
+                           in->completion_handler, task, in, in->parent);
     }
 
-    in_len = (*b)->mem.free - (*b)->mem.pos;
-    buf_len = nxt_http_comp_bound(in_len);
-
-    buf = nxt_buf_mem_ts_alloc(task, (*b)->data, buf_len);
-    if (nxt_slow_path(buf == NULL)) {
-        return NXT_ERROR;
-    }
-
-    buf->data = (*b)->data;
-
-    last = ctx->clen_sent + in_len == ctx->resp_clen;
-
-    cbytes = nxt_http_comp_compress(buf->mem.start, buf_len,
-                                    (*b)->mem.pos, in_len, last);
-    if (cbytes == -1) {
-        nxt_buf_free(buf->data, buf);
-        return NXT_ERROR;
-    }
-
-    buf->mem.free += cbytes;
-
-    ctx->clen_sent += in_len;
-
-#define nxt_swap_buf(db, sb)                                                  \
-    do {                                                                      \
-        nxt_buf_t  **db_ = (db);                                              \
-        nxt_buf_t  **sb_ = (sb);                                              \
-        nxt_buf_t  *tmp_;                                                     \
-                                                                              \
-        tmp_ = *db_;                                                          \
-        *db_ = *sb_;                                                          \
-        *sb_ = tmp_;                                                          \
-    } while (0)
-
-    nxt_swap_buf(b, &buf);
-
-#undef nxt_swap_buf
-
-    nxt_buf_free(buf->data, buf);
+    *b = out;
 
     return NXT_OK;
+
+fail:
+
+    /*
+     * Keep whatever has been produced so far, and re-attach the input that
+     * has not been consumed, so that the caller's error path owns the whole
+     * chain and releases it.
+     */
+    in->next = next;
+    *tail = in;
+    *b = out;
+
+    return NXT_ERROR;
 }
 
 

--- a/test/php/comp_random_body/index.php
+++ b/test/php/comp_random_body/index.php
@@ -1,0 +1,14 @@
+<?php
+/*
+ * An incompressible body of the requested size, so that the compressed
+ * response is roughly as large as the original and each request really does
+ * move that many bytes of shared memory through the router.
+ *
+ * The digest travels in a header so the test can check the decompressed body
+ * byte for byte without the two sides having to agree on the bytes.
+ */
+$n = (int) ($_GET['n'] ?? 1048576);
+$body = random_bytes($n);
+header('X-Body-Sha256: ' . hash('sha256', $body));
+header('Content-Length: ' . strlen($body));
+echo $body;

--- a/test/test_php_compression.py
+++ b/test/test_php_compression.py
@@ -1,4 +1,6 @@
 import gzip
+import hashlib
+import socket
 
 import pytest
 
@@ -26,16 +28,18 @@ def requires_restart_mode():
     if not option.restart:
         pytest.skip('needs --restart until #167 is fixed')
 
-COMPRESSION_CONF = {
-    "compression": {
-        "types": ["text/html*"],
-        "compressors": [{"encoding": "gzip", "level": 1}],
+def configure_compression(encoding='gzip'):
+    conf = {
+        "compression": {
+            "types": ["text/html*"],
+            "compressors": [{"encoding": encoding}],
+        }
     }
-}
 
+    if encoding == 'gzip':
+        conf["compression"]["compressors"][0]["level"] = 1
 
-def configure_compression():
-    resp = client.conf({"http": COMPRESSION_CONF}, 'settings')
+    resp = client.conf({"http": conf}, 'settings')
 
     if 'success' in resp:
         return
@@ -43,7 +47,7 @@ def configure_compression():
     # Compressors are build options; skip only for that, so a broken config
     # here fails loudly instead of quietly turning into a skipped test.
     if 'supported compressor' in resp.get('detail', ''):
-        pytest.skip('unit built without gzip compression support')
+        pytest.skip(f'unit built without {encoding} compression support')
 
     pytest.fail(f'could not configure compression: {resp}')
 
@@ -68,7 +72,7 @@ def dechunk(data):
         data = data[end + 2 + size + 2 :]
 
 
-def get_gzip():
+def get_gzip(encoding='gzip'):
     """
     The shared client decodes bodies as text and splits chunked bodies on
     CRLF, both of which destroy a compressed payload, so read the response
@@ -77,7 +81,7 @@ def get_gzip():
     resp = client.get(
         headers={
             'Host': 'localhost',
-            'Accept-Encoding': 'gzip',
+            'Accept-Encoding': encoding,
             'Connection': 'close',
         },
         raw_resp=True,
@@ -150,3 +154,143 @@ def test_php_compression_small_body():
         # Declining to compress is an equally valid fix, as long as the
         # encoding is not advertised.
         assert body == b'A' * 64, 'uncompressed body delivered verbatim'
+
+
+RANDOM_BODY_SIZE = 9 * 1024 * 1024
+LEAK_REQUESTS = 15  # > 100 MB in total: more shared memory than an app may hold
+
+
+def raw_get(path, encoding, timeout=30):
+    """
+    A plain socket request.  The shared client cannot express "fail rather
+    than block forever", which is exactly the failure these tests look for.
+    """
+    sock = socket.create_connection(('127.0.0.1', 8080), timeout)
+    sock.settimeout(timeout)
+
+    try:
+        sock.sendall(
+            f'GET {path} HTTP/1.1\r\n'
+            f'Host: localhost\r\n'
+            f'Accept-Encoding: {encoding}\r\n'
+            f'Connection: close\r\n\r\n'.encode()
+        )
+
+        chunks = []
+        while True:
+            data = sock.recv(256 * 1024)
+            if not data:
+                break
+            chunks.append(data)
+
+    finally:
+        sock.close()
+
+    resp = b''.join(chunks)
+    head, _, body = resp.partition(b'\r\n\r\n')
+    lines = head.split(b'\r\n')
+
+    status = int(lines[0].split()[1])
+
+    headers = {}
+    for line in lines[1:]:
+        name, _, value = line.partition(b':')
+        headers[name.strip().decode()] = value.strip().decode()
+
+    if headers.get('Transfer-Encoding') == 'chunked':
+        body = dechunk(body)
+
+    return status, headers, body
+
+
+def decompress(encoding, data):
+    if encoding == 'gzip':
+        return gzip.decompress(data)
+
+    if encoding == 'br':
+        brotli = pytest.importorskip(
+            'brotli', reason='python brotli bindings not installed'
+        )
+        return brotli.decompress(data)
+
+    if encoding == 'zstd':
+        try:
+            from compression import zstd  # Python >= 3.14
+
+            return zstd.decompress(data)
+        except ImportError:
+            zstandard = pytest.importorskip(
+                'zstandard', reason='python zstd bindings not installed'
+            )
+            return zstandard.ZstdDecompressor().decompressobj().decompress(data)
+
+    pytest.fail(f'no decompressor for {encoding}')
+
+
+@pytest.mark.parametrize('encoding', ['gzip', 'br', 'zstd'])
+def test_php_compression_large_random_body(encoding):
+    """
+    Coverage for the chain walk in nxt_http_comp_compress_app_response():
+    a multi-megabyte incompressible body arrives as a long sequence of
+    port-mmap buffers, so every compressor is driven across many calls with
+    the finishing one arriving last.  Check the body still round-trips.
+    """
+    client.load('comp_random_body')
+    configure_compression(encoding)
+
+    status, headers, body = raw_get(
+        f'/?n={RANDOM_BODY_SIZE}', encoding
+    )
+
+    assert status == 200, 'status'
+    assert headers['Content-Encoding'] == encoding, 'encoding advertised'
+
+    # The compressed body is framed either by Content-Length or by chunked
+    # transfer encoding -- never by both, and never by neither, or the client
+    # cannot tell where it ends.
+    has_clen = 'Content-Length' in headers
+    is_chunked = headers.get('Transfer-Encoding') == 'chunked'
+
+    assert has_clen != is_chunked, f'exactly one framing: {headers}'
+
+    if has_clen:
+        assert len(body) == int(headers['Content-Length']), 'framing consistent'
+
+    plain = decompress(encoding, body)
+
+    assert len(plain) == RANDOM_BODY_SIZE, 'full body length'
+    assert (
+        hashlib.sha256(plain).hexdigest() == headers['X-Body-Sha256']
+    ), 'round-trips byte for byte'
+
+
+def test_php_compression_shm_not_leaked():
+    """
+    Regression test for #177.
+
+    nxt_http_comp_compress_app_response() released the application's buffer
+    with nxt_buf_free(), a plain pool free that never runs the buffer's
+    completion handler.  For a port-mmap buffer that handler,
+    nxt_port_mmap_buf_completion(), is what marks the shared memory chunks
+    free again, so every compressed response leaked its chunks.
+
+    An application may hold only so much shared memory (shm_limit, 100 MB by
+    default), so the leak is fatal rather than merely wasteful: after enough
+    compressed bytes the worker can no longer allocate a buffer and the next
+    request never gets a response.  Before the fix this wedges partway
+    through the loop and the request below times out.
+    """
+    client.load('comp_random_body')
+    configure_compression()
+
+    for i in range(LEAK_REQUESTS):
+        status, headers, body = raw_get(
+            f'/?n={RANDOM_BODY_SIZE}', 'gzip'
+        )
+
+        assert status == 200, f'status of request {i}'
+        assert headers['Content-Encoding'] == 'gzip', f'encoding, request {i}'
+        assert (
+            hashlib.sha256(gzip.decompress(body)).hexdigest()
+            == headers['X-Body-Sha256']
+        ), f'body of request {i}'


### PR DESCRIPTION
Fixes #177

## What is wrong

`nxt_http_comp_compress_app_response()` (`src/nxt_http_compression.c:170`)
released the application buffer it had just compressed with `nxt_buf_free()`,
which is

```c
/* src/nxt_buf.h:239 */
#define nxt_buf_free(mp, b)  nxt_mp_free((mp), (b))
```

— a plain pool free that never runs `b->completion_handler`.

The only buffers this function touches are the ones that came from the
application through shared memory, and for those the handler is
`nxt_port_mmap_buf_completion()` (`src/nxt_port_memory.c:159`). That handler is
the only thing that marks the buffer's chunks free in `hdr->free_map`, drops the
`nxt_port_mmap_handler_t` reference and releases the `nxt_mp_retain()` on
`port->mem_pool`. So **every compressed response leaked the shared memory it was
built from**.

That is fatal rather than merely wasteful. An application worker may hold only
`shm_limit` bytes of shared memory (100 MB by default), so once enough
compressed bytes have gone out, `nxt_unit_get_outgoing_buf()`
(`src/nxt_unit.c:3795`) can no longer allocate and the worker simply stops
answering.

Measured against a PHP application returning a 9 MB incompressible body over
gzip, on `origin/master`:

```
req  0: 0.69s bytes=9457301 ok=True
...
req 10: 0.57s bytes=9457270 ok=True
req 11: FAILED after 20.1s: TimeoutError('timed out')
```

Eleven requests — about 99 MB — and the worker is wedged for good. With this
change all 20 complete in ~0.57 s each.

Under ASan (`detect_leaks=1` on the router) the same run leaks

```
Direct leak of 48 byte(s) in 2 object(s) allocated from:
    #2 nxt_zalloc src/nxt_malloc.c:54
    #3 nxt_port_incoming_port_mmap src/nxt_port_memory.c:344
    #4 nxt_port_mmap_handler src/nxt_port.c:825
```

on master and does not on this branch — the `nxt_port_mmap_handler_t`
references the completion handler was never given the chance to drop.

## On the issue's other claim

#177 also reports that the function drops every buffer after the head of the
chain, truncating the body. That reading of the code is correct — it compressed
the head and then replaced the whole chain with that single output buffer, and
`ctx->clen_sent` counted only the head — but **I could not reach it from an
application response**, and the issue is right to flag that its severity was not
measured.

`nxt_unit_mmap_buf_send()` (`src/nxt_unit.c:2854`) puts exactly one
`nxt_port_mmap_msg_t` in each port message, so `nxt_port_mmap_read()` yields a
one-buffer chain. Instrumenting the function to log the chain length on every
call gave `chain len 1` for 100 % of calls across 8 MB and 32 MB bodies,
compressible and incompressible, with a fast client and with a client throttled
to 80 KB/s — the compressed-buffer-left-in-`r->out` case never materialised
either, because the app is already back-pressured by shm chunk availability.

The chain walk is fixed anyway: it is what the code says it does, and any
producer that batched two `nxt_port_mmap_msg_t` into one message would hit it.
It is just not the reason responses are breaking today.

## The change

- Walk the chain. Compress each port-mmap buffer into its own output buffer,
  keeping order; accumulate `ctx->clen_sent` across all of them so the
  finishing call actually happens on the last one.
- Pass non-port-mmap buffers through untouched — the trailing sync buffer, and
  a plain-mode response — which is the same condition the old code tested on the
  head.
- Release each consumed input buffer through **its own completion handler**,
  posted to the engine's fast work queue, with `in->next` cleared first because
  `nxt_port_mmap_buf_completion()` walks the chain it is handed.
- Give the output buffer a small fixed margin on top of `bound()`: the flush
  marker each compressor emits per call is not part of what `bound()` promises
  for the input alone.

## Tests

`test/test_php_compression.py`:

- `test_php_compression_shm_not_leaked` — 15 sequential 9 MB gzip responses
  (>100 MB, more shared memory than an app may hold). Fails on master, where the
  request after exhaustion times out; passes here.
- `test_php_compression_large_random_body[gzip|br|zstd]` — a 9 MB incompressible
  body drives every built-in compressor across many calls with the finishing one
  last, and the decompressed body is checked against a SHA-256 the application
  puts in a header. Coverage for the chain walk; passes on both.

New application `test/php/comp_random_body`.

| test | master | this branch |
|---|---|---|
| `test_php_compression.py` | 4 passed, **1 failed**, 1 skipped, 1 error | **5 passed**, 1 skipped |
| `test_php_application.py` | 50 passed, 1 failed\*, 1 skipped | 50 passed, 1 failed\*, 1 skipped |
| `test_static.py` | — | 20 passed, 1 skipped |
| `./build/tests` | OK | OK |

\* `test_php_application_forbidden` fails identically on both — the suite ran as
root in the container, where a `chmod 000` file is still readable.

Built and run in Docker (`php:8.4-cli-trixie`, `linux/amd64`) with
`--tests --debug --zlib --zstd --brotli`, plus a separate ASan build.

## CHANGES

```
    *) Bugfix: the shared memory holding an application's response was never
       released when the response was compressed, so a worker stopped
       answering once it had sent about 100 MB of compressed body.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
