### PR TITLE
http: drop the response body on a status that defines none

### DIFF
--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -1456,7 +1456,13 @@ nxt_h1p_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
         if (r->resp.content_length == NULL || r->resp.content_length->skip) {
 
             if (http11) {
-                if (n != NXT_HTTP_NOT_MODIFIED
+                /*
+                 * r->no_body already covers 204 and 304, plus 1xx and every
+                 * response to HEAD; the two status tests are kept so the
+                 * framing rule stays readable at the point it is applied.
+                 */
+                if (!r->no_body
+                    && n != NXT_HTTP_NOT_MODIFIED
                     && n != NXT_HTTP_NO_CONTENT
                     && body_handler != NULL
                     && !h1p->websocket)
@@ -1467,7 +1473,12 @@ nxt_h1p_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
                     size -= nxt_length("\r\n");
                 }
 
-            } else {
+            } else if (!r->no_body) {
+                /*
+                 * A pre-HTTP/1.1 client needs the close to delimit a body;
+                 * a response that has no body needs no such delimiter, so
+                 * keep-alive stays as negotiated.
+                 */
                 h1p->keepalive = 0;
             }
         }

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -267,6 +267,7 @@ struct nxt_http_request_s {
     uint8_t                         error;        /* 1 bit  */
     uint8_t                         websocket_handshake;  /* 1 bit */
     uint8_t                         chunked;  /* 1 bit */
+    uint8_t                         no_body;  /* 1 bit */
 };
 
 

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -22,6 +22,10 @@ static void nxt_http_request_forward_protocol(nxt_http_request_t *r,
 static void nxt_http_request_ready(nxt_task_t *task, void *obj, void *data);
 static void nxt_http_request_proto_info(nxt_task_t *task,
     nxt_http_request_t *r);
+static nxt_bool_t nxt_http_request_is_bodyless(nxt_http_request_t *r);
+static void nxt_http_request_drop_framing_fields(nxt_http_request_t *r);
+static nxt_buf_t *nxt_http_request_body_drop(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_buf_t *out);
 static void nxt_http_request_mem_buf_completion(nxt_task_t *task, void *obj,
     void *data);
 static void nxt_http_request_done(nxt_task_t *task, void *obj, void *data);
@@ -693,6 +697,45 @@ nxt_http_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
     }
 
     /*
+     * RFC 9112 Sect. 6.3: a 1xx, 204 or 304 response, and any response to a
+     * HEAD request, never has a message body, no matter what the response
+     * headers say.  Record that here, in the layer every response source
+     * (application, proxy, static, "return") passes through, so that the
+     * per-protocol header_send() can drop the framing and
+     * nxt_http_request_send() can drop the body buffers.  Without this an
+     * application that writes a body on 204/304 has those bytes forwarded
+     * verbatim and unframed, which a downstream parser reads as the start of
+     * the next response.
+     */
+    r->no_body = nxt_http_request_is_bodyless(r);
+
+    /*
+     * RFC 9110 Sect. 8.6: a server must not send Content-Length in a 1xx or
+     * 204 response.  A 304 keeps it -- there it describes the body the client
+     * already has -- and so does a HEAD response, where it describes the body
+     * the equivalent GET would return.
+     */
+    if (r->no_body
+        && (r->status < NXT_HTTP_OK || r->status == NXT_HTTP_NO_CONTENT))
+    {
+        if (r->resp.content_length != NULL) {
+            r->resp.content_length->skip = 1;
+        }
+
+        r->resp.content_length_n = -1;
+
+        /*
+         * r->resp.content_length only tracks the field the application sent.
+         * A Content-Length added by "response_headers" (nxt_http_set_headers.c)
+         * is a generic field, and an application-supplied Transfer-Encoding is
+         * one too; both are forbidden here and both would otherwise be
+         * serialized verbatim, desyncing the next response on a connection
+         * whose keep-alive this change preserves.  Sweep the whole field store.
+         */
+        nxt_http_request_drop_framing_fields(r);
+    }
+
+    /*
      * TODO: "Server", "Date", and "Content-Length" processing should be moved
      * to the last header filter.
      */
