### PR TITLE
http: handle file truncation in static serving

### DIFF
--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -1107,6 +1107,11 @@ complete_buf:
         b->next = nxt_http_buf_last(r);
 
     } else {
+        if (nxt_slow_path(n == 0)) {
+            /* file truncated since it was stat(2)'d */
+            nxt_http_request_error_handler(task, r, r->proto.any);
+            goto clean;
+        }
         fb->file_pos += n;
         b->next = NULL;
     }


### PR DESCRIPTION
```
http: handle file truncation in static serving

My removal of the short read check in nxt_http_static_buf_completion()
was a little overzealous; we still need to handle the file truncation
case.

Reading fewer bytes than requested can be perfectly legitimate (for
example a short read from a network filesystem), so in that case we
correctly carry on until we have read the expected amount of data.

However, if the file has been truncated since it was stat(2)'d, then as
we reach the now earlier end of file a pread(2) returns 0 while more
data is still expected. With the check removed file_pos would never
advance, and Unit could get stuck in a loop expecting to read the
missing data. We now catch this (n == 0) and error out.

Fixes: 02d1984c9 ("HTTP: Remove short read check in nxt_http_static_buf_completion()")
Signed-off-by: Andrew Clayton <ac@sigsegv.uk>
```