### PR TITLE
router: fail the start RPC when the prototype dies

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -182,6 +182,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_start_fail_test.c \
     src/test/nxt_router_start_fail_soak_test.c \
     src/test/nxt_router_proto_wedge_test.c \
+    src/test/nxt_router_proto_death_test.c \
     src/test/nxt_router_remove_pid_soak_test.c \
     src/test/nxt_main_start_process_reply_test.c \
     src/test/nxt_port_change_file_test.c \

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -478,6 +478,29 @@ nxt_router_start_app_process_handler(nxt_task_t *task, nxt_port_t *port,
     app_joint_rpc->generation = app->generation;
     app_joint_rpc->proto = (b != NULL);
 
+    /*
+     * Key the registration by the process the START_PROCESS was sent to, so
+     * that its death retires the RPC.  Without a peer the registration is
+     * only ever retired by a reply on its own stream: when the prototype
+     * dies between forking the worker and that worker's PROCESS_READY, the
+     * REMOVE_PID the router gets for the prototype carries no stream (it
+     * had already reached READY itself, see nxt_main_process.c) and
+     * nxt_port_rpc_remove_peer() finds nothing to fail, so the attempt's
+     * pending_processes slot is never given back.  With spare 0 that alone
+     * exceeds max_pending_processes, nxt_router_app_can_start() stays false
+     * for good, and no later request can even ask for a new prototype --
+     * only the start handler does that, and it is what can_start gates.
+     *
+     * With the peer set, nxt_port_rpc_remove_peer() runs
+     * nxt_router_app_port_error() exactly once (it clears ->peer, deletes
+     * the stream and frees the registration), which releases the slot and
+     * fails the ack-waiting requests when no process is left.  For a
+     * prototype start the peer is the main process, which is harmless: its
+     * death is fatal anyway, and a prototype dying before READY is already
+     * reported by the stream-bearing REMOVE_PID.
+     */
+    nxt_port_rpc_ex_set_peer(task, port, app_joint_rpc, dport->pid);
+
     if (b != NULL) {
         app->proto_port_requests++;
 
@@ -1217,14 +1240,6 @@ out_free_mp:
     nxt_mp_destroy(mp);
 
     return NULL;
-}
-
-
-nxt_inline nxt_bool_t
-nxt_router_app_can_start(nxt_app_t *app)
-{
-    return app->processes + app->pending_processes < app->max_processes
-            && app->pending_processes < app->max_pending_processes;
 }
 
 

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -159,6 +159,22 @@ struct nxt_app_s {
 };
 
 
+/*
+ * The gate on every application start.  It lives here rather than in
+ * src/nxt_router.c so that the regression tests which turn on it -- the ones
+ * for the pending_processes accounting, #214 and #269 -- can call the very
+ * predicate the router uses instead of keeping a copy that silently drifts
+ * from it.
+ */
+
+nxt_inline nxt_bool_t
+nxt_router_app_can_start(nxt_app_t *app)
+{
+    return app->processes + app->pending_processes < app->max_processes
+            && app->pending_processes < app->max_pending_processes;
+}
+
+
 typedef struct {
     size_t                 max_frame_size;
     nxt_msec_t             read_timeout;

--- a/src/test/nxt_router_proto_death_test.c
+++ b/src/test/nxt_router_proto_death_test.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for issue #269: a prototype that dies between forking a
+ * worker and that worker's PROCESS_READY strands the router's on-demand
+ * START_PROCESS registration.
+ *
+ * The router hears about the death as a REMOVE_PID for the prototype.  That
+ * message carries no stream once the prototype itself has reached READY
+ * (src/nxt_main_process.c:1200), so the only thing left that can retire the
+ * armed RPC is nxt_port_rpc_remove_peer() (src/nxt_port.c:1067) -- and it
+ * retires registrations by peer.  nxt_router_start_app_process_handler()
+ * used to arm its registration with no peer at all, so the sweep found
+ * nothing, the attempt's pending_processes slot was never given back, and
+ * with "processes: {spare: 0}" (max_pending_processes 1)
+ * nxt_router_app_can_start() stayed false for the router's lifetime: every
+ * later request parked in ack_waiting_req and no replacement prototype was
+ * ever asked for, because only the start handler asks for one and can_start
+ * is what gates it.
+ *
+ * This is the sibling of src/test/nxt_router_proto_wedge_test.c, which
+ * covers the prototype-start branch retired through nxt_port_rpc_close().
+ * Here the application already has a prototype, so the handler takes the
+ * plain app-start branch, and the RPC is retired the way the real
+ * REMOVE_PID does it: by peer.  Before the fix the sweep is a no-op and the
+ * checks below fail; after it the sweep runs nxt_router_app_port_error()
+ * exactly once, the slot comes back, and the application is startable again.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_rpc.h>
+#include <nxt_runtime.h>
+#include <nxt_router.h>
+#include <nxt_event_engine.h>
+#include "nxt_tests.h"
+
+
+/* File scope: the handler hands the application to the router's
+   reference-counting helpers, so its storage must outlive the frame. */
+static nxt_app_t  nxt_router_proto_death_test_app;
+
+
+nxt_int_t
+nxt_router_proto_death_test(nxt_thread_t *thr)
+{
+    nxt_mp_t            *mp;
+    nxt_app_t           *app;
+    nxt_int_t           ret;
+    nxt_bool_t          app_mutex;
+    nxt_task_t          *task;
+    nxt_port_t          *router_port, *proto_port;
+    nxt_runtime_t       *rt, *saved_rt;
+    nxt_app_joint_t     *joint;
+    nxt_event_engine_t  engine, *saved_engine;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                  "router proto death test started");
+
+    ret = NXT_ERROR;
+    router_port = NULL;
+    proto_port = NULL;
+    joint = NULL;
+    app_mutex = 0;
+    app = &nxt_router_proto_death_test_app;
+
+    task = thr->task;
+    task->thread = thr;
+
+    if (nxt_slow_path(nxt_port_rpc_init() != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    joint = nxt_mp_zalloc(mp, sizeof(nxt_app_joint_t));
+    if (nxt_slow_path(rt == NULL || joint == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    /*
+     * Only the members the reached code touches are set; see
+     * src/test/nxt_router_new_port_test.c.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+    thr->runtime = rt;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    /* The port the handler registers its RPC on. */
+
+    router_port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    /*
+     * nxt_port_rpc_register_handler_ex() asserts on a live pair[0]; the
+     * descriptor is never touched here, so borrow the nxt_port_fail_test()
+     * convention of a placeholder that is reset before the port is freed.
+     */
+    router_port->pair[0] = 0;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    /*
+     * The prototype the START_PROCESS is written to, and whose pid the
+     * REMOVE_PID sweep is driven with.  No queue and write_ready unset, so
+     * nxt_port_socket_write2() takes the nxt_port_msg_chk_insert() path and
+     * the message is simply queued: the write succeeds and the RPC stays
+     * armed, which is what this test needs.
+     *
+     * The port's pid is the running process, as everywhere in these
+     * fixtures; the sweep only ever compares it with the value the handler
+     * recorded as the registration's peer.
+     */
+
+    proto_port = nxt_port_new(task, 1, nxt_pid, NXT_PROCESS_PROTOTYPE);
+    if (nxt_slow_path(proto_port == NULL)) {
+        goto done;
+    }
+
+    proto_port->pair[0] = -1;
+    proto_port->pair[1] = -1;
+    proto_port->socket.fd = -1;
+
+    nxt_memzero(app, sizeof(nxt_app_t));
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&app->mutex) != NXT_OK)) {
+        goto done;
+    }
+
+    app_mutex = 1;
+
+    nxt_queue_init(&app->ports);
+    nxt_queue_init(&app->spare_ports);
+    nxt_queue_init(&app->idle_ports);
+    nxt_queue_init(&app->ack_waiting_req);
+
+    nxt_str_set(&app->name, "proto-death-test");
+
+    app->joint = joint;
+    joint->app = app;
+    joint->use_count = 1;
+
+    /*
+     * "processes: {spare: 0}" -- max_pending_processes is 1, so a single
+     * stranded slot is enough to wedge the application for good.
+     */
+    app->max_processes = 8;
+    app->max_pending_processes = 1;
+
+    /* A live prototype, so the handler takes the plain app-start branch. */
+    app->proto_port = proto_port;
+    app->conf.length = 0;
+
+    /* One process alive, so the failure path has no requests to fail. */
+    app->processes = 1;
+
+    /* What a real initiator leaves behind: the slot and the work's use. */
+    app->pending_processes = 1;
+    app->use_count = 2;
+
+    nxt_router_start_app_process_handler(task, router_port, app);
+
+    if (app->pending_processes != 1 || joint->use_count != 2
+        || app->use_count != 1)
+    {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto death test: successful start left "
+                      "pending %uD joint %uD app use %d (expected 1, 2 and 1)",
+                      app->pending_processes, joint->use_count,
+                      (int) app->use_count);
+        goto done;
+    }
+
+    /*
+     * The prototype dies with the worker it forked not yet ready.  This is
+     * exactly what nxt_router_remove_pid_handler() does with the streamless
+     * REMOVE_PID that reports it.
+     */
+
+    nxt_port_rpc_remove_peer(task, router_port, proto_port->pid);
+
+    if (app->pending_processes != 0 || joint->use_count != 1) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto death test: prototype death left pending "
+                      "%uD joint %uD (expected 0 and 1) -- the start RPC was "
+                      "not retired", app->pending_processes,
+                      joint->use_count);
+        goto done;
+    }
+
+    /*
+     * The gate #269 wedges: with the slot back the application can ask for
+     * a replacement prototype on the next request.
+     */
+
+    app->processes = 0;
+
+    if (!nxt_router_app_can_start(app)) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto death test: app cannot start after the "
+                      "prototype's death, processes %uD pending %uD",
+                      app->processes, app->pending_processes);
+        goto done;
+    }
+
+    /*
+     * And the death is reported exactly once: a second sweep for the same
+     * pid, which a REMOVE_PID for an already-forgotten process would drive,
+     * must find nothing left to fail rather than release a second slot.
+     */
+
+    app->pending_processes = 1;
+
+    nxt_port_rpc_remove_peer(task, router_port, proto_port->pid);
+
+    if (app->pending_processes != 1 || joint->use_count != 1) {
+        nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                      "router proto death test: repeated sweep left pending "
+                      "%uD joint %uD (expected 1 and 1)",
+                      app->pending_processes, joint->use_count);
+        goto done;
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "router proto death test passed");
+
+    ret = NXT_OK;
+
+done:
+
+    if (proto_port != NULL) {
+        /*
+         * The start above was queued rather than written, and
+         * nxt_port_msg_chk_insert() takes a port reference for every queued
+         * message.  Left alone the port never reaches nxt_port_mp_cleanup(),
+         * so its pool and messages leak and the assertions there never run
+         * -- which would quietly hollow out this test under a debug build.
+         */
+        nxt_port_test_run_error_handler(task, proto_port);
+
+        if (!nxt_queue_is_empty(&proto_port->messages)) {
+            nxt_log_error(NXT_LOG_NOTICE, thr->log,
+                          "router proto death test: prototype port still "
+                          "holds queued messages after teardown");
+            ret = NXT_ERROR;
+        }
+
+        nxt_port_use(task, proto_port, -1);
+    }
+
+    if (router_port != NULL) {
+        router_port->pair[0] = -1;
+
+        nxt_port_use(task, router_port, -1);
+    }
+
+    thr->engine = saved_engine;
+    thr->runtime = saved_rt;
+
+    if (app_mutex) {
+        nxt_thread_mutex_destroy(&app->mutex);
+    }
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}