@@ -774,9 +817,144 @@ nxt_http_request_ws_frame_start(nxt_task_t *task, nxt_http_request_t *r,
 }
 
 
+static nxt_bool_t
+nxt_http_request_is_bodyless(nxt_http_request_t *r)
+{
+    /*
+     * A 101 upgrade is a 1xx status, but the bytes that follow its header are
+     * not a message body -- they are the upgraded protocol (WebSocket), and
+     * nxt_h1proto_websocket.c pushes them through nxt_http_request_send().
+     *
+     * The status matters as much as the flag.  websocket_handshake is set when
+     * the request headers are parsed (src/nxt_h1proto.c), long before the
+     * application chooses a status, and the h1 sender only treats the response
+     * as an upgrade when it is also 101 (src/nxt_h1proto.c).  Testing the flag
+     * alone would leave an application that answers a WebSocket-upgrade
+     * request with 204 plus a body on the unframed path.
+     */
+    if (r->websocket_handshake && r->status == NXT_HTTP_SWITCHING_PROTOCOLS) {
+        return 0;
+    }
+
+    if (r->status >= NXT_HTTP_CONTINUE && r->status < NXT_HTTP_OK) {
+        return 1;
+    }
+
+    if (r->status == NXT_HTTP_NO_CONTENT
+        || r->status == NXT_HTTP_NOT_MODIFIED)
+    {
+        return 1;
+    }
+
+    return r->method != NULL && nxt_str_eq(r->method, "HEAD", 4);
+}
+
+
+/*
+ * Mark every Content-Length and Transfer-Encoding response field skipped.
+ * Only for 1xx and 204, where RFC 9110 Sect. 8.6 and RFC 9112 Sect. 6.1 forbid
+ * both: a 304 keeps Content-Length, and so does a response to HEAD.
+ */
+
+static void
+nxt_http_request_drop_framing_fields(nxt_http_request_t *r)
+{
+    nxt_http_field_t  *field;
+
+    nxt_http_fields_each(field, r->resp.inline_fields, r->resp.num_inline_fields,
+                         r->resp.fields)
+    {
+        if (field->skip) {
+            continue;
+        }
+
+        if ((field->name_length == nxt_length("Content-Length")
+             && nxt_strncasecmp(field->name, (u_char *) "Content-Length",
+                                nxt_length("Content-Length")) == 0)
+            || (field->name_length == nxt_length("Transfer-Encoding")
+                && nxt_strncasecmp(field->name, (u_char *) "Transfer-Encoding",
+                                   nxt_length("Transfer-Encoding")) == 0))
+        {
+            field->skip = 1;
+        }
+
+    } nxt_http_fields_loop;
+}
+
+
+/*
+ * Strip the payload from a response that must not carry one, keeping the
+ * sync/last markers that drive request completion.  Data-only buffers are
+ * unlinked and drained so their completion handlers run and the shared memory
+ * they hold is released; a buffer that also carries the "last" marker stays in
+ * the chain but is emptied in place, so the request still finishes normally.
+ */
+
+static nxt_buf_t *
+nxt_http_request_body_drop(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_buf_t *out)
+{
+    size_t            dropped;
+    nxt_buf_t         *b, *next, **prev;
+    nxt_work_queue_t  *wq;
+
+    dropped = 0;
+    prev = &out;
+    wq = &task->thread->engine->fast_work_queue;
+
+    for (b = out; b != NULL; b = next) {
+        next = b->next;
+
+        if (nxt_buf_is_sync(b)) {
+            /*
+             * A sync buffer may be allocated with NXT_BUF_SYNC_SIZE, so it
+             * carries no payload and its mem.free/file fields must not even
+             * be read.  Keep it as is.
+             */
+            prev = &b->next;
+            continue;
+        }
+
+        dropped += nxt_buf_used_size(b);
+
+        if (nxt_buf_is_last(b)) {
+            /* Empty it in place; the "last" marker still ends the request. */
+            b->mem.pos = b->mem.free;
+
+            if (nxt_buf_is_file(b)) {
+                b->file_pos = b->file_end;
+            }
+
+            prev = &b->next;
+            continue;
+        }
+
+        *prev = next;
+        b->next = NULL;
+
+        nxt_sendbuf_drain(task, wq, b);
+    }
+
+    if (dropped != 0) {
+        nxt_debug(task, "http request body dropped on status %d: %uz bytes",
+                  (int) r->status, dropped);
+    }
+
+    return out;
+}
+
+
 void
 nxt_http_request_send(nxt_task_t *task, nxt_http_request_t *r, nxt_buf_t *out)
 {
+    if (r->no_body) {
+        out = nxt_http_request_body_drop(task, r, out);
+
+        if (out == NULL) {
+            return;
+        }
+    }
+
     if (nxt_fast_path(r->proto.any != NULL)) {
         nxt_http_proto[r->protocol].send(task, r, out);
     }

--- a/test/php/no_body_status/index.php
+++ b/test/php/no_body_status/index.php
@@ -1,0 +1,15 @@
+<?php
+
+$status = isset($_GET['status']) ? (int) $_GET['status'] : 204;
+
+http_response_code($status);
+
+if (isset($_GET['cl'])) {
+    header('Content-Length: 10');
+}
+
+if (isset($_GET['te'])) {
+    header('Transfer-Encoding: chunked');
+}
+
+echo 'SMUGGLEDXX';

--- a/test/test_http_no_body_status.py
+++ b/test/test_http_no_body_status.py
@@ -1,0 +1,289 @@
+"""Responses that RFC 9112 Sect. 6.3 defines as having no message body.
+
+An application that writes a body on 204/304 -- or on any response to HEAD --
+used to have those bytes forwarded verbatim, with no Content-Length and no
+chunked framing, so a downstream parser read them as the start of the next
+response.  See freeunitorg/freeunit#164.
+"""
+
+import base64
+import os
+
+import pytest
+
+from unit.applications.lang.php import ApplicationPHP
+from unit.option import option
+
+prerequisites = {'modules': {'php': 'all'}}
+
+client = ApplicationPHP()
+
+# The application writes exactly these 10 bytes on every response.
+SMUGGLED = 'SMUGGLEDXX'
+
+KEEPALIVE = {'Host': 'localhost', 'Connection': 'keep-alive'}
+CLOSE = {'Host': 'localhost', 'Connection': 'close'}
+
+
+@pytest.fixture(autouse=True)
+def setup_method_fixture():
+    client.load('no_body_status')
+
+
+def split_response(raw):
+    """Split a raw response into (header block, everything after it)."""
+
+    assert '\r\n\r\n' in raw, f'response has no header terminator: {raw!r}'
+
+    head, _, rest = raw.partition('\r\n\r\n')
+
+    return head, rest
+
+
+def request_raw(url, method='GET', sock=None, headers=None):
+    kwargs = {
+        'url': url,
+        'headers': KEEPALIVE if headers is None else headers,
+        'raw_resp': True,
+        'read_timeout': 1,
+        'start': True,
+    }
+
+    if sock is not None:
+        kwargs['sock'] = sock
+
+    return client.http(method, **kwargs)
+
+
+@pytest.mark.parametrize('status', [204, 304])
+@pytest.mark.parametrize('content_length', [False, True])
+def test_no_body_status_drops_app_body(status, content_length):
+    url = f'/?status={status}'
+    if content_length:
+        url += '&cl=1'
+
+    raw, sock = request_raw(url)
+
+    try:
+        head, rest = split_response(raw)
+
+        assert f' {status} ' in head.split('\r\n')[0], 'status line'
+        assert (
+            SMUGGLED not in raw
+        ), f'body forwarded on {status}: {raw!r}'
+        assert rest == '', f'trailing bytes after header: {rest!r}'
+        assert (
+            'Transfer-Encoding' not in head
+        ), 'no chunked framing on a bodyless status'
+
+        if status == 204:
+            # RFC 9110 Sect. 8.6: no Content-Length on 204.
+            assert 'Content-Length' not in head, 'no Content-Length on 204'
+
+        # The connection must still be usable: the next request has to parse
+        # as a complete response of its own, not as a continuation.
+        resp = client.get(sock=sock, url='/?status=200', headers=CLOSE)
+
+        assert resp['status'] == 200, 'keep-alive: second request status'
+        assert resp['body'] == SMUGGLED, 'keep-alive: second request body'
+
+    finally:
+        sock.close()
+
+
+def test_no_body_status_head_drops_app_body():
+    raw, sock = request_raw('/?status=200&cl=1', method='HEAD')
+
+    try:
+        head, rest = split_response(raw)
+
+        assert ' 200 ' in head.split('\r\n')[0], 'status line'
+        assert SMUGGLED not in raw, f'body forwarded on HEAD: {raw!r}'
+        assert rest == '', f'trailing bytes after header: {rest!r}'
+        # A HEAD response keeps the length the equivalent GET would report.
+        assert 'Content-Length: 10' in head, 'HEAD keeps Content-Length'
+
+        resp = client.get(sock=sock, url='/?status=200', headers=CLOSE)
+
+        assert resp['status'] == 200, 'keep-alive after HEAD: status'
+        assert resp['body'] == SMUGGLED, 'keep-alive after HEAD: body'
+
+    finally:
+        sock.close()
+
+
+def test_no_body_status_get_still_has_body():
+    """Control: an ordinary status keeps the application's body."""
+
+    resp = client.get(url='/?status=200')
+
+    assert resp['status'] == 200, 'status'
+    assert resp['body'] == SMUGGLED, 'body'
+
+
+def test_no_body_status_proxy():
+    """The proxy path must not re-introduce the body either."""
+
+    php_dir = f'{option.test_dir}/php'
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {
+                "*:8080": {"pass": "routes"},
+                "*:8081": {"pass": "applications/no_body_status"},
+            },
+            "routes": [{"action": {"proxy": "http://127.0.0.1:8081"}}],
+            "applications": {
+                "no_body_status": {
+                    "type": client.get_application_type(),
+                    "processes": {"spare": 0},
+                    "root": f'{php_dir}/no_body_status',
+                    "working_directory": f'{php_dir}/no_body_status',
+                    "index": "index.php",
+                }
+            },
+        }
+    ), 'proxy configuration'
+
+    raw, sock = request_raw('/?status=204')
+
+    try:
+        _, rest = split_response(raw)
+
+        assert SMUGGLED not in raw, f'proxy forwarded a 204 body: {raw!r}'
+        assert rest == '', f'proxy trailing bytes: {rest!r}'
+
+        resp = client.get(sock=sock, url='/?status=200', headers=CLOSE)
+
+        assert resp['status'] == 200, 'proxy keep-alive: status'
+        assert resp['body'] == SMUGGLED, 'proxy keep-alive: body'
+
+    finally:
+        sock.close()
+
+
+def test_no_body_status_websocket_upgrade_request():
+    """A WebSocket-upgrade request answered with 204 is still bodyless.
+
+    r->websocket_handshake is set while the *request* headers are parsed, long
+    before the application picks a status, so the upgrade exemption has to test
+    the status too -- otherwise this request keeps the unframed path.
+    """
+
+    key = base64.b64encode(os.urandom(16)).decode()
+
+    raw, sock = request_raw(
+        '/?status=204',
+        headers={
+            'Host': 'localhost',
+            'Connection': 'Upgrade',
+            'Upgrade': 'websocket',
+            'Sec-WebSocket-Key': key,
+            'Sec-WebSocket-Version': 13,
+        },
+    )
+
+    try:
+        head, rest = split_response(raw)
+
+        assert ' 204 ' in head.split('\r\n')[0], 'status line'
+        assert SMUGGLED not in raw, f'body forwarded on upgrade+204: {raw!r}'
+        assert rest == '', f'trailing bytes after header: {rest!r}'
+
+        resp = client.get(sock=sock, url='/?status=200', headers=CLOSE)
+
+        assert resp['status'] == 200, 'keep-alive after upgrade+204: status'
+        assert resp['body'] == SMUGGLED, 'keep-alive after upgrade+204: body'
+
+    finally:
+        sock.close()
+
+
+def test_no_body_status_app_transfer_encoding():
+    """An application-sent Transfer-Encoding is a generic field; drop it."""
+
+    raw, sock = request_raw('/?status=204&te=1')
+
+    try:
+        head, rest = split_response(raw)
+
+        assert ' 204 ' in head.split('\r\n')[0], 'status line'
+        assert (
+            'Transfer-Encoding' not in head
+        ), f'Transfer-Encoding kept on 204: {head!r}'
+        assert SMUGGLED not in raw, f'body forwarded on 204: {raw!r}'
+        assert rest == '', f'trailing bytes after header: {rest!r}'
+
+        resp = client.get(sock=sock, url='/?status=200', headers=CLOSE)
+
+        assert resp['status'] == 200, 'keep-alive: status'
+        assert resp['body'] == SMUGGLED, 'keep-alive: body'
+
+    finally:
+        sock.close()
+
+
+def test_no_body_status_response_headers_content_length():
+    """Framing headers added by "response_headers" must go too.
+
+    They are added as generic fields, without setting r->resp.content_length,
+    so skipping that one pointer is not enough.  Note the lowercase name: the
+    config validator rejects "Content-Length" here, but with a case-sensitive
+    memcmp (nxt_conf_vldt_response_header()), so "content-length" is accepted
+    and reaches the response.  Transfer-Encoding is not guarded at all.
+    """
+
+    php_dir = f'{option.test_dir}/php'
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {
+                    # Scoped to the 204 so the follow-up 200 on the same
+                    # connection is framed by the application alone.
+                    "match": {"arguments": {"status": "204"}},
+                    "action": {
+                        "pass": "applications/no_body_status",
+                        "response_headers": {
+                            "content-length": "10",
+                            "Transfer-Encoding": "chunked",
+                        },
+                    },
+                },
+                {"action": {"pass": "applications/no_body_status"}},
+            ],
+            "applications": {
+                "no_body_status": {
+                    "type": client.get_application_type(),
+                    "processes": {"spare": 0},
+                    "root": f'{php_dir}/no_body_status',
+                    "working_directory": f'{php_dir}/no_body_status',
+                    "index": "index.php",
+                }
+            },
+        }
+    ), 'response_headers configuration'
+
+    raw, sock = request_raw('/?status=204')
+
+    try:
+        head, rest = split_response(raw)
+
+        assert ' 204 ' in head.split('\r\n')[0], 'status line'
+        assert (
+            'content-length' not in head.lower()
+        ), f'response_headers Content-Length kept on 204: {head!r}'
+        assert (
+            'transfer-encoding' not in head.lower()
+        ), f'response_headers Transfer-Encoding kept on 204: {head!r}'
+        assert SMUGGLED not in raw, f'body forwarded on 204: {raw!r}'
+        assert rest == '', f'trailing bytes after header: {rest!r}'
+
+        resp = client.get(sock=sock, url='/?status=200', headers=CLOSE)
+
+        assert resp['status'] == 200, 'keep-alive: status'
+        assert resp['body'] == SMUGGLED, 'keep-alive: body'
+
+    finally:
+        sock.close()


