### PR TITLE
port: take the app port under a lock in the shared memory ack

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -176,6 +176,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_http_chunk_parse_test.c \
     src/test/nxt_conf_parse_test.c \
     src/test/nxt_port_fail_test.c \
+    src/test/nxt_port_use_unless_zero_test.c \
     src/test/nxt_port_mmap_range_test.c \
     src/test/nxt_port_ready_test.c \
     src/test/nxt_router_new_port_test.c \

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -190,9 +190,46 @@ nxt_port_close(nxt_task_t *task, nxt_port_t *port)
 }
 
 
+/*
+ * Take a reference, unless the port has already dropped its last one.
+ *
+ * This is the counterpart of a lookup in process->ports: a reference derived
+ * from a pointer that was found rather than from one the caller already
+ * holds cannot use nxt_port_use(), because the port may be in teardown by
+ * the time the increment lands.  Callers must hold rt->processes_mutex,
+ * which nxt_port_release() also holds while it unlinks the port, so that
+ * {find, ref} and {last drop, unlink} are mutually exclusive: a port still
+ * reachable through process->ports either still has a reference, or has
+ * already had its count latched at zero and fails here.
+ *
+ * Returns 1 when a reference was taken -- the caller then owns it and must
+ * drop it with nxt_port_use(task, port, -1), outside the mutex.
+ */
+
+nxt_bool_t
+nxt_port_use_unless_zero(nxt_port_t *port)
+{
+    nxt_atomic_int_t  c;
+
+    for ( ;; ) {
+        c = port->use_count;
+
+        if (c <= 0) {
+            return 0;
+        }
+
+        if (nxt_atomic_cmp_set(&port->use_count, c, c + 1)) {
+            return 1;
+        }
+    }
+}
+
+
 static void
 nxt_port_release(nxt_task_t *task, nxt_port_t *port)
 {
+    nxt_runtime_t  *rt;
+
     nxt_debug(task, "port %p %d:%d release, type %d", port, port->pid,
               port->id, port->type);
 
@@ -201,7 +238,26 @@ nxt_port_release(nxt_task_t *task, nxt_port_t *port)
     if (port->link.next != NULL) {
         nxt_assert(port->process != NULL);
 
+        rt = task->thread->runtime;
+
+        /*
+         * The unlink happens under rt->processes_mutex so that it cannot
+         * race a lookup in process->ports on another engine -- see
+         * nxt_port_use_unless_zero().  use_count is zero here and stays
+         * zero, so every reader that reaches the port through the queue
+         * before the unlink takes the mutex and fails the try-ref, and every
+         * reader after it cannot reach the port at all.
+         *
+         * rt->processes_mutex must stay a leaf (src/nxt_process.c:150), so
+         * the process reference is dropped after the unlock:
+         * nxt_process_use() takes the same mutex itself.
+         */
+
+        nxt_thread_mutex_lock(&rt->processes_mutex);
+
         nxt_process_port_remove(port);
+
+        nxt_thread_mutex_unlock(&rt->processes_mutex);
 
         nxt_process_use(task, port->process, -1);
     }

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -439,6 +439,7 @@ void nxt_port_empty_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 nxt_int_t nxt_port_post(nxt_task_t *task, nxt_port_t *port,
     nxt_port_post_handler_t handler, void *data);
 void nxt_port_use(nxt_task_t *task, nxt_port_t *port, int i);
+nxt_bool_t nxt_port_use_unless_zero(nxt_port_t *port);
 
 nxt_inline void nxt_port_inc_use(nxt_port_t *port)
 {

--- a/src/nxt_port_memory.c
+++ b/src/nxt_port_memory.c
@@ -1003,35 +1003,83 @@ nxt_port_mmap_get_method(nxt_task_t *task, nxt_port_t *port, nxt_buf_t *b)
 void
 nxt_process_broadcast_shm_ack(nxt_task_t *task, nxt_process_t *process)
 {
-    nxt_port_t  *port;
+    nxt_port_t     *port;
+    nxt_runtime_t  *rt;
 
-    if (nxt_slow_path(process == NULL || nxt_queue_is_empty(&process->ports)))
-    {
+    if (nxt_slow_path(process == NULL)) {
         return;
     }
 
-    port = nxt_process_port_first(process);
+    rt = task->thread->runtime;
 
-    if (port->type == NXT_PROCESS_APP) {
-        /*
-         * The process is handed to another engine as a bare pointer and is
-         * dereferenced there, so the posted handler needs a reference of its
-         * own and drops it when it is done.  nxt_port_post() returns NXT_OK
-         * both when it queues the handler and when it calls it inline on the
-         * current engine, and the handler owns the reference either way; only
-         * the NXT_ERROR case leaves nothing to run, so only that case has to
-         * be undone here.  The inline call is safe: the caller still holds
-         * its own reference, so this one cannot be the last.
-         */
+    /*
+     * This runs on any engine -- most often a worker engine, from
+     * nxt_port_mmap_buf_completion() -- while the app port's teardown runs on
+     * the router's main thread.  The caller holds a reference to the process,
+     * not to the port, so the port has to be looked up, and a reference taken
+     * from a lookup can land on a port whose count already reached zero:
+     * nxt_port_post() below does an unconditional increment, and
+     * nxt_port_release() would by then be destroying the port's memory pool
+     * (issue #195 -- the `port->use_count == 0` assertion in a debug build,
+     * a use-after-free of the port and of the work item in a release one).
+     *
+     * rt->processes_mutex is the lock nxt_port_release() unlinks the port
+     * under, so reading process->ports and try-referencing the port under it
+     * cannot observe a port that is being released: either the try-ref wins
+     * and the port is alive for as long as this function holds it, or the
+     * port is already dying and there is nothing to acknowledge -- the
+     * process is going away and the app will not wait for shared memory
+     * again.
+     *
+     * Only the lookup is done under the mutex.  Everything after it takes
+     * other locks (nxt_process_use() takes this very mutex), and
+     * rt->processes_mutex is a leaf -- see src/nxt_process.c:150.
+     */
 
-        nxt_process_use(task, process, 1);
+    nxt_thread_mutex_lock(&rt->processes_mutex);
 
-        if (nxt_slow_path(nxt_port_post(task, port, nxt_port_broadcast_shm_ack,
-                                        process) != NXT_OK))
-        {
-            nxt_process_use(task, process, -1);
+    port = NULL;
+
+    if (!nxt_queue_is_empty(&process->ports)) {
+        port = nxt_process_port_first(process);
+
+        if (port->type != NXT_PROCESS_APP || !nxt_port_use_unless_zero(port)) {
+            port = NULL;
         }
     }
+
+    nxt_thread_mutex_unlock(&rt->processes_mutex);
+
+    if (port == NULL) {
+        return;
+    }
+
+    /*
+     * The process is handed to another engine as a bare pointer and is
+     * dereferenced there, so the posted handler needs a reference of its
+     * own and drops it when it is done.  nxt_port_post() returns NXT_OK
+     * both when it queues the handler and when it calls it inline on the
+     * current engine, and the handler owns the reference either way; only
+     * the NXT_ERROR case leaves nothing to run, so only that case has to
+     * be undone here.  The inline call is safe: the caller still holds
+     * its own reference, so this one cannot be the last.
+     */
+
+    nxt_process_use(task, process, 1);
+
+    if (nxt_slow_path(nxt_port_post(task, port, nxt_port_broadcast_shm_ack,
+                                    process) != NXT_OK))
+    {
+        nxt_process_use(task, process, -1);
+    }
+
+    /*
+     * nxt_port_post() took its own reference on success, so the lookup
+     * reference is dropped here either way.  It is dropped after the post so
+     * that the port cannot be released between the try-ref and the post.
+     */
+
+    nxt_port_use(task, port, -1);
 }
 
 

--- a/src/test/nxt_port_use_unless_zero_test.c
+++ b/src/test/nxt_port_use_unless_zero_test.c
@@ -1,0 +1,378 @@
+/*
+ * Copyright (C) NGINX, Inc.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include "nxt_tests.h"
+
+#include <pthread.h>
+
+
+#define NXT_PORT_UUZ_RACERS  8
+#define NXT_PORT_UUZ_ROUNDS  2000
+
+
+typedef struct {
+    nxt_port_t        *port;
+    nxt_atomic_t      gen;
+    nxt_atomic_t      done;
+    nxt_atomic_t      released;
+    nxt_atomic_t      wins;
+    nxt_atomic_t      late_wins;
+    nxt_atomic_t      stop;
+} nxt_port_uuz_ctx_t;
+
+
+static nxt_int_t nxt_port_uuz_test_semantics(nxt_thread_t *thr);
+static nxt_int_t nxt_port_uuz_test_after_last_drop(nxt_thread_t *thr);
+static nxt_int_t nxt_port_uuz_test_race(nxt_thread_t *thr);
+static void *nxt_port_uuz_racer(void *data);
+static nxt_port_t *nxt_port_uuz_port(nxt_task_t *task);
+static void nxt_port_uuz_free(nxt_port_t *port);
+
+
+nxt_int_t
+nxt_port_use_unless_zero_test(nxt_thread_t *thr)
+{
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "port use_unless_zero test started");
+
+    if (nxt_port_uuz_test_semantics(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_uuz_test_after_last_drop(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_port_uuz_test_race(thr) != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "port use_unless_zero test passed");
+
+    return NXT_OK;
+}
+
+
+/* A live port hands out references, and the count follows them exactly. */
+
+static nxt_int_t
+nxt_port_uuz_test_semantics(nxt_thread_t *thr)
+{
+    nxt_port_t  *port;
+
+    port = nxt_port_uuz_port(thr->task);
+    if (nxt_slow_path(port == NULL)) {
+        return NXT_ERROR;
+    }
+
+    if (nxt_slow_path(!nxt_port_use_unless_zero(port))) {
+        nxt_log_alert(thr->log, "port use_unless_zero test: a live port "
+                      "(use_count %A) refused a reference", port->use_count);
+        goto fail;
+    }
+
+    if (nxt_slow_path(port->use_count != 2)) {
+        nxt_log_alert(thr->log, "port use_unless_zero test: use_count is %A, "
+                      "expected 2", port->use_count);
+        goto fail;
+    }
+
+    if (nxt_slow_path(!nxt_port_use_unless_zero(port)
+                      || port->use_count != 3))
+    {
+        nxt_log_alert(thr->log, "port use_unless_zero test: a second "
+                      "reference did not stack (use_count %A)",
+                      port->use_count);
+        goto fail;
+    }
+
+    nxt_atomic_fetch_add(&port->use_count, -2);
+
+    if (nxt_slow_path(port->use_count != 1)) {
+        nxt_log_alert(thr->log, "port use_unless_zero test: use_count is %A "
+                      "after two drops, expected 1", port->use_count);
+        goto fail;
+    }
+
+    nxt_port_uuz_free(port);
+
+    return NXT_OK;
+
+fail:
+
+    nxt_port_uuz_free(port);
+
+    return NXT_ERROR;
+}
+
+
+/*
+ * The regression itself (issue #195).
+ *
+ * nxt_process_broadcast_shm_ack() reaches an app port through
+ * process->ports, which is a lookup: the port may already have dropped its
+ * last reference and be inside nxt_port_release(), destroying its memory
+ * pool.  The unconditional nxt_atomic_fetch_add() that nxt_port_post() does
+ * on that pointer resurrects a dead port -- the `use_count == 0` assertion
+ * in nxt_port_mp_cleanup() in a debug build, a use-after-free in a release
+ * one.
+ *
+ * The state reproduced here is exactly the window: use_count has reached
+ * zero and the port is still linked, because nxt_port_release() unlinks it
+ * only afterwards.  A try-ref must fail, and must leave the count alone --
+ * an implementation that increments first and inspects afterwards leaves 1
+ * here and fails the same way the router did.
+ */
+
+static nxt_int_t
+nxt_port_uuz_test_after_last_drop(nxt_thread_t *thr)
+{
+    nxt_int_t   ret;
+    nxt_uint_t  i;
+    nxt_port_t  *port;
+
+    port = nxt_port_uuz_port(thr->task);
+    if (nxt_slow_path(port == NULL)) {
+        return NXT_ERROR;
+    }
+
+    ret = NXT_OK;
+
+    /* The last drop, without the release nxt_port_use() would run. */
+    nxt_atomic_fetch_add(&port->use_count, -1);
+
+    for (i = 0; i < 3; i++) {
+        if (nxt_slow_path(nxt_port_use_unless_zero(port))) {
+            nxt_log_alert(thr->log, "port use_unless_zero test: a port whose "
+                          "last reference is gone handed out one anyway "
+                          "(attempt %ui)", i + 1);
+            ret = NXT_ERROR;
+            break;
+        }
+
+        if (nxt_slow_path(port->use_count != 0)) {
+            nxt_log_alert(thr->log, "port use_unless_zero test: a refused "
+                          "try-ref changed use_count to %A", port->use_count);
+            ret = NXT_ERROR;
+            break;
+        }
+    }
+
+    port->use_count = 0;
+
+    nxt_port_uuz_free(port);
+
+    return ret;
+}
+
+
+/*
+ * The same thing under contention, with the ordering the mutex in
+ * nxt_process_broadcast_shm_ack() and nxt_port_release() guarantees: the
+ * racers only look the port up after the owner has dropped the last
+ * reference.  Every one of them must be refused.
+ *
+ * The rounds also exercise the CAS loop against concurrent increments, so a
+ * lost update would show up as a non-zero count at the end of a round.
+ */
+
+static nxt_int_t
+nxt_port_uuz_test_race(nxt_thread_t *thr)
+{
+    nxt_int_t           ret;
+    nxt_uint_t          i, round;
+    pthread_t           racers[NXT_PORT_UUZ_RACERS];
+    nxt_port_uuz_ctx_t  ctx;
+
+    nxt_memzero(&ctx, sizeof(ctx));
+
+    ctx.port = nxt_port_uuz_port(thr->task);
+    if (nxt_slow_path(ctx.port == NULL)) {
+        return NXT_ERROR;
+    }
+
+    /*
+     * The port outlives every round: the count is put back by hand rather
+     * than letting the port be released, so that the racers never touch
+     * freed memory even when the implementation under test is wrong.
+     */
+    ctx.port->use_count = 0;
+
+    for (i = 0; i < NXT_PORT_UUZ_RACERS; i++) {
+        if (nxt_slow_path(pthread_create(&racers[i], NULL, nxt_port_uuz_racer,
+                                         &ctx) != 0))
+        {
+            nxt_log_alert(thr->log, "port use_unless_zero test: "
+                          "pthread_create() failed");
+
+            ctx.stop = 1;
+            nxt_atomic_fetch_add(&ctx.gen, 1);
+
+            while (i > 0) {
+                pthread_join(racers[--i], NULL);
+            }
+
+            nxt_port_uuz_free(ctx.port);
+
+            return NXT_ERROR;
+        }
+    }
+
+    ret = NXT_OK;
+
+    for (round = 0; round < NXT_PORT_UUZ_ROUNDS; round++) {
+        ctx.port->use_count = 1;
+        ctx.released = 0;
+        ctx.late_wins = 0;
+        ctx.done = 0;
+
+        nxt_atomic_fetch_add(&ctx.gen, 1);
+
+        /* Contended try-refs, which may or may not win. */
+        nxt_thread_yield();
+
+        if (nxt_atomic_fetch_add(&ctx.port->use_count, -1) != 1) {
+            /*
+             * A racer that won still holds a reference; wait for it.  It
+             * cannot be held for long -- every winner drops immediately.
+             */
+            while (ctx.port->use_count != 0) {
+                nxt_thread_yield();
+            }
+        }
+
+        /* From here on no lookup may produce a reference. */
+        ctx.released = 1;
+
+        while (ctx.done != NXT_PORT_UUZ_RACERS) {
+            nxt_thread_yield();
+        }
+
+        if (nxt_slow_path(ctx.port->use_count != 0)) {
+            nxt_log_alert(thr->log, "port use_unless_zero test: use_count is "
+                          "%A after round %ui, expected 0",
+                          ctx.port->use_count, round);
+            ret = NXT_ERROR;
+            break;
+        }
+
+        if (nxt_slow_path(ctx.late_wins != 0)) {
+            nxt_log_alert(thr->log, "port use_unless_zero test: %A "
+                          "reference(s) taken after the last drop, in round "
+                          "%ui", ctx.late_wins, round);
+            ret = NXT_ERROR;
+            break;
+        }
+    }
+
+    ctx.stop = 1;
+    nxt_atomic_fetch_add(&ctx.gen, 1);
+
+    for (i = 0; i < NXT_PORT_UUZ_RACERS; i++) {
+        pthread_join(racers[i], NULL);
+    }
+
+    if (ret == NXT_OK && ctx.wins == 0) {
+        /*
+         * Not a failure of the code under test, but nothing was contended,
+         * so say so rather than pass quietly.
+         */
+        nxt_log_error(NXT_LOG_NOTICE, thr->log, "port use_unless_zero test: "
+                      "no contended try-ref won; the race was not exercised");
+    }
+
+    ctx.port->use_count = 0;
+
+    nxt_port_uuz_free(ctx.port);
+
+    return ret;
+}
+
+
+static void *
+nxt_port_uuz_racer(void *data)
+{
+    nxt_bool_t          late;
+    nxt_atomic_int_t    gen, last_gen;
+    nxt_port_uuz_ctx_t  *ctx;
+
+    ctx = data;
+    last_gen = 0;
+
+    for ( ;; ) {
+        for ( ;; ) {
+            gen = ctx->gen;
+
+            if (gen != last_gen) {
+                break;
+            }
+
+            nxt_thread_yield();
+        }
+
+        last_gen = gen;
+
+        if (ctx->stop) {
+            return NULL;
+        }
+
+        /*
+         * Whether this lookup is racing the owner's last drop or is
+         * unambiguously after it decides what the outcome is allowed to be:
+         * a try-ref after the drop must always be refused.
+         */
+        late = (ctx->released != 0);
+
+        if (nxt_port_use_unless_zero(ctx->port)) {
+            if (late) {
+                nxt_atomic_fetch_add(&ctx->late_wins, 1);
+            }
+
+            nxt_atomic_fetch_add(&ctx->wins, 1);
+            nxt_atomic_fetch_add(&ctx->port->use_count, -1);
+        }
+
+        nxt_atomic_fetch_add(&ctx->done, 1);
+    }
+}
+
+
+static nxt_port_t *
+nxt_port_uuz_port(nxt_task_t *task)
+{
+    nxt_port_t  *port;
+
+    port = nxt_port_new(task, 1, nxt_pid, NXT_PROCESS_APP);
+
+    if (nxt_slow_path(port == NULL)) {
+        return NULL;
+    }
+
+    port->pair[0] = -1;
+    port->pair[1] = -1;
+    port->socket.fd = -1;
+
+    return port;
+}
+
+
+/*
+ * nxt_port_use() cannot be used here: the last drop goes to
+ * nxt_port_release(), which needs a runtime this test does not build.  The
+ * pool cleanup that nxt_port_new() registered still runs, and still asserts
+ * the port is quiescent.
+ */
+
+static void
+nxt_port_uuz_free(nxt_port_t *port)
+{
+    port->use_count = 0;
+
+    nxt_mp_destroy(port->mem_pool);
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -190,6 +190,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_port_use_unless_zero_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_mmap_range_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -71,6 +71,7 @@ nxt_int_t nxt_http_chunk_parse_test(nxt_thread_t *thr);
 nxt_int_t nxt_conf_json_depth_test(nxt_thread_t *thr);
 nxt_int_t nxt_http_route_addr_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fail_test(nxt_thread_t *thr);
+nxt_int_t nxt_port_use_unless_zero_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_mmap_range_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_ready_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);

--- a/test/test_process_shm_oosm.py
+++ b/test/test_process_shm_oosm.py
@@ -44,6 +44,8 @@ Cheap on purpose: one request and one deliberate client stall, about a second
 of work once the PHP worker is warm.
 """
 
+import subprocess
+import threading
 import time
 
 import pytest
@@ -145,5 +147,191 @@ def test_process_shm_oosm():
     assert _body(resp, 1024 * 1024).count(b'x') == 1024 * 1024, (
         'still serving'
     )
+
+    Log.check_alerts()
+
+
+# ---------------------------------------------------------------------------
+# The OOSM ack path against an application that is being torn down (issue #195)
+# ---------------------------------------------------------------------------
+
+# Kills, and the gap between them.  Each one has to land while the segment is
+# still full and clients are still stalled, which is what puts a SHM_ACK
+# broadcast and the port teardown of the process it is aimed at on two engines
+# at once.
+KILLS = 5
+KILL_INTERVAL = 0.4
+
+# Stalled readers, so the response buffers -- the application's shared memory
+# -- stay busy for the whole run instead of draining between kills.
+STALLERS = 3
+
+# Bounded on purpose: this is a race driver, not a soak.  Five kills at 0.4 s
+# is about three seconds of workload, cheap enough for every leg including the
+# sanitiser ones.  It is timing-dependent by nature: a green run is evidence
+# only in the same weak sense as test_process_abrupt_teardown.py, and the
+# deterministic check of the primitive this test exercises lives in the C
+# suite (src/test/nxt_port_use_unless_zero_test.c).
+
+
+def _oosm_app_pids():
+    """PIDs currently serving the application, via ps (as conftest does)."""
+    out = subprocess.check_output(
+        ['ps', '-ax', '-o', 'pid', '-o', 'command']
+    ).decode()
+
+    marker = f'unit: "{APP}" application'
+
+    return {line.split()[0] for line in out.splitlines() if marker in line}
+
+
+def _wait_for_fresh_pids(spent, timeout=5):
+    """A worker this run has not killed yet, so every kill is a distinct
+    abrupt teardown rather than a repeat shot at a corpse.  Same reasoning as
+    test_process_abrupt_teardown.py."""
+
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        pids = _oosm_app_pids() - spent
+
+        if pids:
+            return pids
+
+        time.sleep(0.05)
+
+    return set()
+
+
+def test_process_shm_oosm_kill(skip_alert):
+    """Kill the OOSM-blocked worker while the router is acknowledging it.
+
+    What this drives: the same one-segment application as above, but with
+    several clients stalled at once so the segment stays full, and the worker
+    SIGKILLed underneath them.  The router then has two things happening on
+    two engines: on a worker engine,
+    ``nxt_port_mmap_buf_completion()`` (src/nxt_port_memory.c) drains a
+    completed response buffer, wins ``cmp_set(&hdr->oosm, 1, 0)`` and calls
+    ``nxt_process_broadcast_shm_ack()``; on the router's main thread, the
+    SIGCHLD-driven ``nxt_port_remove_pid()`` -> ``nxt_process_close_ports()``
+    has dropped the app port's references and ``nxt_port_release()``
+    (src/nxt_port.c) is destroying its memory pool.
+
+    ``nxt_process_broadcast_shm_ack()`` read the app port out of
+    ``process->ports`` as a bare pointer and handed it to ``nxt_port_post()``,
+    whose unconditional ``nxt_atomic_fetch_add(&port->use_count, 1)`` lands on
+    a port whose count is already zero: the ``port->use_count == 0`` assertion
+    in ``nxt_port_mp_cleanup()`` in a --debug build, and a use-after-free of
+    the port and of the posted work item in a release one.  The fix takes the
+    port with ``nxt_port_use_unless_zero()`` under ``rt->processes_mutex``,
+    which ``nxt_port_release()`` now unlinks under.
+
+    What this proves and what it does not: on a --debug build the assertion
+    fires as an alert and this test catches it directly -- that is the
+    reproduction from the issue.  On a non-debug build it is only a UAF
+    driver, worth its runtime under ASan and little without it.  A green run
+    is weak evidence, as in test_process_abrupt_teardown.py; read it as "the
+    OOSM ack raced repeated abrupt teardowns and the router stayed correct".
+    """
+
+    # SIGKILLing a worker is the point of the test, so the main process'
+    # report of it is expected, not a finding.  Nothing else is waived --
+    # in particular the assertion alert this test exists to catch is not.
+    skip_alert(r'process \d+ exited on signal 9')
+
+    client.load(APP, limits={"shm": SHM_LIMIT}, processes=1)
+
+    assert 'success' in client.conf(
+        {"listen_threads": LISTEN_THREADS}, 'settings'
+    ), 'listen_threads'
+
+    stop = threading.Event()
+    failures = []
+
+    def staller():
+        """Ask for a response far larger than the segment and then read it
+        slowly, so the application blocks in nxt_unit_wait_shm_ack() and the
+        router keeps completing buffers for it."""
+
+        while not stop.is_set():
+            try:
+                sock = client.get(url=f'/?mb={RESPONSE_MB}', no_recv=True)
+                time.sleep(STALL)
+                client.recvall(sock, read_timeout=READ_TIMEOUT,
+                               buff_size=65536)
+                sock.close()
+
+            except Exception:
+                # A request cut short by a kill is the point of the test, not
+                # a failure.  Only a hang or a crashed daemon is, and those
+                # are caught by the join and the assertions below.
+                pass
+
+    stallers = [threading.Thread(target=staller) for _ in range(STALLERS)]
+
+    for thread in stallers:
+        thread.start()
+
+    # Let the first responses reach the OOSM state before killing anything.
+    time.sleep(STALL * 2)
+
+    killed = []
+
+    for round_ in range(KILLS):
+        pids = _wait_for_fresh_pids(set(killed))
+
+        if not pids:
+            failures.append(f'no fresh worker for kill {round_ + 1}')
+            break
+
+        subprocess.call(['kill', '-9', *pids])
+
+        killed.extend(pids)
+
+        time.sleep(KILL_INTERVAL)
+
+    stop.set()
+
+    for thread in stallers:
+        thread.join(timeout=120)
+        assert not thread.is_alive(), 'stalled request thread hung'
+
+    assert not failures, f'{len(failures)} failure(s), first: {failures[0]}'
+    assert len(killed) >= KILLS, (
+        f'only {len(killed)} worker(s) killed: {killed}'
+    )
+
+    log = Log.read()
+
+    # The direct hit.  nxt_assert() aborts the router in a --debug build, and
+    # the record it prints names the file and line -- src/nxt_port.c, the
+    # use_count assertion in nxt_port_mp_cleanup().  Checked before anything
+    # else, because a dead router makes every other assertion here fail for
+    # the wrong reason.
+    assert 'assertion failed' not in log, (
+        'a port was referenced after its last drop: '
+        + next(
+            line
+            for line in log.splitlines()
+            if 'assertion failed' in line
+        )
+    )
+
+    # Still serving, on a worker started after the last kill.
+    sock = client.get(url='/?mb=1', no_recv=True)
+    resp = client.recvall(sock, read_timeout=READ_TIMEOUT, buff_size=65536)
+    sock.close()
+
+    assert _body(resp, 1024 * 1024).count(b'x') == 1024 * 1024, (
+        'still serving'
+    )
+
+    if '[debug]' not in log:
+        pytest.skip('OOSM evidence needs a --debug build')
+
+    # Same proof as the test above that the OOSM round trip really ran; here
+    # it also establishes that the kills landed on a blocked worker rather
+    # than an idle one.
+    assert 'oosm in ' in log, 'router handled an OOSM message'
 
     Log.check_alerts()


### PR DESCRIPTION
Fixes #195.

## The bug

`nxt_process_broadcast_shm_ack()` (`src/nxt_port_memory.c:1000`) holds a
reference to the *process*, but reaches the app port through a *lookup*:
`nxt_process_port_first()` on `process->ports`, with no lock. It hands that bare
pointer to `nxt_port_post()`, whose unconditional
`nxt_atomic_fetch_add(&port->use_count, 1)` (`src/nxt_port.c:1139`) can land on
a port that has already dropped its last reference.

That is exactly what happens when an OOSM-blocked application is killed under
load:

- on a **router worker engine**, `nxt_port_mmap_buf_completion()`
  (`src/nxt_port_memory.c:230`) wins `cmp_set(&hdr->oosm, 1, 0)` as a stalled
  client's response buffer finishes writing, and broadcasts the SHM ack;
- on the **router's main thread**, `SIGCHLD` → `REMOVE_PID` →
  `nxt_port_remove_pid()` (`src/nxt_port.c:1055`) → `nxt_process_close_ports()`
  has taken the app port's references away, and `nxt_port_release()`
  (`src/nxt_port.c:194`) is unlinking it and destroying its memory pool.

The `+1` arrives a few hundred nanoseconds before `nxt_port_mp_cleanup()`
(`src/nxt_port.c:101`) asserts `port->use_count == 0`. Interleaved `--debug`
log from a reproducing run (router 3443, worker thread 3447):

```
3443#3447 mmap buf completion: ... 3482->3443,0,476
3443#3447 pthread_mutex_lock(...) enter/exit          <- nxt_runtime_process_ref
3443#3443 port 74B921B54660 3482:0 release, type 5    <- nxt_port_release on main
3443#3447 malloc(56): 74B922216550                    <- nxt_port_post: +1, work item
3443#3447 event engine post
3443#3443 mp 74B921C8D0F0 release: 0
3443#3443 src/nxt_port.c:101 assertion failed: port->use_count == 0
```

This is **not** a debug-only nuisance. `nxt_assert()` compiles to nothing in a
release build, so the same window is a use-after-free of the port and of the
work item posted with it.

## The fix

A reference derived from a lookup cannot be taken with `nxt_port_use()`; it
needs a try-ref, paired with the lock that decides whether a port is still
reachable.

- **`nxt_port_use_unless_zero()`** (new, `src/nxt_port.c`): a CAS loop in the
  shape of the kernel's `kref_get_unless_zero()`. It refuses a port whose count
  has already reached zero, and leaves the count alone when it refuses.
- **`nxt_port_release()`** now unlinks the port from `process->ports` under
  `rt->processes_mutex`.
- **`nxt_process_broadcast_shm_ack()`** reads `process->ports` and try-refs the
  port under that same mutex, returns if the try-ref fails, and drops the
  lookup reference after the post returns.

`{find, ref}` and `{last drop, unlink}` are then mutually exclusive: the
broadcast either gets a port that stays alive for the length of the post, or
gets nothing — which is the right answer, since the process is going away and
its application will not wait for shared memory again.

`rt->processes_mutex` is a documented leaf (`src/nxt_process.c:150`) and stays
one: only the lookup is inside the critical section. `nxt_process_use()` takes
that mutex itself, so both the process reference the broadcast takes and the one
`nxt_port_release()` drops are handled outside it. The mutex is only taken in
`nxt_port_release()` when the port is actually linked, which is also the only
case in which `nxt_process_use()` was already going to take it — so no call site
that releases a port without a runtime (the C suite does this) is affected.

Reviewed and deliberately *not* changed: `nxt_process_port_add()` must not take
`rt->processes_mutex`, because it calls `nxt_process_use()`, which takes it.

## Tests

**`src/test/nxt_port_use_unless_zero_test.c`** (new, wired into `./build/tests`)
pins the primitive deterministically: a live port hands out stacking references;
a port whose last reference is gone refuses them *and* keeps its count at zero;
and neither property is lost under contention (8 threads × 2000 rounds, each
round racing try-refs against the owner's last drop, asserting that no reference
is ever taken after it and that the count returns to zero). Replacing the CAS
loop with the unconditional `fetch_add` it stands in for fails the test on the
first attempt:

```
tests: [alert] port use_unless_zero test: a port whose last reference is gone
handed out one anyway (attempt 1)
```

**`test_process_shm_oosm_kill`** (new, in `test/test_process_shm_oosm.py`)
drives the router path itself, and is the issue's recipe: the one-segment
`big_response` application, `listen_threads: 4`, three clients stalling before
they read so the segment stays full, and the single worker `kill -9`ed five
times at 0.4 s. About three seconds of workload. It asserts directly that no
`assertion failed` reached the log, then that the daemon still serves, then (on
a `--debug` build) that the OOSM round trip really ran. It is a use-after-free
driver for the sanitizer legs.

Measured on two machines, master being `origin/master` (3e3ce864) with only the
new test file copied in:

| build | runs | failures |
|---|---|---|
| master, `--debug` (local, PHP 8.5.4) | 6 | **5** — `src/nxt_port.c:101 assertion failed: port->use_count == 0` |
| this branch, `--debug` (local) | 6 | **0** |
| master, `--debug` (Docker, `php:8.4-cli-trixie`) | 6 | **6** — same assertion |
| this branch, `--debug` (Docker) | 6 | **0** |
| master, ASan+UBSan (Docker) | 3 | **3** — assertion in 3, ASan `heap-use-after-free` in 2 |
| this branch, ASan+UBSan (Docker) | 3 | **0** |
| master, ASan+UBSan (local) | 1 | **1** — assertion |
| this branch, ASan+UBSan (local) | 3 | **0** |

The sanitizer sees the release-build consequence directly:

```
==11738==ERROR: AddressSanitizer: heap-use-after-free on address 0x514000001378
WRITE of size 8 at 0x514000001378 thread T0
    #0 nxt_port_use src/nxt_port.c:1167
    #1 nxt_port_post_handler src/nxt_port.c:1117
0x514000001378 is located 312 bytes inside of 392-byte region
freed by thread T0 here:
    #3 nxt_port_mp_cleanup src/nxt_port.c:111
    #4 nxt_mp_destroy src/nxt_mp.c:335
    #6 nxt_port_release src/nxt_port.c:209
    #7 nxt_port_use src/nxt_port.c:1172
    #8 nxt_port_post_handler src/nxt_port.c:1117
previously allocated by thread T0 here:
    #5 nxt_port_new src/nxt_port.c:128
    #6 nxt_runtime_process_port_create src/nxt_runtime.c:2028
```

Also on this branch: `./build/tests` passes (exit 0, including the new
`port use_unless_zero test`), and `test_process_abrupt_teardown.py`,
`test_process_teardown_churn.py`, `test_respawn.py`, `test_php_application.py`
and `test_conn_recycle.py` are unchanged from master.

## Not in scope

Two adjacent unlocked reads of `process->ports` are left alone, deliberately, to
keep this change to the defect in the issue: the walk inside
`nxt_port_broadcast_shm_ack()` (guarding it would mean holding
`rt->processes_mutex` across `nxt_port_socket_write()`, which takes
`port->write_mutex` and would cost the mutex its leaf property), and the insert
in `nxt_process_port_add()`, which runs on the main thread only.

## Drafted CHANGES entry

```
    *) Bugfix: a router worker engine could take a reference on an
       application port that the main thread had already released, when a
       worker blocked waiting for shared memory was killed under load. The
       shared memory acknowledgement looked the port up in the process' port
       list without a lock; the router aborted on an assertion in a debug
       build, and used freed memory in a release one.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