--- a/src/test/nxt_router_start_fail_soak_test.c
+++ b/src/test/nxt_router_start_fail_soak_test.c
@@ -45,21 +45,6 @@
 static nxt_app_t  nxt_router_start_fail_soak_test_app;
 
 
-/*
- * Mirrors the nxt_inline nxt_router_app_can_start() predicate in
- * src/nxt_router.c:1218.  Being nxt_inline, the gate #214 wedges is private
- * to the router's translation unit and cannot be called from here, so this
- * copy must be kept in sync with it.
- */
-
-static nxt_bool_t
-nxt_router_start_fail_soak_can_start(nxt_app_t *app)
-{
-    return app->processes + app->pending_processes < app->max_processes
-           && app->pending_processes < app->max_pending_processes;
-}
-
-
 nxt_int_t
 nxt_router_start_fail_soak_test(nxt_thread_t *thr)
 {
@@ -255,7 +240,7 @@ nxt_router_start_fail_soak_test(nxt_thread_t *thr)
     app->conf.length = 0;
     app->proto_port = dport;
 
-    if (!nxt_router_start_fail_soak_can_start(app)) {
+    if (!nxt_router_app_can_start(app)) {
         nxt_log_error(NXT_LOG_NOTICE, thr->log,
                       "router start fail soak test: app cannot start after "
                       "%d failures, processes %uD pending %uD",

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -213,6 +213,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_router_proto_death_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_router_remove_pid_soak_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -77,6 +77,7 @@ nxt_int_t nxt_router_new_port_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_start_fail_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_proto_wedge_test(nxt_thread_t *thr);
+nxt_int_t nxt_router_proto_death_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_remove_pid_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_main_start_process_reply_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);

--- a/test/python/slow_start/wsgi.py
+++ b/test/python/slow_start/wsgi.py
@@ -1,0 +1,16 @@
+import os
+import time
+
+# Widen the window between the worker's PROCESS_CREATED and its PROCESS_READY,
+# which is what test_python_prototype_killed_mid_start() kills the prototype
+# inside of.  The delay is at import time, before `application` is even
+# defined: nxt_python_start() imports the module and only then sends READY
+# (src/python/nxt_python.c), so a sleep here lands squarely in that window,
+# while a sleep inside application() would not -- the process is ready long
+# before a request arrives.
+time.sleep(float(os.environ.get('UNIT_SLOW_START', '4')))
+
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Length', '0')])
+    return []

--- a/test/test_python_application.py
+++ b/test/test_python_application.py
@@ -4,6 +4,7 @@ import os
 import pwd
 import re
 import subprocess
+import threading
 import time
 import venv
 
@@ -1052,3 +1053,172 @@ def test_python_application_upload_multiple_files():
     )
     assert resp['status'] == 200, 'multiple files status'
     assert resp['body'] == 'first.txtfirst data', 'multiple files body'
+
+
+def _ps_rows():
+    out = subprocess.check_output(
+        ['ps', 'ax', '-o', 'pid=', '-o', 'ppid=', '-o', 'args=']
+    ).decode()
+
+    return [
+        parts
+        for parts in (line.split(None, 2) for line in out.splitlines())
+        if len(parts) == 3
+    ]
+
+
+def _proto_pid(name):
+    """The pid of the application's prototype process, or None.
+
+    `unit: "<name>" prototype` is the title nxt_main_process.c gives it, and
+    unlike a worker's title it survives for every runtime -- the prototype
+    never execve()s.  Matched on the whole ps line for the same reason
+    test_app_lifecycle.py does.
+    """
+
+    marker = f'unit: "{name}" prototype'
+
+    for pid, _, args in _ps_rows():
+        if marker in args:
+            return pid
+
+    return None
+
+
+def _child_pids(ppid):
+    return [pid for pid, parent, _ in _ps_rows() if parent == ppid]
+
+
+def test_python_prototype_killed_mid_start(skip_alert, findall):
+    """Issue #269: a prototype killed between forking a worker and that
+    worker's PROCESS_READY must not strand the router's START_PROCESS.
+
+    The router takes an app->pending_processes slot before posting
+    nxt_router_start_app_process_handler(), which arms an RPC on the router
+    port and sends START_PROCESS to the prototype.  The reply that would
+    retire it -- the worker's READY, forwarded by the prototype -- can never
+    arrive once the prototype is dead, and the REMOVE_PID that reports the
+    death carries no stream for a prototype that had itself reached READY.
+    Only a peer-keyed registration is retired by that message.  Without one
+    the slot is never given back; with "spare": 0 that is the whole of
+    max_pending_processes, so nxt_router_app_can_start() is false for good,
+    every later request parks in ack_waiting_req with no timeout, and no
+    replacement prototype is ever requested -- the start handler is the only
+    thing that asks, and it is what can_start gates.  The wedge is permanent
+    and survives a reload that leaves the app's config text unchanged.
+
+    So the assertions are: the in-flight request is answered rather than
+    hung, /status shows the slot back at zero, and the next request gets a
+    fresh prototype and a 200.  On the unfixed router the first of those
+    never returns, which is why every wait here is bounded.
+
+    The app module sleeps in its *import* (test/python/slow_start/wsgi.py),
+    which is what widens the PROCESS_CREATED -> READY window enough to aim
+    at.  A kill that lands outside the window makes the test skip rather
+    than assert something it did not drive.
+    """
+
+    client.load(
+        'slow_start',
+        processes={'max': 2, 'spare': 0, 'idle_timeout': 1},
+        environment={'UNIT_SLOW_START': '4'},
+    )
+
+    resp = []
+
+    def _request():
+        try:
+            # Bounded: on the unfixed router this request is never answered,
+            # and a thread stuck in recv() would outlive the test.
+            resp.append(client.get(read_timeout=20)['status'])
+
+        except Exception as exc:  # noqa: BLE001 - reported as a failure below
+            resp.append(repr(exc))
+
+    thread = threading.Thread(target=_request)
+    thread.start()
+
+    try:
+        # The prototype appears as soon as main forks it; the worker it then
+        # forks spends the next 4s importing the module.
+        deadline = time.time() + 10
+        pid = None
+
+        while time.time() < deadline:
+            pid = _proto_pid('slow_start')
+
+            if pid is not None:
+                break
+
+            time.sleep(0.1)
+
+        assert pid is not None, 'prototype never started'
+
+        # Wait for the worker to exist: killing the prototype before it has
+        # forked would carry the original start stream and let an unfixed
+        # router pass this test by the other route.  Then a short pause puts
+        # the worker mid-import: past PROCESS_CREATED, well before READY.
+        workers = []
+        for _ in range(100):
+            workers = _child_pids(pid)
+            if workers:
+                break
+            time.sleep(0.05)
+
+        assert workers, 'the prototype never forked a worker'
+
+        time.sleep(0.3)
+
+        # The worker is still importing the module.  Its own teardown noise
+        # is scoped to its pid below rather than skipped by shape, so an
+        # alert from any other process still fails the test.
+
+        subprocess.call(['kill', '-9', pid])
+        skip_alert(fr'process {pid} exited on signal 9')
+
+        for worker in workers:
+            # Orphaned by the kill, the worker finishes its import and then
+            # writes READY into the dead prototype's socket, which is EPIPE,
+            # and unwinds closing descriptors it inherited from the
+            # prototype -- which the kill already closed.  All of that is
+            # the pre-existing consequence of killing a prototype, not
+            # something this test's subject produces; it happens on the
+            # unfixed router too.
+            skip_alert(fr'\b{worker}#{worker} ')
+
+        # The kill retires the start RPC, which releases the slot and -- no
+        # process being left -- fails the waiting request instead of letting
+        # it sit forever.
+        thread.join(timeout=25)
+
+    finally:
+        if thread.is_alive():
+            # Do not leave a thread blocked in recv() behind; the assertion
+            # below reports the wedge.
+            thread.join(timeout=10)
+
+    assert not thread.is_alive(), (
+        'the in-flight request never completed: the start RPC was stranded'
+    )
+    assert resp == [503], f'in-flight request: {resp}'
+
+    # The slot is back, so the application is startable again.
+    deadline = time.time() + 10
+    starting = None
+
+    while time.time() < deadline:
+        starting = client.conf_get('/status')['applications']['slow_start'][
+            'processes'
+        ]['starting']
+
+        if starting == 0:
+            break
+
+        time.sleep(0.2)
+
+    assert starting == 0, f'processes.starting stuck at {starting}'
+
+    # And the next request gets a brand new prototype and is served.
+    assert client.get(read_timeout=30)['status'] == 200, 'recovered'
+    assert _proto_pid('slow_start') not in (None, pid), 'fresh prototype'
+    assert findall(fr'process {pid} exited on signal 9'), 'kill logged'


### PR DESCRIPTION
## The wedge

`nxt_router_start_app_process_handler()` (`src/nxt_router.c:401`) arms an RPC on
the router's own port and sends `START_PROCESS` to the application's prototype
(`:469`). It armed that registration with **no peer**, so the only thing that
could ever retire it was a reply on its own stream — the worker's
`PROCESS_READY`, forwarded by the prototype as `NEW_PORT`.

A prototype that dies **after forking the worker and before that worker's
READY** makes such a reply impossible, and nothing else retires the
registration:

- the router is told by `REMOVE_PID`, and that message carries **no stream**
  for a prototype which had itself reached READY
  (`src/nxt_main_process.c:1200`), so the `RPC_ERROR` branch in
  `nxt_router_remove_pid_handler()` (`src/nxt_port.c:1126`) does not fire;
- the sweep that runs instead, `nxt_port_rpc_remove_peer()`
  (`src/nxt_port.c:1067`), retires registrations **by peer** and found none —
  the debug log says `rpc: no reg found for peer <proto pid>`;
- `nxt_port_rpc_close()` (`src/nxt_port_rpc.c:548`) runs for the *prototype's*
  port, a different table;
- the orphaned worker is reparented to init, its READY write fails with
  `Broken pipe` and it exits.

So `app->pending_processes` keeps the attempt's slot. With
`"processes": {"spare": 0}` that one slot is the whole of
`max_pending_processes` (`:2061`), so `nxt_router_app_can_start()` (`:1226`) is
false for the router's lifetime. Every later request joins `ack_waiting_req`,
where nothing times it out (an application's `timeout` defaults to 0), and **no
replacement prototype is ever asked for** — the start handler is the only thing
that asks (`:428`), and it is what `can_start` gates. Only replacing the
application's configuration text recovers; a reload that leaves it unchanged
reuses the wedged `nxt_app_t`.

Reproduced on master with `--debug`, an app module that sleeps 4 s in its
import, `processes: {max: 2, spare: 0}`, and a `kill -9` on the prototype
~1.5 s into the first request:

```
[alert] process 3106 exited on signal 9
[alert] 3107 [unit] sendmsg(15, 16) failed: Broken pipe / failed to send READY
[debug] rpc: stream #7 registered      <- the on-demand START_PROCESS
[debug] port remove pid 3106 handler
[debug] rpc: no reg found for peer 3106  <- no peer, not retired
A: http=000 after 12s   status: processes {running:0, starting:1}, requests {active:1}
B: http=000 after 15s   status: starting:1, active:2
```

`starting` never returns to 0 and no request is ever answered again.

## The fix

Key the registration by the process the `START_PROCESS` was sent to:

```c
nxt_port_rpc_ex_set_peer(task, port, app_joint_rpc, dport->pid);
```

This mirrors the prefork site at `:3355`, which has keyed its registration by
peer all along. The `REMOVE_PID` sweep then runs `nxt_router_app_port_error()`
(`:5054`) **exactly once** — `nxt_port_rpc_remove_peer()` clears the peer,
deletes the stream and frees the registration (`src/nxt_port_rpc.c:486`) —
which releases the slot through `nxt_router_app_start_failed()` (the accounting
added in 2906191e) and, when no process is left to answer, fails the
ack-waiting requests with **503** instead of letting them hang. When a live
worker remains, the waiting requests stay queued and it serves them. The next
request re-enters the start handler and asks main for a fresh prototype.

For a *prototype* start (`proto = 1`) the peer is the main process, which is
harmless: main's death is fatal to the daemon anyway, and a prototype that dies
before its own READY is already reported by the stream-bearing `REMOVE_PID`.

A straggler `NEW_PORT` on the retired stream hits "no handler found"
(`src/nxt_port_rpc.c:388`) and is dropped — the same stream-reuse caveat #268
and #280 already document.

## Relation to the rest of the class

- **#268** (`application: report a worker that dies before it is created`) is
  the other half of this class: a worker that dies *before* `PROCESS_CREATED`,
  reported by the prototype's own reaper. Its `RPC_ERROR` is sent by a *live*
  prototype for a dead child, so it cannot fire in this scenario, and this
  change cannot fire in that one. Independent, and they compose.
- **#280** (optional `start_timeout`) does not fix this on its own —
  `NXT_APP_START_TIMEOUT` defaults to 0 — and its timer is cancelled inside
  `port_ready`/`port_error`, so peer-retirement cancels it too.
- The prototype reaper is untouched.

`git merge-tree --write-tree --merge-base=origin/master` against both:

| against | result |
|---|---|
| #268 (`5725d870`) | clean |
| #280 (`9caf38e7`) | `src/nxt_router.c` merges **clean**; conflicts only in `auto/sources`, `src/test/nxt_tests.c`, `src/test/nxt_tests.h` — both branches append a new C test at the same anchor. Textual, one-line each. |

The other wave-2 branch, `fix/proto-start-sender-and-stream` (#270/#271), does
not touch `src/nxt_router.c` at all.

## Verified

php:8.4-cli-trixie, `--debug --tests`, python + php modules, same tree built
twice with only `src/nxt_router.c` differing:

| | master | branch |
|---|---|---|
| `./build/tests` | `router proto death test: prototype death left pending 1 joint 2 (expected 0 and 1) -- the start RPC was not retired` | all pass, exit 0 |
| `test_python_prototype_killed_mid_start` | **fail** in 80 s: the in-flight request is never answered, and the router is left leaking 6 descriptors | **pass** in 5.8 s, 5/5 runs |
| `test_python_application.py test_php_application.py test_configuration.py` | | 125 passed, 12 skipped |

The two runs differ by exactly one log line in the kill window (prototype 32
killed 307 ms after its worker was forked, ~3.7 s before that worker's READY):

```
master:  port remove pid 32 handler
         rpc: no reg found for peer 32          <- nothing retired; wedged
branch:  port remove pid 32 handler
         app 'slow_start' start error           <- retired via the peer
         app 'slow_start' start prototype process   <- 5 ms later, a fresh one
```

`nxt_router_remove_pid_soak_test` (#231, the *stream-bearing* `REMOVE_PID`
route) still passes its 1000 iterations on the branch: adding a peer to those
same registrations does not double-release when that route fires first.

The killed prototype leaves its orphaned worker writing READY into a dead
socket and closing descriptors the kill already closed, which is a handful of
`[alert]` lines from that worker. That is pre-existing -- it happens on the
unfixed router too -- so the test skips those alerts *scoped to the worker's
pid* rather than by shape.

## Tests

- `src/test/nxt_router_proto_death_test.c` — the sibling of
  `nxt_router_proto_wedge_test.c`. Drives the handler through a start that
  succeeds, then the peer sweep the real `REMOVE_PID` performs, and requires
  the `pending_processes` slot back, the joint reference back, and the
  application startable again; a repeated sweep must release nothing further.
  Fails on master.
- `test_python_prototype_killed_mid_start()` — `kill -9`s the prototype during
  a worker's module import (`test/python/slow_start/wsgi.py`) and requires the
  in-flight request answered with 503, `/status`'s `processes.starting` back at
  0, and the next request served by a **new** prototype. On master the first
  assertion never returns, so every wait is bounded.

## CHANGES

```
    *) Bugfix: an application could stop starting processes for good if its
       prototype died between forking a worker and that worker becoming
       ready; requests to the application then hung instead of failing, and
       no replacement prototype was ever started. Together with the fix for
       a worker that dies before it is created, this closes both halves of
       the class of start attempts that could never be reported back.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