### PR DESCRIPTION
Fixes #164

## Problem

An application that returns **204 No Content** or **304 Not Modified** and also
writes a body has those bytes forwarded verbatim — no `Content-Length`, no
chunked framing. On a keep-alive connection a downstream parser reads them as
the start of the next response, which an application can shape deliberately.

`src/nxt_h1proto.c:1459` declined chunked framing for `NXT_HTTP_NOT_MODIFIED` and
`NXT_HTTP_NO_CONTENT`, and those two lines were the only references to either
status anywhere in `src/*.c`. Nothing dropped the body itself, so
`nxt_http_request_send()` handed the application's buffers straight to the
connection. The same held for every response to HEAD, which had no special
handling outside `src/nxt_http_static.c:313`.

## Fix

RFC 9112 §6.3 makes this a property of the response, not of any one source, so
the decision is made once in the layer every source — application, proxy,
static, `return` — passes through:

- `nxt_http_request_header_send()` sets `r->no_body` via
  `nxt_http_request_is_bodyless()`: 1xx, 204, 304, or any response to HEAD.
  A 101 WebSocket upgrade is excluded — the bytes after its header are the
  upgraded protocol, not a message body. The exemption tests the *status*
  alongside `websocket_handshake`, not the flag alone: that flag is set while
  the request headers are parsed, long before the application picks a status,
  and the h1 sender only treats the response as an upgrade when it is also 101.
  Testing the flag by itself would leave an application answering a
  WebSocket-upgrade request with 204 plus a body on the unframed path.
