### PR TITLE
port: defer the last reference drop with an embedded work item

### DIFF
--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -1153,27 +1153,117 @@ nxt_port_post(nxt_task_t *task, nxt_port_t *port,
 
 
 static void
-nxt_port_release_handler(nxt_task_t *task, nxt_port_t *port, void *data)
+nxt_port_release_work_handler(nxt_task_t *task, void *obj, void *data)
 {
-    /* no op */
+    /*
+     * Drop the reference nxt_port_use() handed to this item, rather than
+     * releasing outright: this runs on port->engine, so the drop takes the
+     * on-engine branch of nxt_port_use() and releases only if nobody else
+     * took a reference while the item was in flight.  That re-check is the
+     * whole point of holding a reference across the post -- see
+     * nxt_port_use().
+     */
+
+    nxt_port_use(task, obj, -1);
 }
 
 
 void
 nxt_port_use(nxt_task_t *task, nxt_port_t *port, int i)
 {
-    int  c;
+    nxt_atomic_int_t  c;
 
-    c = nxt_atomic_fetch_add(&port->use_count, i);
+    if (i >= 0
+        || port->engine == NULL
+        || task->thread->engine == port->engine)
+    {
+        c = nxt_atomic_fetch_add(&port->use_count, i);
 
-    if (i < 0 && c == -i) {
-
-        if (port->engine == NULL || task->thread->engine == port->engine) {
+        if (i < 0 && c == -i) {
             nxt_port_release(task, port);
-
-            return;
         }
 
-        nxt_port_post(task, port, nxt_port_release_handler, NULL);
+        return;
     }
+
+    /*
+     * A drop on another thread cannot release the port here -- the release
+     * frees port->mem_pool, and may drop the port's process reference,
+     * neither of which this thread owns -- so the last one is carried to
+     * port->engine by a work item.
+     *
+     * The item is embedded in the port and posted straight to the engine
+     * rather than routed through nxt_port_post(), which allocates one with
+     * nxt_zalloc() and can return NXT_ERROR.  This call site has nowhere to
+     * put that error: the reference it is dropping is the last, so refusing
+     * to defer would leak the port, its memory pool and the process
+     * reference it holds -- unbounded, under exactly the memory pressure
+     * that caused the failure -- while releasing here would free another
+     * engine's memory from this thread, which is what the deferral exists
+     * to prevent.  A deferral that cannot allocate cannot fail.  This
+     * mirrors nxt_runtime_process_release().
+     *
+     * The reference is handed to the item instead of being given up: the
+     * count is left standing at 1 and the posted handler drops it on
+     * port->engine.  The port stays reachable through process->ports until
+     * then, so another engine can still take a reference in that window --
+     * nxt_process_broadcast_shm_ack() walks a process's ports through bare
+     * pointers and nxt_port_socket_write() takes a reference on each -- and
+     * only a drop re-checked at the far end can tell that apart from a port
+     * nobody wants.  Releasing from the handler unconditionally would free
+     * a port somebody holds.  Routing through nxt_port_post() used to
+     * provide exactly this: it took a reference of its own and ended in
+     * nxt_port_use(port, -1).
+     *
+     * The hand-over is why the loop below is a compare-and-set that stores
+     * the item's one reference in place of the last drop, rather than a
+     * fetch-and-add to zero followed by a compensating increment.  use_count
+     * reaches zero only on port->engine, immediately before
+     * nxt_port_release(), so while the item is in flight no other thread can
+     * observe a last drop: a reference taken in that window takes the count
+     * to 2, and the holder's drop finds the item's own reference still
+     * standing, so it is not the last and cannot reach this branch.  At most
+     * one post is therefore ever in flight, and the item cannot be posted
+     * twice.  That matters because nxt_locked_work_queue_add() links the
+     * item onto the queue tail: an item posted while it is already queued
+     * becomes its own successor, and the engine draining the queue then
+     * spins forever.
+     *
+     * The item becomes free again only once the handler's drop can run, and
+     * that is after nxt_locked_work_queue_move() has taken it off the
+     * locked queue and copied it into the engine's own work queue -- which
+     * is also why the release may free the pool the item lives in.
+     */
+
+    for ( ;; ) {
+        c = port->use_count;
+
+        if (c != -i) {
+            nxt_assert(c > -i);
+
+            if (nxt_atomic_cmp_set(&port->use_count, c, c + i)) {
+                return;
+            }
+
+            continue;
+        }
+
+        /*
+         * Exactly one reference is left standing, whatever the size of the
+         * batch this drop carries, because the item's handler drops exactly
+         * one.
+         */
+
+        if (nxt_atomic_cmp_set(&port->use_count, c, 1)) {
+            break;
+        }
+    }
+
+    port->release_work.handler = nxt_port_release_work_handler;
+    port->release_work.task = &port->engine->task;
+    port->release_work.obj = port;
+    port->release_work.data = NULL;
+    port->release_work.next = NULL;
+
+    nxt_event_engine_post(port->engine, &port->release_work);
 }

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -300,6 +300,15 @@ struct nxt_port_s {
     nxt_mp_t            *mem_pool;
     nxt_event_engine_t  *engine;
 
+    /*
+     * The deferral that carries the last reference drop to port->engine.
+     * Embedded rather than allocated, so that nxt_port_use() has no failure
+     * path -- see the comment there.  Single-instance: use_count reaches
+     * zero only on port->engine, so only one thread at a time can hand the
+     * last reference over, and at most one post is ever in flight.
+     */
+    nxt_work_t          release_work;
+
     nxt_buf_t           *free_bufs;
     nxt_socket_t        pair[2];
 

--- a/src/test/nxt_port_fail_test.c
+++ b/src/test/nxt_port_fail_test.c
@@ -18,6 +18,17 @@ static nxt_int_t nxt_port_fail_test_socket_write(nxt_thread_t *thr);
 static nxt_int_t nxt_port_fail_test_rpc_register(nxt_thread_t *thr);
 static nxt_int_t nxt_port_fail_test_error_handler(nxt_thread_t *thr);
 static nxt_int_t nxt_port_fail_test_mp_baseline(nxt_thread_t *thr);
+static nxt_int_t nxt_port_fail_test_cross_engine_release(nxt_thread_t *thr);
+static nxt_int_t nxt_port_fail_test_cross_engine_acquire(nxt_thread_t *thr);
+static nxt_int_t nxt_port_fail_test_cross_engine_race(nxt_thread_t *thr);
+static nxt_int_t nxt_port_fail_test_cross_engine_batch(nxt_thread_t *thr);
+static void nxt_port_fail_test_racer(void *data);
+static nxt_int_t nxt_port_fail_test_queued(nxt_locked_work_queue_t *lwq,
+    nxt_work_t *item);
+static void nxt_port_fail_test_engine_signal(nxt_event_engine_t *engine,
+    nxt_uint_t signo);
+static void nxt_port_fail_test_released(nxt_task_t *task, void *obj,
+    void *data);
 static nxt_int_t nxt_port_fail_test_sender_pattern(nxt_task_t *task,
     nxt_port_t *port, nxt_mp_t *mp);
 static void nxt_port_fail_test_mp_completion(nxt_task_t *task, void *obj,
@@ -30,6 +41,8 @@ static nxt_int_t nxt_port_fail_test_fd_count(void);
 
 
 static nxt_uint_t  nxt_port_fail_test_completions;
+static nxt_uint_t  nxt_port_fail_test_releases;
+static nxt_uint_t  nxt_port_fail_test_signals;
 
 
 nxt_int_t
@@ -51,6 +64,22 @@ nxt_port_fail_test(nxt_thread_t *thr)
     }
 
     if (nxt_port_fail_test_mp_baseline(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_fail_test_cross_engine_release(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_fail_test_cross_engine_acquire(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_fail_test_cross_engine_race(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_fail_test_cross_engine_batch(thr) != NXT_OK) {
         return NXT_ERROR;
     }
 
@@ -577,6 +606,643 @@ nxt_port_fail_test_sender_pattern(nxt_task_t *task, nxt_port_t *port,
     nxt_mp_retain(mp);
 
     return NXT_OK;
+}
+
+
+/*
+ * A last reference dropped from a thread other than port->engine's must be
+ * deferred to that engine, and the deferral must not be able to fail.
+ *
+ * nxt_port_use() used to route the drop through nxt_port_post(), which
+ * nxt_zalloc()s an nxt_port_work_t and returns NXT_ERROR when that fails.
+ * The return value was ignored: use_count was already zero, nothing was
+ * queued, and the port, its memory pool and the process reference it holds
+ * leaked (issue #187).
+ *
+ * There is no allocation-failure injection hook reachable from here, so the
+ * regression is pinned structurally instead: the item that lands on the
+ * foreign engine's locked work queue must be the one embedded in the port.
+ * That is false for any implementation that allocates it, whether or not the
+ * allocation succeeds.  Draining then has to reach nxt_port_release(), which
+ * is observed through a cleanup on the port's own memory pool.
+ */
+
+static nxt_int_t
+nxt_port_fail_test_cross_engine_release(nxt_thread_t *thr)
+{
+    nxt_task_t          *task;
+    nxt_port_t          *port;
+    nxt_work_t          *posted;
+    nxt_event_engine_t  current, foreign;
+
+    task = thr->task;
+    task->thread = thr;
+
+    /*
+     * Two minimal engines: the one this thread runs on, and the port's.
+     * They only have to differ and to carry a work queue; the post path
+     * touches locked_work_queue, event.signal and task.
+     */
+    nxt_memzero(&current, sizeof(current));
+    nxt_work_queue_cache_create(&current.work_queue_cache, 1024);
+    current.fast_work_queue.cache = &current.work_queue_cache;
+    nxt_work_queue_name(&current.fast_work_queue, "fast");
+
+    nxt_memzero(&foreign, sizeof(foreign));
+    foreign.task.thread = thr;
+    foreign.task.log = thr->log;
+
+    /*
+     * Without this stub nxt_event_engine_signal() would fall through to
+     * writing on foreign.pipe, which a bare engine does not have.
+     */
+    foreign.event.signal = nxt_port_fail_test_engine_signal;
+
+    thr->engine = &current;
+
+    port = nxt_port_fail_test_port(task);
+    if (nxt_slow_path(port == NULL)) {
+        goto fail_engine;
+    }
+
+    port->engine = &foreign;
+
+    if (nxt_slow_path(nxt_mp_cleanup(port->mem_pool,
+                                     nxt_port_fail_test_released,
+                                     task, port, NULL) != NXT_OK))
+    {
+        nxt_port_use(task, port, -1);
+        goto fail_engine;
+    }
+
+    nxt_port_fail_test_releases = 0;
+    nxt_port_fail_test_signals = 0;
+
+    posted = &port->release_work;
+
+    nxt_port_use(task, port, -1);
+
+    /* The release must be deferred, not run on this thread. */
+    if (nxt_slow_path(nxt_port_fail_test_releases != 0)) {
+        nxt_log_alert(thr->log, "port fail test: cross-engine release ran "
+                      "on the calling thread");
+        goto fail_engine;
+    }
+
+    if (nxt_slow_path(nxt_port_fail_test_signals != 1)) {
+        nxt_log_alert(thr->log, "port fail test: cross-engine release did "
+                      "not signal the target engine (%ui)",
+                      nxt_port_fail_test_signals);
+        goto fail_engine;
+    }
+
+    /*
+     * The heart of the regression check: an allocated work item would make
+     * this a different pointer, and a failed allocation would leave the
+     * queue empty.
+     */
+    if (nxt_slow_path(foreign.locked_work_queue.head != posted)) {
+        nxt_log_alert(thr->log, "port fail test: the posted item is not the "
+                      "port's embedded release work");
+        goto fail_engine;
+    }
+
+    /*
+     * The reference is handed to the item, not given up: the count is back
+     * at 1 and the posted handler is what drops it.
+     */
+    if (nxt_slow_path(port->use_count != 1)) {
+        nxt_log_alert(thr->log, "port fail test: the deferred release does "
+                      "not hold a reference (use_count %A)", port->use_count);
+        goto fail_engine;
+    }
+
+    /* The handler runs on the port's engine, so this thread becomes it. */
+    thr->engine = &foreign;
+
+    nxt_locked_work_queue_move(thr, &foreign.locked_work_queue,
+                               &current.fast_work_queue);
+
+    nxt_port_fail_test_drain_wq(&current.fast_work_queue);
+
+    if (nxt_slow_path(nxt_port_fail_test_releases != 1)) {
+        nxt_log_alert(thr->log, "port fail test: draining the target engine "
+                      "did not release the port (%ui)",
+                      nxt_port_fail_test_releases);
+        goto fail_engine;
+    }
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_OK;
+
+fail_engine:
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_ERROR;
+}
+
+
+/*
+ * A cross-engine last drop leaves the port reachable through
+ * process->ports until the deferred item runs, so another engine can still
+ * take a reference in that window -- nxt_process_broadcast_shm_ack() does.
+ * The deferral therefore has to hand its reference over and re-check at the
+ * far end, which is what routing through nxt_port_post() used to provide:
+ * it took a reference of its own and ended in nxt_port_use(port, -1).
+ *
+ * A deferred handler that released unconditionally would free a port
+ * somebody holds -- a use-after-free, and only an assertion in a --debug
+ * build.  Here the acquisition is made between the post and the drain: the
+ * drain must not release, and the release must happen exactly once, when
+ * the other holder drops its reference.
+ */
+
+static nxt_int_t
+nxt_port_fail_test_cross_engine_acquire(nxt_thread_t *thr)
+{
+    nxt_task_t          *task;
+    nxt_port_t          *port;
+    nxt_event_engine_t  current, foreign;
+
+    task = thr->task;
+    task->thread = thr;
+
+    nxt_memzero(&current, sizeof(current));
+    nxt_work_queue_cache_create(&current.work_queue_cache, 1024);
+    current.fast_work_queue.cache = &current.work_queue_cache;
+    nxt_work_queue_name(&current.fast_work_queue, "fast");
+
+    nxt_memzero(&foreign, sizeof(foreign));
+    foreign.task.thread = thr;
+    foreign.task.log = thr->log;
+    foreign.event.signal = nxt_port_fail_test_engine_signal;
+
+    thr->engine = &current;
+
+    port = nxt_port_fail_test_port(task);
+    if (nxt_slow_path(port == NULL)) {
+        goto fail_engine;
+    }
+
+    port->engine = &foreign;
+
+    if (nxt_slow_path(nxt_mp_cleanup(port->mem_pool,
+                                     nxt_port_fail_test_released,
+                                     task, port, NULL) != NXT_OK))
+    {
+        nxt_port_use(task, port, -1);
+        goto fail_engine;
+    }
+
+    nxt_port_fail_test_releases = 0;
+
+    nxt_port_use(task, port, -1);
+
+    /*
+     * The concurrent acquisition, made while the item is queued.  A real one
+     * comes from another engine; what matters here is that it happens after
+     * the drop that posted the item and before that item runs.
+     */
+    nxt_port_use(task, port, 1);
+
+    thr->engine = &foreign;
+
+    nxt_locked_work_queue_move(thr, &foreign.locked_work_queue,
+                               &current.fast_work_queue);
+
+    nxt_port_fail_test_drain_wq(&current.fast_work_queue);
+
+    if (nxt_slow_path(nxt_port_fail_test_releases != 0)) {
+        nxt_log_alert(thr->log, "port fail test: the deferred release freed "
+                      "a port another reference was taken on");
+        goto fail_port;
+    }
+
+    if (nxt_slow_path(port->use_count != 1)) {
+        nxt_log_alert(thr->log, "port fail test: use_count is %A after the "
+                      "deferred release, expected 1", port->use_count);
+        goto fail_port;
+    }
+
+    /* Now the other holder lets go, on the port's own engine. */
+    nxt_port_use(task, port, -1);
+
+    if (nxt_slow_path(nxt_port_fail_test_releases != 1)) {
+        nxt_log_alert(thr->log, "port fail test: dropping the last reference "
+                      "released the port %ui times, expected 1",
+                      nxt_port_fail_test_releases);
+        goto fail_engine;
+    }
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_OK;
+
+fail_port:
+
+    nxt_port_use(task, port, -1);
+
+fail_engine:
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_ERROR;
+}
+
+
+/*
+ * The hand-over must not be able to post the embedded item twice.
+ *
+ * The item is a single object, so two threads that both believe they are
+ * dropping the last reference would post it twice, and
+ * nxt_locked_work_queue_add() links a work onto the queue tail: the second
+ * post makes tail->next point at the item itself, and the engine draining
+ * that queue then walks a one-element cycle forever.  Routing through
+ * nxt_port_post() could not produce this, because it allocated a separate
+ * item for every post.
+ *
+ * The shape that would produce it is a foreign drop that publishes a zero
+ * use_count: another engine promoting a bare port pointer --
+ * nxt_process_broadcast_shm_ack() walks a process's ports that way, and
+ * nxt_port_socket_write() takes a reference on each -- can then complete a
+ * 0 -> 1 -> 0 cycle of its own and reach the deferral as well.  So the
+ * invariant this pins is the one that makes it impossible: use_count is
+ * never observable as zero off port->engine.
+ *
+ * A racer thread on a third engine watches use_count across a cross-engine
+ * last drop and reports every zero it sees; then, with the item already in
+ * flight, it takes a reference and drops it again -- the 1 -> 2 -> 1 that
+ * must not post anything.  The locked queue is walked with a step limit, so
+ * a self-linked item fails the test instead of hanging it.
+ */
+
+#define NXT_PORT_FAIL_TEST_RACE_TRIALS  128
+#define NXT_PORT_FAIL_TEST_RACE_SPINS   4000000
+#define NXT_PORT_FAIL_TEST_QUEUE_LIMIT  16
+
+
+typedef struct {
+    nxt_port_t          *port;
+    nxt_event_engine_t  *engine;
+    nxt_atomic_t        ready;
+    nxt_atomic_t        stop;
+    nxt_uint_t          zeroes;
+} nxt_port_fail_test_race_t;
+
+
+static nxt_int_t
+nxt_port_fail_test_cross_engine_race(nxt_thread_t *thr)
+{
+    nxt_int_t                  queued;
+    nxt_task_t                 *task;
+    nxt_uint_t                 trial;
+    nxt_port_t                 *port;
+    nxt_thread_link_t          *link;
+    nxt_thread_handle_t        handle;
+    nxt_event_engine_t         current, foreign, other;
+    nxt_port_fail_test_race_t  race;
+
+    task = thr->task;
+    task->thread = thr;
+
+    nxt_memzero(&other, sizeof(other));
+
+    for (trial = 0; trial < NXT_PORT_FAIL_TEST_RACE_TRIALS; trial++) {
+
+        nxt_memzero(&current, sizeof(current));
+        nxt_work_queue_cache_create(&current.work_queue_cache, 1024);
+        current.fast_work_queue.cache = &current.work_queue_cache;
+        nxt_work_queue_name(&current.fast_work_queue, "fast");
+
+        nxt_memzero(&foreign, sizeof(foreign));
+        foreign.task.thread = thr;
+        foreign.task.log = thr->log;
+        foreign.event.signal = nxt_port_fail_test_engine_signal;
+
+        thr->engine = &current;
+
+        port = nxt_port_fail_test_port(task);
+        if (nxt_slow_path(port == NULL)) {
+            goto fail_engine;
+        }
+
+        port->engine = &foreign;
+
+        if (nxt_slow_path(nxt_mp_cleanup(port->mem_pool,
+                                         nxt_port_fail_test_released,
+                                         task, port, NULL) != NXT_OK))
+        {
+            nxt_port_use(task, port, -1);
+            goto fail_engine;
+        }
+
+        nxt_port_fail_test_releases = 0;
+        nxt_port_fail_test_signals = 0;
+
+        nxt_memzero(&race, sizeof(race));
+        race.port = port;
+        race.engine = &other;
+
+        link = nxt_zalloc(sizeof(nxt_thread_link_t));
+        if (nxt_slow_path(link == NULL)) {
+            goto fail_port;
+        }
+
+        link->start = nxt_port_fail_test_racer;
+        link->work.data = &race;
+
+        if (nxt_slow_path(nxt_thread_create(&handle, link) != NXT_OK)) {
+            goto fail_port;
+        }
+
+        /*
+         * The racer has to be spinning before the drop, or the window it
+         * watches for is gone before it looks.
+         */
+
+        while (race.ready == 0) {
+            nxt_cpu_pause();
+        }
+
+        nxt_port_use(task, port, -1);
+
+        race.stop = 1;
+
+        nxt_thread_wait(handle);
+
+        if (nxt_slow_path(race.zeroes != 0)) {
+            nxt_log_alert(thr->log, "port fail test: a foreign thread saw "
+                          "use_count 0 on a live port %ui times", race.zeroes);
+            goto fail_port;
+        }
+
+        queued = nxt_port_fail_test_queued(&foreign.locked_work_queue,
+                                           &port->release_work);
+
+        if (nxt_slow_path(queued < 0)) {
+            nxt_log_alert(thr->log, "port fail test: the embedded release "
+                          "work is linked into the target engine's queue "
+                          "more than once");
+            goto fail_engine;
+        }
+
+        if (nxt_slow_path(queued != 1)) {
+            nxt_log_alert(thr->log, "port fail test: the embedded release "
+                          "work is queued %i times, expected 1", queued);
+            goto fail_port;
+        }
+
+        if (nxt_slow_path(nxt_port_fail_test_signals != 1)) {
+            nxt_log_alert(thr->log, "port fail test: the target engine was "
+                          "signalled %ui times, expected 1",
+                          nxt_port_fail_test_signals);
+            goto fail_port;
+        }
+
+        if (nxt_slow_path(port->use_count != 1)) {
+            nxt_log_alert(thr->log, "port fail test: use_count is %A with "
+                          "the deferral in flight, expected 1",
+                          port->use_count);
+            goto fail_port;
+        }
+
+        thr->engine = &foreign;
+
+        nxt_locked_work_queue_move(thr, &foreign.locked_work_queue,
+                                   &current.fast_work_queue);
+
+        nxt_port_fail_test_drain_wq(&current.fast_work_queue);
+
+        if (nxt_slow_path(nxt_port_fail_test_releases != 1)) {
+            nxt_log_alert(thr->log, "port fail test: draining the target "
+                          "engine released the port %ui times, expected 1",
+                          nxt_port_fail_test_releases);
+            goto fail_engine;
+        }
+
+        nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    }
+
+    thr->engine = NULL;
+
+    return NXT_OK;
+
+fail_port:
+
+    nxt_port_use(task, port, -1);
+
+fail_engine:
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_ERROR;
+}
+
+
+static void
+nxt_port_fail_test_racer(void *data)
+{
+    nxt_task_t                 task;
+    nxt_uint_t                 i;
+    nxt_thread_t               *thr;
+    nxt_port_fail_test_race_t  *race;
+
+    race = data;
+
+    thr = nxt_thread();
+    thr->engine = race->engine;
+
+    nxt_memzero(&task, sizeof(task));
+    task.thread = thr;
+    task.log = thr->log;
+
+    race->ready = 1;
+
+    for (i = 0; i < NXT_PORT_FAIL_TEST_RACE_SPINS; i++) {
+
+        if (nxt_slow_path(race->port->use_count == 0)) {
+            race->zeroes++;
+            break;
+        }
+
+        if (race->stop != 0) {
+            break;
+        }
+
+        nxt_cpu_pause();
+    }
+
+    /*
+     * The acquisition another engine can still make while the deferral is
+     * in flight, and the drop that follows it: 1 -> 2 -> 1, which must not
+     * reach the deferral and must not post anything.
+     */
+
+    nxt_port_use(&task, race->port, 1);
+    nxt_port_use(&task, race->port, -1);
+}
+
+
+/*
+ * Count the occurrences of one work item in a locked work queue, refusing to
+ * walk further than the queue can legitimately be.  A work item posted twice
+ * becomes its own successor, so the walk would otherwise not terminate --
+ * which is exactly what the draining engine does.
+ */
+
+static nxt_int_t
+nxt_port_fail_test_queued(nxt_locked_work_queue_t *lwq, nxt_work_t *item)
+{
+    nxt_int_t   n, steps;
+    nxt_work_t  *w;
+
+    n = 0;
+
+    for (w = lwq->head, steps = 0; w != NULL; w = w->next, steps++) {
+
+        if (steps >= NXT_PORT_FAIL_TEST_QUEUE_LIMIT) {
+            return -1;
+        }
+
+        if (w == item) {
+            n++;
+        }
+    }
+
+    return n;
+}
+
+
+/*
+ * A drop can carry more than one reference at once: nxt_port_socket_write()
+ * and nxt_port_error_handler() batch theirs into use_delta
+ * (src/nxt_port_socket.c:601, src/nxt_port_socket.c:1500), so a cross-engine
+ * drop of -2 or more can be the last one.
+ *
+ * The deferral must then leave exactly one reference standing, whatever the
+ * size of the batch, because the posted handler drops exactly one.  A
+ * hand-over that left the whole batch behind would strand the port, its
+ * memory pool and the process reference it holds -- the very leak this
+ * change exists to remove, reintroduced through the other door.
+ */
+
+static nxt_int_t
+nxt_port_fail_test_cross_engine_batch(nxt_thread_t *thr)
+{
+    nxt_task_t          *task;
+    nxt_port_t          *port;
+    nxt_event_engine_t  current, foreign;
+
+    task = thr->task;
+    task->thread = thr;
+
+    nxt_memzero(&current, sizeof(current));
+    nxt_work_queue_cache_create(&current.work_queue_cache, 1024);
+    current.fast_work_queue.cache = &current.work_queue_cache;
+    nxt_work_queue_name(&current.fast_work_queue, "fast");
+
+    nxt_memzero(&foreign, sizeof(foreign));
+    foreign.task.thread = thr;
+    foreign.task.log = thr->log;
+    foreign.event.signal = nxt_port_fail_test_engine_signal;
+
+    thr->engine = &current;
+
+    port = nxt_port_fail_test_port(task);
+    if (nxt_slow_path(port == NULL)) {
+        goto fail_engine;
+    }
+
+    port->engine = &foreign;
+
+    if (nxt_slow_path(nxt_mp_cleanup(port->mem_pool,
+                                     nxt_port_fail_test_released,
+                                     task, port, NULL) != NXT_OK))
+    {
+        nxt_port_use(task, port, -1);
+        goto fail_engine;
+    }
+
+    nxt_port_fail_test_releases = 0;
+
+    /*
+     * Two references, given up by one drop, from a thread that is not the
+     * port's engine.
+     */
+
+    nxt_port_use(task, port, 1);
+
+    nxt_port_use(task, port, -2);
+
+    if (nxt_slow_path(nxt_port_fail_test_releases != 0)) {
+        nxt_log_alert(thr->log, "port fail test: a batched cross-engine "
+                      "release ran on the calling thread");
+        goto fail_engine;
+    }
+
+    if (nxt_slow_path(foreign.locked_work_queue.head != &port->release_work)) {
+        nxt_log_alert(thr->log, "port fail test: a batched cross-engine last "
+                      "drop did not post the port's embedded release work");
+        goto fail_engine;
+    }
+
+    if (nxt_slow_path(port->use_count != 1)) {
+        nxt_log_alert(thr->log, "port fail test: use_count is %A after a "
+                      "batched cross-engine last drop, expected 1",
+                      port->use_count);
+        goto fail_port;
+    }
+
+    thr->engine = &foreign;
+
+    nxt_locked_work_queue_move(thr, &foreign.locked_work_queue,
+                               &current.fast_work_queue);
+
+    nxt_port_fail_test_drain_wq(&current.fast_work_queue);
+
+    if (nxt_slow_path(nxt_port_fail_test_releases != 1)) {
+        nxt_log_alert(thr->log, "port fail test: draining the target engine "
+                      "released the batched port %ui times, expected 1",
+                      nxt_port_fail_test_releases);
+        goto fail_engine;
+    }
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_OK;
+
+fail_port:
+
+    nxt_port_use(task, port, -1);
+
+fail_engine:
+
+    nxt_work_queue_cache_destroy(&current.work_queue_cache);
+    thr->engine = NULL;
+
+    return NXT_ERROR;
+}
+
+
+static void
+nxt_port_fail_test_engine_signal(nxt_event_engine_t *engine, nxt_uint_t signo)
+{
+    nxt_port_fail_test_signals++;
+}
+
+
+static void
+nxt_port_fail_test_released(nxt_task_t *task, void *obj, void *data)
+{
+    nxt_port_fail_test_releases++;
 }
 
 


### PR DESCRIPTION
## What

`nxt_port_use()` funnels a port's last reference drop to `port->engine` whenever the
drop happens on another thread, and it did that through `nxt_port_post()` while
ignoring the return value:

```c
    if (port->engine == NULL || task->thread->engine == port->engine) {
        nxt_port_release(task, port);
        return;
    }

    nxt_port_post(task, port, nxt_port_release_handler, NULL);
```

`nxt_port_post()` allocates an `nxt_port_work_t` with `nxt_zalloc()`
(`src/nxt_port.c:1131`) and returns `NXT_ERROR` when that fails. By then
`nxt_atomic_fetch_add()` has already taken `use_count` to zero, so on failure
nothing is queued and `nxt_port_release()` is never reached: the `nxt_port_t`,
its memory pool, and the process reference the port holds
(`nxt_process_use(task, port->process, -1)`, `src/nxt_port.c:206`) all leak — and
with it the whole `nxt_process_t`, which then never reaches zero and is never torn
down. It happens under exactly the memory pressure that caused it, so each
occurrence makes the next more likely.

## Fix

There is nowhere to report the error from that call site: `use_count` is already
zero, and releasing inline would free another engine's memory from this thread,
which is what the deferral exists to prevent. So the failure path is removed
rather than handled — the work item is embedded in `nxt_port_t` and posted
straight to the engine with `nxt_event_engine_post()`, the shape
`nxt_runtime_process_release()` (`src/nxt_runtime.c:1644`) already uses for the
process free. A deferral that cannot allocate cannot fail.

**What the deferral carries is unchanged.** The reference is handed to the item
rather than given up: the count is left standing at 1 and the posted handler
drops it with `nxt_port_use()`, so the release happens only if nobody else took a
reference while the item was in flight. That re-check is not incidental — the
port stays reachable through `process->ports` until the item runs, and another
engine can still take a reference in that window:
`nxt_process_broadcast_shm_ack()` walks a process's ports through bare pointers
(`src/nxt_port_memory.c:1045`) and `nxt_port_socket_write()` takes a reference on
each (`src/nxt_port_socket.c:351`). Routing through `nxt_port_post()` provided
the re-check, because it took a reference of its own and
`nxt_port_post_handler()` ended in `nxt_port_use(port, -1)`; a handler that
released unconditionally would free a port somebody holds.

**The foreign drop is a compare-and-set, not a fetch-and-add plus a compensating
increment.** A single embedded item cannot be posted twice, and the two-atomic
form published a `use_count` of zero on a port that is still linked in
`process->ports` and `rt->ports`. A second thread promoting a bare pointer in
that window — the sibling loop of `nxt_port_broadcast_shm_ack()` reaches ports
that way, and `nxt_port_socket_write()` takes and drops a reference on each —
completes a 0 → 1 → 0 cycle of its own, reaches the same branch, and posts the
same item again. `nxt_locked_work_queue_add()` (`src/nxt_work_queue.c:230`) links
a work onto the queue tail, so the second post makes `tail->next` point at the
item itself and the engine draining that queue walks a one-element cycle forever.
`nxt_port_post()` could not produce that, because it allocated a separate item
per post. This is the P1 Codex raised on review 5142187973.

The compare-and-set never stores zero: a drop that is not the last one sets the
count to `c + i`, and the last one stores `1` — exactly one reference, whatever
the size of the batch the drop carries, because the item's handler drops exactly
one (`nxt_port_socket_write()` and `nxt_port_error_handler()` batch several into
`use_delta`, `src/nxt_port_socket.c:601` and `:1500`). `use_count` therefore
reaches zero only on `port->engine`,
immediately before `nxt_port_release()`. While the item is in flight the count is
at least 1, so no other thread can observe a last drop, at most one post is ever
outstanding, and the double post is impossible by construction — no latch, no
flag. The item is free again only once the handler's drop can run, which is after
`nxt_locked_work_queue_move()` (`src/nxt_work_queue.c:289`) has taken it off the
locked queue and copied it into the engine's own work queue; that same copy is
what makes it safe for the release to free the pool the item lives in.

A bare-pointer promotion *after* the on-engine release is a different bug (#195,
#287's business) and is unchanged here. #287 is not a prerequisite: this PR does
not rely on `nxt_port_use_unless_zero()`.

`nxt_port_release_handler()`, the no-op that existed only to satisfy
`nxt_port_post()`'s handler signature, goes away with the call. The port refcount
protocol is unchanged, and `nxt_port_post()` keeps its other callers.

## Test

There is no allocation-failure injection hook reachable from the C suite, so the
first of two new subtests in `src/test/nxt_port_fail_test.c` pins the leak
structurally: it drops a port's last reference from a thread whose engine is not
the port's and asserts that the item landing on the target engine's locked work
queue is the port's own `release_work` — false for any implementation that
allocates it, whether or not the allocation succeeds — that the item holds a
reference, and that draining the port's engine reaches `nxt_port_release()`,
observed through a cleanup registered on the port's memory pool.

The second covers the handover: it takes a reference between the post and the
drain, then asserts the drain does **not** release, and that the release happens
exactly once, when that other holder lets go.

The third subtest pins the P1 directly. A racer thread on a third engine watches
`use_count` across a cross-engine last drop and reports every zero it sees; the
locked queue is then walked with a step limit, so an item linked to itself fails
the test instead of hanging it; and the racer finishes with the 1 → 2 → 1 an
in-flight acquisition performs, which must not post anything. 128 trials.

A fourth gives up two references in one cross-engine drop — the shape
`nxt_port_error_handler()` produces when it batches into `use_delta` — and
asserts that the count left standing is 1, not 2, and that draining releases the
port.

Both fail on the implementations they are aimed at:

| injected defect | result |
| --- | --- |
| revert `src/nxt_port.c` to master (allocated item) | `alert: the posted item is not the port's embedded release work` |
| embedded item, no reference handover | `alert: the deferred release does not hold a reference (use_count 0)` |
| handover kept, handler releases unconditionally | `SIGABRT` — `nxt_assert(port->use_count == 0)` in `nxt_port_mp_cleanup` (a UAF in a release build) |
| handover kept, but `fetch_add(-1)` + compensating `fetch_add(+1)` instead of the CAS | `alert: a foreign thread saw use_count 0 on a live port 1 times` — 5 runs out of 5 |
| CAS handover that leaves the whole batch standing (`c` → `c`) instead of `c` → `1` | `alert: use_count is 2 after a batched cross-engine last drop, expected 1` |

| check (host: Debian, gcc, PHP 8.5.4) | branch |
| --- | --- |
| `./configure --debug --tests && ./configure php && make -j8 && make tests` | rc 0, no warnings |
| `./build/tests` | exit 0, 43 passed |
| `pytest test/test_php_application.py test/test_conn_recycle.py` | 51 passed, 3 skipped |
| `tools/check-style origin/master` (whitespace gate) | clean |
| `git merge-tree --merge-base=origin/master HEAD` vs #287 (`acc8b1b3`) | merges cleanly; merged `nxt_port_use()` is the CAS version, `nxt_port_use_unless_zero()` intact |
| C suite under ASan+UBSan, `detect_leaks=1` | branch: 109 allocations / 13760 bytes leaked; `origin/master`: 109 / 13600 — the same leak set, +160 bytes because four leaked ports each grew by the embedded `nxt_work_t`. One UBSan `runtime error` in both (`src/nxt_buf.h:250`, pre-existing) |

The ASan run stops in both trees at the same pre-existing UBSan report
(`nxt_buf_cpy` / `src/nxt_buf.h:250`, a zero-length `memcpy` from NULL reached by
`nxt_router_proto_wedge_test`); with `halt_on_error=0` both complete with an
identical leak set of 109 allocations, the only difference being one leaked port
growing 392 -> 432 bytes because `nxt_port_t` gained the embedded `nxt_work_t`.

## CHANGES

```
    *) Bugfix: a port's last reference could be dropped without releasing
       the port. When the drop happened on a thread other than the port's
       event engine, the release was deferred through a work item allocated
       for it, and an allocation failure there was ignored: the reference
       count had already reached zero, so nothing released the port, its
       memory pool, or the process reference it held, and the process was
       never torn down. The deferral now uses a work item embedded in the
       port, so it cannot fail.
```

## Note for #287 (not this PR)

`nxt_port_use_unless_zero()` guards only the *first-port lookup* in
`nxt_process_broadcast_shm_ack()`. The static handler it posts,
`nxt_port_broadcast_shm_ack()` (`src/nxt_port_memory.c:1039`), still iterates
`process->ports` with bare pointers and calls `nxt_port_socket_write()` on each
without the mutex or the try-ref — the same #195 shape one level down. Worth
guarding there too.

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh

