### PR TITLE
router: build object-format access log records per member

### DIFF
--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -158,10 +158,8 @@ static nxt_router_access_log_format_t *
 nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     nxt_conf_value_t *value)
 {
-    size_t                          size;
     uint32_t                        i, n, next;
     nxt_str_t                       name, str, *dst;
-    nxt_bool_t                      has_js;
     nxt_conf_value_t                *cv;
     nxt_router_access_log_member_t  *member;
     nxt_router_access_log_format_t  *format;
@@ -179,68 +177,40 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     if (value != NULL) {
 
         if (nxt_conf_type(value) == NXT_CONF_OBJECT) {
-            next = 0;
-            has_js = 0;
-
             n = nxt_conf_object_members_count(value);
 
-            for ( ;; ) {
+            member = nxt_mp_alloc(rtcf->mem_pool,
+                                  n * sizeof(nxt_router_access_log_member_t));
+            if (nxt_slow_path(member == NULL)) {
+                return NULL;
+            }
+
+            next = 0;
+
+            for (i = 0; i < n; i++) {
                 cv = nxt_conf_next_object_member(value, &name, &next);
                 if (cv == NULL) {
                     break;
                 }
 
-                nxt_conf_get_string(cv, &str);
-
-                if (nxt_tstr_is_js(&str)) {
-                    has_js = 1;
-                }
-            }
-
-            if (has_js) {
-                member = nxt_mp_alloc(rtcf->mem_pool,
-                                    n * sizeof(nxt_router_access_log_member_t));
-                if (nxt_slow_path(member == NULL)) {
+                dst = nxt_str_dup(rtcf->mem_pool, &member[i].name, &name);
+                if (nxt_slow_path(dst == NULL)) {
                     return NULL;
                 }
 
-                next = 0;
+                nxt_conf_get_string(cv, &str);
 
-                for (i = 0; i < n; i++) {
-                    cv = nxt_conf_next_object_member(value, &name, &next);
-                    if (cv == NULL) {
-                        break;
-                    }
-
-                    dst = nxt_str_dup(rtcf->mem_pool, &member[i].name, &name);
-                    if (nxt_slow_path(dst == NULL)) {
-                        return NULL;
-                    }
-
-                    nxt_conf_get_string(cv, &str);
-
-                    member[i].tstr = nxt_tstr_compile(rtcf->tstr_state, &str,
-                                                      NXT_TSTR_LOGGING);
-                    if (nxt_slow_path(member[i].tstr == NULL)) {
-                        return NULL;
-                    }
+                member[i].tstr = nxt_tstr_compile(rtcf->tstr_state, &str,
+                                                  NXT_TSTR_LOGGING);
+                if (nxt_slow_path(member[i].tstr == NULL)) {
+                    return NULL;
                 }
-
-                format->nmembers = n;
-                format->member = member;
-
-                return format;
             }
 
-            size = nxt_conf_json_length(value, NULL);
+            format->nmembers = n;
+            format->member = member;
 
-            str.start = nxt_mp_nget(rtcf->mem_pool, size);
-            if (nxt_slow_path(str.start == NULL)) {
-                return NULL;
-            }
-
-            str.length = nxt_conf_json_print(str.start, value, NULL)
-                         - str.start;
+            return format;
 
         } else {
             nxt_conf_get_string(value, &str);

--- a/test/test_access_log.py
+++ b/test/test_access_log.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 import pytest
@@ -305,6 +306,73 @@ def test_access_log_format(wait_for_record):
         'uri': '$uri'
     }
     check_format(log_format, '{"status":"200","uri":"/"}')
+
+
+def _read_log_lines():
+    with open(
+        f'{option.temp_dir}/access.log', 'r', encoding='utf-8', errors='strict'
+    ) as f:
+        return [ln for ln in f.read().splitlines() if ln]
+
+
+def test_access_log_object_escape(wait_for_record):
+    load('empty')
+
+    # Every character below is significant inside a JSON string: the first
+    # chunk closes the "ua" member and opens a forged one, then come a bare
+    # quote, a backslash, a control character (HTAB is legal in a field
+    # value) and a multi-byte UTF-8 sequence.
+    evil = '", "injected": "1 " \\ \t \u00e9'
+
+    set_format({'status': '$status', 'ua': '$header_user_agent'})
+
+    assert (
+        client.get(
+            headers={
+                'Host': 'localhost',
+                'User-Agent': evil,
+                'Connection': 'close',
+            }
+        )['status']
+        == 200
+    )
+    assert wait_for_record(r'"status":"200"', 'access.log') is not None
+
+    line = _read_log_lines()[-1]
+
+    record = json.loads(line)
+
+    assert list(record.keys()) == ['status', 'ua'], 'no injected members'
+    assert record['status'] == '200'
+    assert record['ua'] == evil, 'value round-trips'
+
+
+def test_access_log_object_escape_njs(require, wait_for_record):
+    require({'modules': {'njs': 'any'}})
+
+    load('empty')
+
+    evil = '", "injected": "1 " \\ \t \u00e9'
+
+    set_format({'uri': '`${vars.uri}`', 'ua': '$header_user_agent'})
+
+    assert (
+        client.get(
+            headers={
+                'Host': 'localhost',
+                'User-Agent': evil,
+                'Connection': 'close',
+            }
+        )['status']
+        == 200
+    )
+    assert wait_for_record(r'"uri":"/"', 'access.log') is not None
+
+    record = json.loads(_read_log_lines()[-1])
+
+    assert list(record.keys()) == ['uri', 'ua'], 'no injected members'
+    assert record['uri'] == '/'
+    assert record['ua'] == evil, 'value round-trips'
 
 
 def test_access_log_variables(wait_for_record):


### PR DESCRIPTION
Behavioural fix for object-format access logs: records are now built per member for every
object `format`, not only when a member contains a JavaScript expression. Details in a
forthcoming advisory; the full write-up is held for it.

## The fix

`nxt_router_access_log_format_create()` had two paths for an object `format`. The per-member
path (one `nxt_conf_value_t` per request, printed with `nxt_conf_json_print()`) was taken only
when some member value contained JS. This change removes the other path, so every object-format
record is produced the same way.

### Cost

One small `nxt_conf_value_t` and one string per member from `r->mem_pool` per logged request,
freed with the request. Identical to what every njs object format has always paid.

### Not affected

The string form of `format` and the default format are templates by design and are unchanged.
Member order and the `-` for an unset variable are preserved. A valid configuration produces the
same members as before; the validator already requires every member value to be a string.

## Tests

`test/test_access_log.py` gains two tests: a plain object format and the same with one njs
member (skipped when njs is absent). Both assert the record parses as JSON, contains exactly the
configured members, and that a header value containing quotes, a backslash, a control character
and a multi-byte UTF-8 sequence round-trips byte for byte.

| | `test_access_log.py` | `./build/tests` |
|---|---|---|
| `origin/master` (3e3ce864) + new tests | 21 passed, 1 skipped, **1 failed** | OK |
| this branch | **22 passed, 1 skipped** | OK |

Built in Docker (`php:8.4-cli-trixie`, njs 1.0.0 built `--no-openssl`), `./configure --debug
--tests --njs` + `./configure python`, pytest as root.

## CHANGES (for the release splice, not this PR)

```
    *) Security: access log records could be forged by a request header when
       "format" was an object: variable values were substituted into a
       pre-serialised JSON template without escaping. Records are now built
       per member and every value is escaped.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