- For 1xx and 204 it also drops the framing headers (RFC 9110 §8.6, RFC 9112
  §6.1): `content_length_n` is reset, and `nxt_http_request_drop_framing_fields()`
  marks every `Content-Length` and `Transfer-Encoding` response field skipped,
  matching names case-insensitively. `r->resp.content_length` alone is not
  enough — `response_headers` adds fields via `nxt_http_resp_field_zero_add()`
  without setting that pointer, and an application-supplied `Transfer-Encoding`
  is a generic field too; both would otherwise be serialized verbatim and
  desync the next response. A 304 keeps `Content-Length` (there it describes
  the body the client already has), and so does a HEAD response.
- `nxt_http_request_send()` routes a bodyless response through
  `nxt_http_request_body_drop()`, which unlinks the data-carrying buffers and
  `nxt_sendbuf_drain()`s them, so their completion handlers run and the shared
  memory they hold is released. Sync buffers are left untouched — one may be
  allocated with `NXT_BUF_SYNC_SIZE`, so its `mem.free` must not even be read —
  and a buffer that also carries the "last" marker stays in the chain but is
  emptied in place, so the request still completes normally.
- `src/nxt_h1proto.c` additionally tests `r->no_body`, so HEAD and 1xx stop
  getting chunked framing. Without that, a discarded HEAD body would still have
  emitted a terminating `0\r\n\r\n` chunk. Its pre-HTTP/1.1 branch also no
  longer disables keep-alive for a bodyless response: a close is only needed to
  delimit a body, and there is none.

Keep-alive stays correct: the header is framed properly and nothing follows it,
so the next request on the connection parses cleanly. An application doing this
is common and harmless once dropped, so it is logged at debug level only —
nothing at error level.

## Tests

New `test/test_http_no_body_status.py` (+ `test/php/no_body_status`), 10 cases.
The application returns 204/304 with and without `Content-Length` while writing
10 bytes of body, and each case asserts no body on the wire, no
`Transfer-Encoding`, no `Content-Length` on 204, and that a second request on
the same keep-alive connection parses as a complete response of its own. Also
covered: a WebSocket-upgrade request (valid `Upgrade`/`Sec-WebSocket-Key`)
answered with 204 + body; an application sending `Transfer-Encoding: chunked`
on a 204; and `response_headers` injecting framing headers on a 204. A HEAD case
and a plain-200 case are the controls, and a proxy case covers the proxy path.

One incidental finding from writing that last test: `nxt_conf_vldt_response_header()`
rejects a `Content-Length` response header, but with a case-sensitive
`nxt_strstr_eq`, so `content-length` is accepted and reaches the response
(`Transfer-Encoding` is not guarded at all). The test uses the lowercase spelling.
The sweep added here matches case-insensitively and so covers it for 1xx/204,
but tightening that validator is a separate change.

Built and run on Debian trixie / amd64, `--debug --tests` with the PHP and Python
modules, `./build/tests` plus pytest:

| suite | `origin/master` | this branch |
|---|---|---|
| `test_http_no_body_status.py` (new, 10 cases) | **8 failed**, 2 passed | **10 passed** |
| `test_php_application.py`, `test_proxy.py`, `test_static.py`, `test_http_header.py`, `test_conn_recycle.py` | 121 passed, 5 skipped | 121 passed, 5 skipped |
| `./build/tests` | pass | pass |

The master failures are exactly the reported behaviour, e.g.

```
AssertionError: body forwarded on 204: 'HTTP/1.1 204 No Content\r\n...\r\n\r\nSMUGGLEDXX'
```

Note that the HEAD case passes on master too: PHP's SAPI suppresses its own
output for HEAD, so it is a control rather than a regression test. The C-level
HEAD path is hardened regardless.

## Drafted CHANGES entry

```
    *) Bugfix: a response body written by an application on a status that
       defines none -- 1xx, 204, 304, or any response to a HEAD request --
       was forwarded to the client unframed, which a downstream parser read
       as the start of the next response on a keep-alive connection.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
