### PR TITLE
Authenticate the prototype's START_PROCESS, and retire a start stream on its reply

### DIFF
--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -619,6 +619,90 @@ nxt_proto_start(nxt_task_t *task, nxt_process_data_t *data)
 }
 
 
+#if (NXT_USE_CMSG_PID)
+
+/*
+ * Is the kernel-validated sender of this START_PROCESS allowed to make the
+ * prototype fork a worker?
+ *
+ * Only the router ever sends one (nxt_router_start_app_process_handler(),
+ * src/nxt_router.c:469, and nxt_router_app_prefork(), :3379), but every
+ * worker the prototype forks inherits the write end of the prototype's own
+ * port socket -- nxt_proc_keep_matrix[] does not list it, and
+ * nxt_process_close_ports() keeps the parent's port unconditionally -- and
+ * nxt_port_handler() dispatches on the wire type alone.  So without this
+ * test one compromised worker can spend the prototype's process budget, and,
+ * once #268 has the prototype answer for a child that dies, drive the
+ * router's start bookkeeping from the inside.
+ *
+ * The test has two arms because the prototype has two pid views of the
+ * router, and the credential the kernel writes is always relative to the
+ * receiver's pid namespace:
+ *
+ *  - Sharing main's namespace, the router is an ordinary visible process and
+ *    the credential is its global pid, which is what the inherited
+ *    rt->port_by_type[NXT_PROCESS_ROUTER] is keyed on.  This is the same
+ *    whitelist nxt_main_start_process_handler() applies
+ *    (src/nxt_main_process.c:532).
+ *
+ *  - Under "isolation": {"namespaces": {"pid": true}} the prototype is the
+ *    init of its own namespace (nxt_process.c:765) and the router lives in
+ *    an ancestor of it, so the router has no pid there at all: the kernel
+ *    translates an untranslatable sender to 0 (pid_vnr() returns 0 outside
+ *    the receiver's namespace; measured, not assumed).  Comparing against
+ *    the router's global pid would then refuse every legitimate start.  A
+ *    credential of 0 is therefore what "from outside this namespace" looks
+ *    like, and it is exactly the set the prototype does not fork: its
+ *    workers are forked with no clone flags of their own
+ *    (nxt_proto_start_process_handler() leaves process->isolation zeroed),
+ *    so each of them is inside this namespace and presents a non-zero
+ *    namespace-local pid.  What this arm authenticates is therefore a
+ *    namespace boundary, not an identity: it admits every holder of the
+ *    write end that sits outside this namespace.  By construction that is
+ *    main and the router (nxt_proc_keep_matrix[] keeps only those two in a
+ *    worker, and nxt_proc_send_matrix[] lets the prototype answer only
+ *    those two); main is trusted and does not send START_PROCESS.  A worker
+ *    that passes its inherited port out of the namespace over SCM_RIGHTS
+ *    turns an accomplice into an admitted sender, which needs a second
+ *    foothold and is the limit of what a credential can decide here.
+ *
+ * The reply addressing at "failed:" is deliberately left keyed on
+ * msg->port_msg.pid: the runtime port hash is keyed on the global pid, which
+ * in the isolated arm is precisely the number the credential cannot supply.
+ * That is why a refused message is not answered at all -- answering it would
+ * let the forger name any port and stream it likes and have the prototype
+ * cancel somebody else's RPC.  A forgery strands nothing: the router never
+ * armed an RPC for a message it did not send.  A genuine start refused by
+ * the router-port-is-NULL branch would be a different matter -- the router's
+ * RPC is keyed on the prototype (nxt_port_rpc_ex_set_peer(), src/nxt_router.c),
+ * so it would stay armed until the prototype dies -- but that branch is
+ * reachable only once the router is already gone, and a restarted router
+ * cannot address a pre-existing prototype at all: nxt_port_send_new_port()
+ * announces a newcomer outward and never announces existing peers to it.
+ */
+static nxt_bool_t
+nxt_proto_start_process_sender_ok(nxt_task_t *task, nxt_runtime_t *rt,
+    nxt_port_recv_msg_t *msg)
+{
+    nxt_port_t  *router_port;
+
+    if (rt->is_pid_isolated) {
+        return nxt_recv_msg_cmsg_pid(msg) == 0;
+    }
+
+    router_port = rt->port_by_type[NXT_PROCESS_ROUTER];
+
+    if (nxt_slow_path(router_port == NULL)) {
+        nxt_alert(task, "router port not found");
+        return 0;
+    }
+
+    return nxt_recv_msg_cmsg_pid(msg) == router_port->pid;
+}
+
+#endif
+
+
 static void
 nxt_proto_start_process_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 {
@@ -630,6 +714,27 @@ nxt_proto_start_process_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_process_init_t  *init;
 
     rt = task->thread->runtime;
+
+#if (NXT_USE_CMSG_PID)
+    /*
+     * Before anything is allocated or forked, and without a reply: see
+     * nxt_proto_start_process_sender_ok().  The descriptors are closed here
+     * because this handler owns whatever the message carried -- the port
+     * read loop does not reclaim them (src/nxt_port_socket.c:1381).  The
+     * router's own START_PROCESS to a prototype carries none (both fds are
+     * -1 at src/nxt_router.c:469 and :3379; the shared port and queue only
+     * travel in the one it sends main), so this is for what a forger
+     * attaches, not for anything a legitimate message brings.
+     */
+    if (nxt_slow_path(!nxt_proto_start_process_sender_ok(task, rt, msg))) {
+        nxt_alert(task, "process %PI cannot start processes",
+                  nxt_recv_msg_cmsg_pid(msg));
+
+        nxt_port_recv_msg_close_fds(msg);
+
+        return;
+    }
+#endif
 
     process = nxt_process_new(rt);
     if (nxt_slow_path(process == NULL)) {
@@ -694,6 +799,18 @@ failed:
                               -1, msg->port_msg.stream, 0, NULL);
     }
 }
+
+
+#if (NXT_TESTS)
+
+void
+nxt_proto_test_run_start_process_handler(nxt_task_t *task,
+    nxt_port_recv_msg_t *msg)
+{
+    nxt_proto_start_process_handler(task, msg);
+}
+
+#endif
 
 
 static void

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -167,6 +167,15 @@ struct nxt_app_module_s {
 nxt_app_lang_module_t *nxt_app_lang_module(nxt_runtime_t *rt, nxt_str_t *name);
 nxt_app_type_t nxt_app_parse_type(u_char *p, size_t length);
 
+#if (NXT_TESTS)
+/*
+ * Invokes the static nxt_proto_start_process_handler() with a synthesised
+ * runtime and message; see src/test/nxt_main_start_process_reply_test.c.
+ */
+void nxt_proto_test_run_start_process_handler(nxt_task_t *task,
+    nxt_port_recv_msg_t *msg);
+#endif
+
 NXT_EXPORT extern nxt_str_t  nxt_server;
 extern nxt_app_module_t      nxt_external_module;
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -1197,9 +1197,15 @@ nxt_main_process_sigchld_handler(nxt_task_t *task, void *obj, void *data)
         if (process != NULL) {
             nxt_main_process_cleanup(task, process);
 
-            if (process->state == NXT_PROCESS_STATE_READY) {
-                process->stream = 0;
-            }
+            /*
+             * ->stream is no longer cleared here.  It is cleared where the
+             * start RPC is actually answered -- on a successful NEW_PORT
+             * announcement in nxt_port_process_ready_handler() -- which is
+             * both earlier and narrower: the READY state is set before that
+             * announcement is written, so clearing on the state dropped the
+             * REMOVE_PID fallback for a start whose reply never went out.
+             * See issue #271.
+             */
 
             nxt_queue_init(&children);
 

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -251,8 +251,9 @@ nxt_port_enable(nxt_task_t *task, nxt_port_t *port,
  * nxt_port_socket.c fill msg->cmsg_pid.  Individual handlers are
  * being gated on nxt_recv_msg_cmsg_pid() one at a time --
  * nxt_main_process_created_handler(), nxt_main_start_process_handler(),
- * nxt_port_process_ready_handler(), nxt_proto_process_created_handler()
- * and the cert/script/socket/access-log handlers already are.
+ * nxt_port_process_ready_handler(), nxt_proto_process_created_handler(),
+ * nxt_proto_start_process_handler() and the cert/script/socket/
+ * access-log handlers already are.
  *
  * What is left is the table-driven part: a per-message-type sender
  * ACL applied here, in the dispatcher, so that a handler which

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -311,11 +311,54 @@ nxt_port_quit_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 }
 
 
+/*
+ * Announce a port to every peer the send matrix pairs it with, carrying
+ * "stream" so that the announcement doubles as the reply to the start RPC
+ * the initiator armed.
+ *
+ * Returns NXT_OK when the announcement that answers that RPC was accepted
+ * for delivery, so that the caller can read it as "the start has been
+ * answered".
+ *
+ * That is the announcement addressed to the router, and only that one.  The
+ * router owns the registration for every start: it registers the RPC on its
+ * own port and then sends START_PROCESS elsewhere -- to main when a
+ * prototype has to be forked and to the prototype when a worker has, but the
+ * handler is armed on the router port in both cases
+ * (nxt_router_start_app_process_handler() registers on the router port it
+ * was called with, src/nxt_router.c:5069 and :459;
+ * nxt_router_app_prefork() on rt->port_by_type[NXT_PROCESS_ROUTER],
+ * src/nxt_router.c:3365).  Main forks the prototype but never owns the RPC
+ * for it.  nxt_router_new_port_handler() then feeds a stream-bearing
+ * NEW_PORT to nxt_port_rpc_handler() (src/nxt_router.c:788-791), which is
+ * what retires the registration -- when it gets that far.  NXT_OK here means
+ * the announcement was queued for the router, not that the router acted on
+ * it: nxt_router_new_port_handler() returns at src/nxt_router.c:782 when it
+ * cannot map the new port's queue, walking past the RPC dispatch and leaving
+ * the start outstanding.  Retiring the stream on a queued write is therefore
+ * the best answer available here and not a guarantee; issue #223 is where
+ * the router learns to fail the start it refused.
+ *
+ * Aggregating every peer instead would be wrong in the direction that costs
+ * correctness: when the prototype announces a worker it writes to main as
+ * well as to the router, and a failure to main with the router's write
+ * accepted would keep a stream the router has already retired -- exactly the
+ * wrapped-counter hazard the caller clears it to avoid.  A failed write to
+ * any other peer is logged and does not change the answer; it is a delivery
+ * problem for that peer, not evidence about the start.
+ *
+ * With no router peer at all there is nothing to report on and NXT_OK is the
+ * honest answer: an initiator that is not in this runtime has no
+ * registration here to keep alive for.  That is the boot-time shape, where
+ * main announces the core processes with stream 0 and clearing is a no-op.
+ */
+
 /* TODO join with process_ready and move to nxt_main_process.c */
-nxt_inline void
+nxt_inline nxt_int_t
 nxt_port_send_new_port(nxt_task_t *task, nxt_runtime_t *rt,
     nxt_port_t *new_port, uint32_t stream)
 {
+    nxt_int_t      ret;
     nxt_port_t     *port;
     nxt_process_t  *process;
 
@@ -326,19 +369,36 @@ nxt_port_send_new_port(nxt_task_t *task, nxt_runtime_t *rt,
     nxt_debug(task, "new port %d for process %PI",
               new_port->pair[1], new_port->pid);
 
+    ret = NXT_OK;
+
     nxt_runtime_process_each(rt, process) {
 
-        if (process->pid == new_port->pid || process->pid == nxt_pid) {
+        if (process->pid == new_port->pid || process->pid == nxt_pid
+            || nxt_queue_is_empty(&process->ports))
+        {
             continue;
         }
 
         port = nxt_process_port_first(process);
 
         if (nxt_proc_send_matrix[port->type][new_port->type]) {
-            (void) nxt_port_send_port(task, port, new_port, stream);
+            if (nxt_slow_path(nxt_port_send_port(task, port, new_port, stream)
+                              != NXT_OK))
+            {
+                if (port->type == NXT_PROCESS_ROUTER) {
+                    ret = NXT_ERROR;
+
+                } else {
+                    nxt_log(task, NXT_LOG_WARN, "failed to announce the port "
+                            "of process %PI to process %PI", new_port->pid,
+                            port->pid);
+                }
+            }
         }
 
     } nxt_runtime_process_loop;
+
+    return ret;
 }
 
 
@@ -389,6 +449,7 @@ nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
      * so rather than leave the garbage the stack happened to hold.
      */
     msg->u.new_port = NULL;
+    msg->new_port_created = 0;
 
     new_port_msg = (nxt_port_msg_new_port_t *) msg->buf->mem.pos;
 
@@ -461,6 +522,7 @@ nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_port_write_enable(task, port);
 
     msg->u.new_port = port;
+    msg->new_port_created = 1;
 
     /*
      * fd[1] is deliberately left in the message: it is the queue of the
@@ -477,6 +539,7 @@ void
 nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
 {
     void           *mem;
+    uint32_t       stream;
     nxt_port_t     *port;
     nxt_process_t  *process;
     nxt_runtime_t  *rt;
@@ -560,9 +623,11 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
      * Every guard here rejects before the state is set: a message that is
      * not acted upon must leave no trace.  Marking a process ready and only
      * then rejecting it would make the next, legitimate PROCESS_READY trip
-     * the guard above, and would let nxt_main_process_sigchld_handler()
-     * clear the start stream of a process that never finished starting,
-     * dropping the REMOVE_PID that cancels the pending start RPC.
+     * the guard above -- and, before the start stream was tied to the
+     * announcement at the tail of this handler, would have let
+     * nxt_main_process_sigchld_handler() clear the start stream of a process
+     * that never finished starting, dropping the REMOVE_PID that cancels the
+     * pending start RPC.
      */
     if (nxt_slow_path(nxt_queue_is_empty(&process->ports))) {
         nxt_log(task, NXT_LOG_WARN, "PROCESS_READY claiming process %PI, "
@@ -708,10 +773,11 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
          * kill the worker and still leave the start pending, which
          * is the wedge this arm exists to end.
          *
-         * CREATED, not READY: it never became usable, and on the
-         * paths main reports rather than the prototype, READY is
-         * what makes main clear the start stream
-         * (nxt_main_process.c:1108-1110).
+         * CREATED, not READY: it never became usable.  The start
+         * stream survives either way -- this arm returns above the
+         * announcement at the tail of this handler, which is the
+         * only thing that clears it -- so the REMOVE_PID this
+         * guarantees still carries it.
          */
         if (process->state == NXT_PROCESS_STATE_CREATING) {
             process->state = NXT_PROCESS_STATE_CREATED;
@@ -784,7 +850,72 @@ nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
      */
     nxt_port_recv_msg_close_fds(msg);
 
-    nxt_port_send_new_port(task, rt, port, msg->port_msg.stream);
+    /*
+     * Retire the start stream, but only once the announcement that answers
+     * it has actually gone out.
+     *
+     * ->stream is the RPC the initiator armed for this start.  While it is
+     * set, nxt_port_remove_notify_others() puts it into the REMOVE_PID that
+     * reports this process's death, and nxt_router_remove_pid_handler()
+     * turns a stream-bearing REMOVE_PID into an RPC_ERROR
+     * (src/nxt_router.c:1147-1153).  That is the right fallback for a start
+     * that never completed, and a liability afterwards: stream identifiers
+     * come from one 32-bit counter (nxt_stream_ident, src/nxt_port_rpc.c:11,
+     * bumped at src/nxt_port_rpc.c:164) that every request also draws on
+     * (src/nxt_router.c:5880), so once it wraps, an ordinary worker exit
+     * would fail whatever live RPC has inherited the number.  The reachable
+     * collision set is small -- the retype lands on the router's main port,
+     * which holds start, prefork, listen-socket and access-log
+     * registrations, while request RPCs live on the worker threads' engine
+     * ports -- but it is not empty.
+     *
+     * Zeroing on the READY state alone is what this deliberately is not.
+     * The state is set above and the announcement is sent here, and in
+     * between the start RPC has not been retired by anything -- so a
+     * PROCESS_READY whose NEW_PORT could not be written would lose both the
+     * reply and the REMOVE_PID fallback, and leave the initiator waiting
+     * forever.  That is the wedge issue #231 is about, re-entered through a
+     * corner.  Keyed on the send instead, the stream survives exactly the
+     * cases that still need it.  See issue #271.
+     *
+     * nxt_main_process_sigchld_handler() used to do this, later and on the
+     * state; it no longer needs to, and main gets the same treatment here
+     * because it runs the same handler for its own children.
+     *
+     * The stream announced is process->stream, the value this process itself
+     * registered when it forked the child (nxt_main_start_process_handler()
+     * and nxt_proto_start_process_handler()), not the one the message
+     * carries.  A child echoes the stream it inherited across the fork
+     * (nxt_process_send_ready(), src/nxt_process.c:1203), so for a healthy
+     * child the two are the same number -- but the wire field is written by
+     * the sender, and the sender gate above authenticates who sent the
+     * message, not what it says.  A child that named a different stream, or
+     * zero, would otherwise have the announcement carry a number no
+     * registration is waiting on while this cleared the one that is: the
+     * router would never retire the real start, and the REMOVE_PID that is
+     * the remaining fallback would carry nothing.  Announcing the registered
+     * value and clearing that same value keeps the reply and the fallback
+     * describing one start.
+     *
+     * A mismatch is logged rather than refused.  Refusing would strand the
+     * start the receiver knows about, which is the failure this is avoiding;
+     * announcing the authoritative stream answers it correctly and leaves a
+     * record that a child sent something it should not have.
+     */
+    stream = process->stream;
+
+    if (nxt_slow_path(msg->port_msg.stream != stream)) {
+        nxt_log(task, NXT_LOG_WARN, "process %PI sent PROCESS_READY naming "
+                "start stream #%uD, but it was started for stream #%uD; "
+                "answering the latter", msg->port_msg.pid,
+                msg->port_msg.stream, stream);
+    }
+
+    if (nxt_fast_path(nxt_port_send_new_port(task, rt, port, stream)
+                      == NXT_OK))
+    {
+        process->stream = 0;
+    }
 }
 
 

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -227,6 +227,14 @@ struct nxt_port_recv_msg_s {
     nxt_pid_t           cmsg_pid;
 #endif
     nxt_bool_t          cancelled;
+    /*
+     * Set by nxt_port_new_port_handler() when it had to create the port
+     * u.new_port names, clear when it found one already registered.  A
+     * caller that refuses the announcement needs the difference: an existing
+     * port is live and must be left alone, while one this message brought
+     * into the runtime is the caller's to undo.
+     */
+    nxt_bool_t          new_port_created;
     union {
         nxt_port_t      *new_port;
         nxt_pid_t       removed_pid;

--- a/src/nxt_process.c
+++ b/src/nxt_process.c
@@ -1010,11 +1010,12 @@ nxt_process_created_ok(nxt_task_t *task, nxt_port_recv_msg_t *msg, void *data)
          *
          * The refusal is visible: this exits nonzero, main's SIGCHLD
          * reaper notifies the router with the start's stream still
-         * attached (main zeroes ->stream only at state READY, and its
-         * copy of a prototype that died here is still CREATED), the
-         * router turns that REMOVE_PID into an RPC error for the start
-         * attempt, and the requests waiting on the application are
-         * answered 503 rather than left to time out.
+         * attached (main clears ->stream only once the NEW_PORT that
+         * answers the start has gone out, and a prototype that died
+         * here never sent the PROCESS_READY that would have caused
+         * one), the router turns that REMOVE_PID into an RPC error for
+         * the start attempt, and the requests waiting on the application
+         * are answered 503 rather than left to time out.
          */
 
         nxt_alert(task, "%s refused to start: capset() is denied, so the "

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -793,10 +793,53 @@ nxt_router_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     nxt_debug(task, "new port id %d (%d)", port->id, port->type);
 
     /*
-     * Port with "id == 0" is application 'main' port and it always
-     * should come with non-zero stream.
+     * An application's "main" port has id 0 and is announced carrying the
+     * stream of the start it answers, which the dispatch above consumes.
+     * Arriving here means id 0 with no stream, and the arm below cannot
+     * serve that pair: it looks the announcement up as a *sibling* of an
+     * already-known main port, and for id 0 that lookup finds the port
+     * itself.  Which of the two cases this is decides the remedy, and only
+     * nxt_port_new_port_handler() knows -- hence msg->new_port_created.
+     *
+     * Already registered: a worker that sent PROCESS_READY a second time.
+     * Its start stream was retired by the first announcement
+     * (nxt_port_process_ready_handler(), src/nxt_port.c), so the repeat
+     * carries none.  The port is live and its queue, if it brought one, was
+     * mapped above -- leave it alone.  Falling through would re-add it to
+     * the application hash: nxt_port_hash_add() declines the duplicate key,
+     * but ->port_hash_count is incremented regardless, and
+     * nxt_router_app_need_start() reads that count, so the router would
+     * believe it has workers it does not have.  It would also send a second
+     * PORT_ACK for one port.
+     *
+     * Created by this message: an application main port announced with no
+     * stream at all, which no start is waiting on and nothing else will
+     * complete.  Keeping it would leave a port registered in the runtime
+     * that no application owns and no PORT_ACK was ever sent for.  Undo the
+     * registration this message caused instead.
+     *
+     * An assertion is not enough for either: nxt_assert() compiles out in a
+     * release build, which is exactly where the miscount and the orphan
+     * would do their damage.
      */
-    nxt_assert(port->id != 0);
+    if (nxt_slow_path(port->id == 0)) {
+
+        if (msg->new_port_created) {
+            nxt_alert(task, "new port of process %PI has id 0 and no start "
+                      "stream; refused", port->pid);
+
+            nxt_port_close(task, port);
+            nxt_runtime_port_remove(task, port);
+
+            return;
+        }
+
+        nxt_log(task, NXT_LOG_WARN, "process %PI announced its main port "
+                "again with no start stream; already registered, ignored",
+                port->pid);
+
+        return;
+    }
 
     /* Find 'main' app port and get app reference. */
     rt = task->thread->runtime;

--- a/src/test/nxt_main_start_process_reply_test.c
+++ b/src/test/nxt_main_start_process_reply_test.c
@@ -32,6 +32,17 @@
  * ever cancel a stream of the forger's own; that case gives the two pids
  * different values and requires the router's port to stay untouched.
  *
+ * The prototype's own START_PROCESS handler is covered here too.  It is the
+ * other end of the same message -- the router sends one to main to get a
+ * prototype and one to the prototype to get a worker
+ * (src/nxt_router.c:469 and :3379) -- and until issue #270 it checked
+ * nothing at all, although every worker it forks inherits the write end of
+ * the prototype's port.  Its cases are refusals only, and each is run in a
+ * forked child: a handler that does not refuse goes on to fork a worker
+ * from a fixture that has no application loaded, and containing that keeps
+ * one broken gate from taking the whole test binary down.  The parent
+ * reports a child that died as the fall-through it is.
+ *
  * Not covered: the nxt_mp_create() failure a few lines below the process
  * allocation.  Arming it needs a malloc-failure hook that does not exist,
  * and the sites are not independent -- both reach "failed:" through the
@@ -45,10 +56,12 @@
 #include <nxt_port.h>
 #include <nxt_port_hash.h>
 #include <nxt_main_process.h>
+#include <nxt_application.h>
 #include <nxt_event_engine.h>
 #include "nxt_tests.h"
 
 #include <fcntl.h>
+#include <sys/wait.h>
 
 
 static nxt_bool_t
@@ -268,6 +281,130 @@ done:
     return ret;
 }
 
+#if (NXT_USE_CMSG_PID)
+
+/*
+ * One refusal case for nxt_proto_start_process_handler(), run inside a
+ * forked child.
+ *
+ * The child does the whole check and reports through its exit status: 0 when
+ * the handler refused, 1 when it was reached and left a trace it should not
+ * have.  A handler with no gate does not return at all -- it allocates a
+ * process and reads nxt_app_conf, which no fixture here sets -- so the
+ * parent treats a signalled child as the failure it is, and names it.
+ *
+ * What "refused" means, in the order the child tests it: nothing was queued
+ * on any port (a refusal must not answer, because the reply is addressed by
+ * the sender-chosen msg->port_msg.pid and answering would let a forger
+ * cancel a stream of its choosing), and both descriptors the message carried
+ * were closed (this handler owns them; the port read loop reclaims nothing).
+ */
+static nxt_int_t
+nxt_main_start_process_reply_test_proto_case(nxt_thread_t *thr,
+    nxt_task_t *task, nxt_port_recv_msg_t *msg, nxt_port_t *port_a,
+    nxt_port_t *port_b, const char *name)
+{
+    int        status;
+    pid_t      child;
+    nxt_fd_t   fd0, fd1;
+    nxt_int_t  ret;
+
+    fd0 = open("/dev/null", O_RDONLY);
+    fd1 = open("/dev/null", O_RDONLY);
+
+    if (nxt_slow_path(fd0 == -1 || fd1 == -1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s failed to "
+                      "open the descriptors", name);
+
+        if (fd0 != -1) {
+            (void) close(fd0);
+        }
+
+        if (fd1 != -1) {
+            (void) close(fd1);
+        }
+
+        return NXT_ERROR;
+    }
+
+    msg->fd[0] = fd0;
+    msg->fd[1] = fd1;
+
+    child = fork();
+
+    if (nxt_slow_path(child == -1)) {
+        nxt_log_alert(thr->log, "main start process reply test: %s failed to "
+                      "fork %E", name, nxt_errno);
+        (void) close(fd0);
+        (void) close(fd1);
+
+        return NXT_ERROR;
+    }
+
+    if (child == 0) {
+        ret = NXT_OK;
+
+        nxt_proto_test_run_start_process_handler(task, msg);
+
+        if (!nxt_queue_is_empty(&port_a->messages)
+            || (port_b != NULL && !nxt_queue_is_empty(&port_b->messages)))
+        {
+            nxt_log_alert(thr->log, "main start process reply test: %s was "
+                          "answered; a refused START_PROCESS must not reply, "
+                          "because the reply is addressed by the pid the "
+                          "sender chose", name);
+            ret = NXT_ERROR;
+        }
+
+        if (msg->fd[0] != -1 || msg->fd[1] != -1
+            || nxt_main_start_process_reply_test_fd_is_open(fd0)
+            || nxt_main_start_process_reply_test_fd_is_open(fd1))
+        {
+            nxt_log_alert(thr->log, "main start process reply test: %s leaked "
+                          "a descriptor", name);
+            ret = NXT_ERROR;
+        }
+
+        /*
+         * _exit(), not exit(): the child shares the parent's stdio and its
+         * pools, and must run no destructor or atexit handler of theirs.
+         */
+        _exit(ret == NXT_OK ? 0 : 1);
+    }
+
+    /* The child owns them now; this frame only has to stop naming them. */
+    (void) close(fd0);
+    (void) close(fd1);
+
+    msg->fd[0] = -1;
+    msg->fd[1] = -1;
+
+    while (waitpid(child, &status, 0) == -1) {
+        if (nxt_errno != NXT_EINTR) {
+            nxt_log_alert(thr->log, "main start process reply test: %s failed "
+                          "to reap the child %E", name, nxt_errno);
+            return NXT_ERROR;
+        }
+    }
+
+    if (nxt_slow_path(!WIFEXITED(status))) {
+        nxt_log_alert(thr->log, "main start process reply test: %s did not "
+                      "refuse -- the handler ran past the sender check and "
+                      "into the start path, and died there on signal %d",
+                      name, WTERMSIG(status));
+        return NXT_ERROR;
+    }
+
+    if (nxt_slow_path(WEXITSTATUS(status) != 0)) {
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+#endif
+
+
 nxt_int_t
 nxt_main_start_process_reply_test(nxt_thread_t *thr)
 {
@@ -473,6 +610,94 @@ nxt_main_start_process_reply_test(nxt_thread_t *thr)
     if (nxt_slow_path(ret != NXT_OK)) {
         goto done;
     }
+
+#if (NXT_USE_CMSG_PID)
+
+    /*
+     * The prototype's START_PROCESS handler, issue #270.  Each case is a
+     * refusal; the fixture is the one above, read as the prototype's own
+     * runtime -- rt->port_by_type[NXT_PROCESS_ROUTER] is the router port the
+     * prototype inherited from main, which nxt_proc_keep_matrix[] keeps.
+     */
+
+    /*
+     * A worker forging a START_PROCESS.  It claims to be the router in the
+     * one field it controls, and the credential names it.  This is the whole
+     * exposure: nxt_process_close_ports() keeps the parent's port
+     * unconditionally, so every worker holds the write end of the port this
+     * message arrived on.
+     */
+
+    msg.cmsg_pid = nxt_pid + 1;
+    msg.port_msg.stream = 0x55555555;
+
+    ret = nxt_main_start_process_reply_test_proto_case(thr, task, &msg,
+                                                      router_port,
+                                                      foreign_port,
+                                                      "a foreign sender to "
+                                                      "the prototype");
+
+    msg.cmsg_pid = nxt_pid;
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * No router port to compare against.  The prototype cannot tell who sent
+     * this, and refusing is the only safe answer -- the same conclusion
+     * nxt_main_start_process_handler() reaches, minus the reply it can
+     * address and the prototype cannot.
+     */
+
+    rt->port_by_type[NXT_PROCESS_ROUTER] = NULL;
+
+    msg.port_msg.stream = 0x66666666;
+
+    ret = nxt_main_start_process_reply_test_proto_case(thr, task, &msg,
+                                                      router_port,
+                                                      foreign_port,
+                                                      "a missing router port "
+                                                      "in the prototype");
+
+    rt->port_by_type[NXT_PROCESS_ROUTER] = router_port;
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+    /*
+     * A pid-isolated prototype.  There the router is in an ancestor pid
+     * namespace and has no pid at all in this one, so the kernel writes a
+     * credential of 0 and the router's global pid is the wrong thing to
+     * compare against; the prototype's own workers, forked with no clone
+     * flags of their own, are inside the namespace and carry non-zero
+     * namespace-local pids.  This case is such a worker -- a credential that
+     * is neither 0 nor the router's -- and pins the arm down from the side
+     * that matters: a gate that simply skipped the check when isolated would
+     * pass every other case here and fail this one.
+     */
+
+    rt->is_pid_isolated = 1;
+
+    msg.cmsg_pid = 2;
+    msg.port_msg.stream = 0x77777777;
+
+    ret = nxt_main_start_process_reply_test_proto_case(thr, task, &msg,
+                                                      router_port,
+                                                      foreign_port,
+                                                      "a worker inside a "
+                                                      "pid-isolated "
+                                                      "prototype");
+
+    rt->is_pid_isolated = 0;
+    msg.cmsg_pid = nxt_pid;
+
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
+
+#endif
 
     nxt_thread_time_update(thr);
     nxt_log_error(NXT_LOG_NOTICE, thr->log,

--- a/src/test/nxt_port_ready_test.c
+++ b/src/test/nxt_port_ready_test.c
@@ -25,12 +25,17 @@
  * pid-isolated process -- pid and isolated_pid deliberately differ -- so
  * that the cases below can tell the two apart: a credential equal to the
  * global pid has to be refused just like a foreign one.
+ *
+ * The last case covers what the handler does with process->stream, the start
+ * RPC the initiator armed: it is retired when the announcement that answers
+ * that RPC has gone out, and kept when it has not.  See issue #271.
  */
 
 #include <nxt_main.h>
 #include <nxt_port.h>
 #include <nxt_port_queue.h>
 #include <nxt_runtime.h>
+#include <nxt_event_engine.h>
 #include "nxt_tests.h"
 
 #include <fcntl.h>
@@ -867,6 +872,459 @@ fail:
 #endif
 
 
+/*
+ * Require that the announcement the handler just made is on the router's
+ * port and carries "expect" as its stream, then drain both peer ports so the
+ * next case starts from empty queues.
+ *
+ * The stream is what these cases are about: it is the number the router
+ * matches against its registered start RPCs, so announcing the wrong one
+ * answers nobody while looking, from every other angle, like a success.
+ *
+ * "expect" may be NXT_PORT_READY_TEST_NO_MSG to require that the router was
+ * not announced to at all, or NXT_PORT_READY_TEST_ANY to make no
+ * requirement and only report, through *got, whether it was -- which is what
+ * the mixed-outcome case below needs, since which of the two peers a single
+ * armed allocation failure lands on is hash order, not something this test
+ * fixes.
+ */
+
+#define NXT_PORT_READY_TEST_NO_MSG  ((uint32_t) -1)
+#define NXT_PORT_READY_TEST_ANY     ((uint32_t) -2)
+
+static nxt_int_t
+nxt_port_ready_test_announced(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_port_t *router_port, nxt_port_t *other_port, uint32_t expect,
+    nxt_bool_t *got, const char *name)
+{
+    nxt_int_t            ret;
+    nxt_uint_t           n;
+    nxt_queue_link_t     *link;
+    nxt_port_send_msg_t  *sent;
+
+    ret = NXT_OK;
+    sent = NULL;
+    n = 0;
+
+    for (link = nxt_queue_first(&router_port->messages);
+         link != nxt_queue_tail(&router_port->messages);
+         link = nxt_queue_next(link))
+    {
+        n++;
+        sent = nxt_queue_link_data(link, nxt_port_send_msg_t, link);
+    }
+
+    if (got != NULL) {
+        *got = (n != 0);
+    }
+
+    if (expect == NXT_PORT_READY_TEST_ANY) {
+        /* Reported, not required. */
+
+    } else if (expect == NXT_PORT_READY_TEST_NO_MSG) {
+        if (nxt_slow_path(n != 0)) {
+            nxt_log_alert(thr->log, "port ready test: %s announced the port "
+                          "to the router anyway", name);
+            ret = NXT_ERROR;
+        }
+
+    } else if (nxt_slow_path(n != 1)) {
+        nxt_log_alert(thr->log, "port ready test: %s left %ui announcements "
+                      "on the router port (expected 1)", name, n);
+        ret = NXT_ERROR;
+
+    } else if (nxt_slow_path(sent->port_msg.stream != expect)) {
+        nxt_log_alert(thr->log, "port ready test: %s announced the port on "
+                      "stream #%uD, but the start it answers is stream #%uD "
+                      "-- the router matches its registrations on that "
+                      "number, so this answers nobody", name,
+                      sent->port_msg.stream, expect);
+        ret = NXT_ERROR;
+    }
+
+    nxt_port_test_run_error_handler(task, router_port);
+
+    if (other_port != NULL) {
+        nxt_port_test_run_error_handler(task, other_port);
+    }
+
+    return ret;
+}
+
+
+/*
+ * Issue #271: process->stream is the start RPC the initiator armed, and the
+ * handler has to retire it exactly when that RPC has been answered -- which
+ * is when the NEW_PORT announcement carrying the stream has gone out, not
+ * when the READY state has been set.
+ *
+ * The two are not the same moment.  The state is set first and the
+ * announcement is written afterwards, so a READY whose announcement fails
+ * leaves the initiator with no reply at all; the only thing that can still
+ * fail its RPC is the stream in the REMOVE_PID this process's death will
+ * send (src/nxt_router.c:1148-1153).  Clearing on the state -- which is
+ * what nxt_main_process_sigchld_handler() used to do -- throws that away.
+ * Keeping it forever is the other error the issue names: stream numbers come
+ * from one counter that every request draws on, so after a wrap an ordinary
+ * exit retires somebody else's live RPC.
+ *
+ * The fixture is a process announcing itself with no queue descriptor, on a
+ * prototype port: that is a real shape (only libunit attaches a queue, and
+ * the core processes that announce to main do not), and it keeps the
+ * announcement free of descriptors, so the peer's queued message can be
+ * drained without closing a descriptor another port owns.
+ *
+ * The peer is a router, because nxt_proc_send_matrix[] pairs ROUTER with
+ * PROTOTYPE; without a peer the announcement would have nothing to fail on
+ * and both cases would pass vacuously.  Its port has no socket and is not
+ * write-ready, so nxt_port_socket_write2() queues rather than writes, and
+ * nxt_port_test_msg_alloc_failures() can fail that queueing on demand.
+ */
+static nxt_int_t
+nxt_port_ready_test_stream(nxt_thread_t *thr, nxt_task_t *task,
+    nxt_runtime_t *rt, nxt_mp_t *mp)
+{
+    uint32_t             stream;
+    nxt_int_t            ret;
+    nxt_bool_t           router_got_it;
+    nxt_port_t           *proto_port, *router_port, *main_port;
+    nxt_process_t        *proto, *router, *mainp;
+    nxt_event_engine_t   engine, *saved_engine;
+    nxt_port_recv_msg_t  msg;
+
+    ret = NXT_ERROR;
+    proto_port = NULL;
+    router_port = NULL;
+    main_port = NULL;
+    stream = 0x21212121;
+
+    proto = nxt_mp_zalloc(mp, sizeof(nxt_process_t));
+    router = nxt_mp_zalloc(mp, sizeof(nxt_process_t));
+    mainp = nxt_mp_zalloc(mp, sizeof(nxt_process_t));
+
+    if (nxt_slow_path(proto == NULL || router == NULL || mainp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    proto->pid = nxt_pid + 7;
+    proto->isolated_pid = nxt_pid + 8;
+    proto->state = NXT_PROCESS_STATE_CREATING;
+    proto->stream = stream;
+    nxt_queue_init(&proto->ports);
+
+    nxt_runtime_process_add(task, proto);
+
+    proto_port = nxt_port_new(task, 0, proto->pid, NXT_PROCESS_PROTOTYPE);
+    if (nxt_slow_path(proto_port == NULL)) {
+        return NXT_ERROR;
+    }
+
+    proto_port->pair[0] = -1;
+    proto_port->pair[1] = -1;
+    proto_port->socket.fd = -1;
+
+    nxt_queue_insert_tail(&proto->ports, &proto_port->link);
+
+    /*
+     * A second peer, of main's type.  nxt_proc_send_matrix[] pairs MAIN with
+     * everything, so the prototype announcing a child writes to main as well
+     * as to the router -- and only the router's write is evidence about the
+     * start.  Without this peer the two rules ("every peer succeeded" and
+     * "the router succeeded") cannot be told apart.
+     */
+    mainp->pid = nxt_pid + 10;
+    mainp->isolated_pid = nxt_pid + 10;
+    mainp->state = NXT_PROCESS_STATE_READY;
+    nxt_queue_init(&mainp->ports);
+
+    nxt_runtime_process_add(task, mainp);
+
+    main_port = nxt_port_new(task, 0, mainp->pid, NXT_PROCESS_MAIN);
+    if (nxt_slow_path(main_port == NULL)) {
+        goto done;
+    }
+
+    main_port->pair[0] = -1;
+    main_port->pair[1] = -1;
+    main_port->socket.fd = -1;
+
+    nxt_queue_insert_tail(&mainp->ports, &main_port->link);
+
+    router->pid = nxt_pid + 9;
+    router->isolated_pid = nxt_pid + 9;
+    router->state = NXT_PROCESS_STATE_READY;
+    nxt_queue_init(&router->ports);
+
+    nxt_runtime_process_add(task, router);
+
+    router_port = nxt_port_new(task, 0, router->pid, NXT_PROCESS_ROUTER);
+    if (nxt_slow_path(router_port == NULL)) {
+        goto done;
+    }
+
+    router_port->pair[0] = -1;
+    router_port->pair[1] = -1;
+    router_port->socket.fd = -1;
+
+    nxt_queue_insert_tail(&router->ports, &router_port->link);
+
+    /*
+     * An engine only for the announcement: nxt_port_send_port() allocates
+     * its buffer from task->thread->engine->mem_pool, and the queued message
+     * is completed on the engine's work queue.  The rest of this file needs
+     * none, so it is installed and taken away again here.
+     */
+    nxt_memzero(&engine, sizeof(engine));
+    nxt_work_queue_cache_create(&engine.work_queue_cache, 1024);
+    engine.fast_work_queue.cache = &engine.work_queue_cache;
+    nxt_work_queue_name(&engine.fast_work_queue, "fast");
+    engine.mem_pool = mp;
+
+    saved_engine = thr->engine;
+    thr->engine = &engine;
+    rt->main_engine = &engine;
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    msg.port_msg.pid = proto->pid;
+    msg.port_msg.stream = stream;
+    msg.fd[0] = -1;
+    msg.fd[1] = -1;
+#if (NXT_USE_CMSG_PID)
+    msg.cmsg_pid = proto->isolated_pid;
+#endif
+
+    /*
+     * The announcement cannot be queued.  The process is ready as far as the
+     * state goes, and the initiator has still not been told anything, so the
+     * stream has to survive -- it is the only thing that will fail that RPC
+     * when this process dies.
+     */
+    nxt_port_test_msg_alloc_failures(2);
+
+    nxt_port_process_ready_handler(task, &msg);
+
+    nxt_port_test_msg_alloc_failures(0);
+
+    if (nxt_slow_path(nxt_port_ready_test_announced(thr, task, router_port,
+                                                    main_port,
+                                                    NXT_PORT_READY_TEST_NO_MSG,
+                                                    NULL,
+                                                    "an announcement whose "
+                                                    "allocation was made to "
+                                                    "fail")
+                      != NXT_OK))
+    {
+        goto drain;
+    }
+
+    if (nxt_slow_path(proto->state != NXT_PROCESS_STATE_READY)) {
+        nxt_log_alert(thr->log, "port ready test: a queueless prototype was "
+                      "not marked ready");
+        goto drain;
+    }
+
+    if (nxt_slow_path(proto->stream != stream)) {
+        nxt_log_alert(thr->log, "port ready test: the start stream was "
+                      "cleared although the announcement never went out, so "
+                      "nothing is left to fail that RPC");
+        goto drain;
+    }
+
+    /*
+     * The same message again, with the announcement allowed through.  Now
+     * the initiator has its reply -- nxt_router_new_port_handler() feeds a
+     * stream-bearing NEW_PORT to nxt_port_rpc_handler() -- and the stream is
+     * spent: keeping it would put it into this process's REMOVE_PID and,
+     * once the counter has wrapped, fail an unrelated live RPC.
+     */
+    nxt_port_process_ready_handler(task, &msg);
+
+    if (nxt_slow_path(nxt_port_ready_test_announced(thr, task, router_port,
+                                                    main_port, stream, NULL,
+                                                    "a healthy READY")
+                      != NXT_OK))
+    {
+        goto drain;
+    }
+
+    if (nxt_slow_path(proto->stream != 0)) {
+        nxt_log_alert(thr->log, "port ready test: the start stream survived "
+                      "an announcement that answered it, so a later "
+                      "REMOVE_PID would fail whatever RPC now holds that "
+                      "number");
+        goto drain;
+    }
+
+    /*
+     * A child naming a stream of its own choosing.  The gate above
+     * authenticates who sent a PROCESS_READY, not what it says, and the
+     * stream field is written by the sender: a child that echoes something
+     * other than the stream it was started for -- malformed, or forged by a
+     * compromised worker -- must not be able to redirect the answer.
+     *
+     * The announcement has to carry the stream this process registered when
+     * it forked the child, so the router retires the start that is really
+     * pending; and clearing is then correct, because that start has been
+     * answered.  Taking the wire value instead would announce a number no
+     * registration waits on while clearing the one that does -- the start
+     * would never be retired by the reply, and the REMOVE_PID fallback would
+     * carry nothing.
+     */
+    proto->stream = stream;
+    proto->state = NXT_PROCESS_STATE_CREATING;
+    msg.port_msg.stream = 0xdeadbeef;
+
+    nxt_port_process_ready_handler(task, &msg);
+
+    if (nxt_slow_path(nxt_port_ready_test_announced(thr, task, router_port,
+                                                    main_port, stream, NULL,
+                                                    "a READY naming a foreign "
+                                                    "stream")
+                      != NXT_OK))
+    {
+        goto drain;
+    }
+
+    if (nxt_slow_path(proto->stream != 0)) {
+        nxt_log_alert(thr->log, "port ready test: a READY naming a foreign "
+                      "stream did not retire the start that was answered");
+        goto drain;
+    }
+
+    /*
+     * The same with a stream of 0, which is what a truncated or zeroed
+     * message carries.  0 is the "no RPC" value everywhere else
+     * (nxt_router_remove_pid_handler() returns on it), so a handler that
+     * passed the wire value straight through would announce nothing
+     * answerable and still count the start as replied to.
+     */
+    proto->stream = stream;
+    proto->state = NXT_PROCESS_STATE_CREATING;
+    msg.port_msg.stream = 0;
+
+    nxt_port_process_ready_handler(task, &msg);
+
+    if (nxt_slow_path(nxt_port_ready_test_announced(thr, task, router_port,
+                                                    main_port, stream, NULL,
+                                                    "a READY naming stream 0")
+                      != NXT_OK))
+    {
+        goto drain;
+    }
+
+    if (nxt_slow_path(proto->stream != 0)) {
+        nxt_log_alert(thr->log, "port ready test: a READY naming stream 0 did "
+                      "not retire the start that was answered");
+        goto drain;
+    }
+
+    /*
+     * One peer's announcement fails and the other's succeeds.  Only the
+     * router's is evidence about the start: it owns the registration for
+     * every start, whether main or the prototype did the forking, and
+     * nxt_router_new_port_handler() retires it on a stream-bearing NEW_PORT.
+     * A failure to any other peer is a delivery problem for that peer.
+     *
+     * One armed allocation failure lands on whichever peer the runtime walks
+     * first, and that is the order they were registered in, not the pids:
+     * main is added to the fixture before the router above so that the
+     * failure falls on main and the router's write goes through.  That is
+     * the branch which discriminates the two implementations -- aggregating
+     * every peer keeps a stream the router has already retired -- and it is
+     * reached on every run; the log line below records which branch was
+     * taken, so a future change to the walk order shows up as a note rather
+     * than as a test that silently stopped testing anything.
+     *
+     * The assertion is still written as the rule for both branches, so it
+     * cannot fail spuriously if that order does change.  The opposite branch
+     * -- the router itself missing out -- is covered deterministically by
+     * the failed-announcement case above, which arms a failure for every
+     * peer.
+     */
+    proto->stream = stream;
+    proto->state = NXT_PROCESS_STATE_CREATING;
+    msg.port_msg.stream = stream;
+
+    nxt_port_test_msg_alloc_failures(1);
+
+    nxt_port_process_ready_handler(task, &msg);
+
+    nxt_port_test_msg_alloc_failures(0);
+
+    router_got_it = 0;
+
+    if (nxt_slow_path(nxt_port_ready_test_announced(thr, task, router_port,
+                                                    main_port,
+                                                    NXT_PORT_READY_TEST_ANY,
+                                                    &router_got_it,
+                                                    "a partly failed "
+                                                    "announcement")
+                      != NXT_OK))
+    {
+        goto drain;
+    }
+
+    nxt_log_error(NXT_LOG_INFO, thr->log, "port ready test: the partly failed "
+                  "announcement %s the router",
+                  router_got_it ? "reached" : "missed");
+
+    if (nxt_slow_path(router_got_it && proto->stream != 0)) {
+        nxt_log_alert(thr->log, "port ready test: the router was announced to "
+                      "and retired the start, but the stream was kept because "
+                      "another peer's write failed -- after a counter wrap "
+                      "that stream fails an unrelated RPC");
+        goto drain;
+    }
+
+    if (nxt_slow_path(!router_got_it && proto->stream != stream)) {
+        nxt_log_alert(thr->log, "port ready test: the router was not "
+                      "announced to, so nothing retired the start, yet the "
+                      "stream was cleared -- the REMOVE_PID fallback is gone");
+        goto drain;
+    }
+
+    msg.port_msg.stream = stream;
+
+    ret = NXT_OK;
+
+drain:
+
+    /*
+     * A queued message is malloc'd and holds a port reference; the error
+     * handler is what releases both, and it has to run while the engine it
+     * was queued on is still installed.  The checker above drains after each
+     * case; this catches whatever a failed case left behind.
+     */
+    nxt_port_test_run_error_handler(task, router_port);
+
+    if (main_port != NULL) {
+        nxt_port_test_run_error_handler(task, main_port);
+    }
+
+    thr->engine = saved_engine;
+    rt->main_engine = NULL;
+
+    nxt_work_queue_cache_destroy(&engine.work_queue_cache);
+
+done:
+
+    if (main_port != NULL) {
+        nxt_port_close(task, main_port);
+    }
+
+    if (router_port != NULL) {
+        nxt_port_close(task, router_port);
+    }
+
+    if (proto_port != NULL) {
+        nxt_port_close(task, proto_port);
+    }
+
+    return ret;
+}
+
+
 nxt_int_t
 nxt_port_ready_test(nxt_thread_t *thr)
 {
@@ -1176,6 +1634,15 @@ nxt_port_ready_test(nxt_thread_t *thr)
 #endif
 
 #endif
+
+    /*
+     * Last, because it registers two more processes in the fixture runtime
+     * and every case above walks that runtime when it announces a port.
+     */
+    ret = nxt_port_ready_test_stream(thr, task, rt, mp);
+    if (nxt_slow_path(ret != NXT_OK)) {
+        goto done;
+    }
 
 done:
 

--- a/src/test/nxt_router_new_port_test.c
+++ b/src/test/nxt_router_new_port_test.c
@@ -76,7 +76,7 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     nxt_buf_t                buf;
     nxt_task_t               *task;
     nxt_int_t                ret;
-    nxt_port_t               *port, *reply_port;
+    nxt_port_t               *port, *port2, *reply_port;
     nxt_runtime_t            *rt, *saved_rt;
     nxt_event_engine_t       engine;
     nxt_port_recv_msg_t      msg;
@@ -89,6 +89,7 @@ nxt_router_new_port_test(nxt_thread_t *thr)
     sock = -1;
     queue = -1;
     port = NULL;
+    port2 = NULL;
     reply_port = NULL;
 
     task = thr->task;
@@ -243,6 +244,119 @@ nxt_router_new_port_test(nxt_thread_t *thr)
         goto done;
     }
 
+    /*
+     * An application's main port (id 0) announced with no start stream.  The
+     * handler has to tell the two ways that can happen apart, so both are
+     * exercised here.
+     *
+     * First the duplicate: register (pid + 2, 0) with a stream, then send
+     * that exact port again with none, as a worker that called
+     * nxt_unit_ready() twice does once its prototype has retired the start
+     * stream.  The port must survive unchanged -- falling through would
+     * re-add it to the application hash and ack it a second time.
+     */
+
+    nxt_memzero(&new_port, sizeof(nxt_port_msg_new_port_t));
+
+    new_port.pid = nxt_pid + 2;
+    new_port.id = 0;
+    new_port.type = NXT_PROCESS_APP;
+    new_port.max_size = 1024;
+    new_port.max_share = 1024;
+
+    nxt_memzero(&buf, sizeof(nxt_buf_t));
+
+    buf.mem.pos = (u_char *) &new_port;
+    buf.mem.free = buf.mem.pos + sizeof(nxt_port_msg_new_port_t);
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    msg.buf = &buf;
+    msg.fd[0] = -1;
+    msg.fd[1] = -1;
+    msg.port = reply_port;
+    msg.port_msg.stream = 5;
+    msg.port_msg.pid = new_port.pid;
+
+    nxt_router_new_port_handler(task, &msg);
+
+    port2 = msg.u.new_port;
+
+    if (port2 == NULL || !msg.new_port_created) {
+        nxt_log_alert(thr->log, "router new port test: the first main port "
+                      "announcement did not create a port");
+        goto done;
+    }
+
+    buf.mem.pos = (u_char *) &new_port;
+    buf.mem.free = buf.mem.pos + sizeof(nxt_port_msg_new_port_t);
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    msg.buf = &buf;
+    msg.fd[0] = -1;
+    msg.fd[1] = -1;
+    msg.port = reply_port;
+    msg.port_msg.stream = 0;
+    msg.port_msg.pid = new_port.pid;
+
+    nxt_router_new_port_handler(task, &msg);
+
+    if (msg.u.new_port != port2 || msg.new_port_created) {
+        nxt_log_alert(thr->log, "router new port test: the repeated "
+                      "announcement did not resolve to the registered port");
+        goto done;
+    }
+
+    if (nxt_runtime_port_find(rt, new_port.pid, 0) != port2) {
+        nxt_log_alert(thr->log, "router new port test: the repeated "
+                      "announcement disturbed the registered port");
+        goto done;
+    }
+
+    if (port2->app != NULL) {
+        nxt_log_alert(thr->log, "router new port test: the repeated "
+                      "announcement enrolled the port in an application");
+        goto done;
+    }
+
+    /*
+     * Then the other case: a main port the router has never seen, announced
+     * with no stream.  No start is waiting on it and nothing else will
+     * complete it, so the handler must undo the registration this message
+     * caused rather than leave an orphan in the runtime.
+     *
+     * What this pins, honestly: with the check removed both cases reach
+     * nxt_assert(port->id != 0) -- an abort in a debug build, compiled out in
+     * a release one, where the orphan check below is what reports it.  So the
+     * case has teeth either way.  What it does not cover is the other half of
+     * the duplicate: ->port_hash_count being incremented past a declined
+     * nxt_port_hash_add(), which needs an nxt_app_t the fixture does not
+     * build.
+     */
+
+    new_port.pid = nxt_pid + 3;
+
+    buf.mem.pos = (u_char *) &new_port;
+    buf.mem.free = buf.mem.pos + sizeof(nxt_port_msg_new_port_t);
+
+    nxt_memzero(&msg, sizeof(nxt_port_recv_msg_t));
+
+    msg.buf = &buf;
+    msg.fd[0] = -1;
+    msg.fd[1] = -1;
+    msg.port = reply_port;
+    msg.port_msg.stream = 0;
+    msg.port_msg.pid = new_port.pid;
+
+    nxt_router_new_port_handler(task, &msg);
+
+    if (nxt_runtime_port_find(rt, new_port.pid, 0) != NULL) {
+        nxt_log_alert(thr->log, "router new port test: a streamless first "
+                      "announcement was left registered");
+        goto done;
+    }
+
     ret = NXT_OK;
 
     nxt_log_error(NXT_LOG_NOTICE, thr->log, "router new port test passed");
@@ -268,6 +382,11 @@ done:
          */
         nxt_port_close(task, port);
         nxt_runtime_port_remove(task, port);
+    }
+
+    if (port2 != NULL) {
+        nxt_port_close(task, port2);
+        nxt_runtime_port_remove(task, port2);
     }
 
     if (reply_port != NULL) {

--- a/test/test_php_isolation.py
+++ b/test/test_php_isolation.py
@@ -211,3 +211,46 @@ def test_php_isolation_rootfs_credential_no_automount(is_su, require,
     )
 
     assert client.get()['status'] == 200, 'no automount serves'
+
+
+def test_php_isolation_pid_namespace(is_su, require):
+    """A prototype in its own pid namespace still starts workers.
+
+    The router's START_PROCESS reaches such a prototype from an ancestor pid
+    namespace, so the credential the kernel attaches to it is 0 rather than
+    the router's pid: the prototype has no pid for the router at all.  The
+    sender check in nxt_proto_start_process_handler() (issue #270) has to
+    know that, and a version of it that simply compared against the router's
+    global pid would refuse every start here -- with the application never
+    coming up, which is what this asks about.
+
+    Unlike the rootfs cases above, the pid namespace is requested whether or
+    not the suite runs as root: as root is exactly where the other tests do
+    not ask for one.  Unprivileged, unshare(CLONE_NEWPID) needs CAP_SYS_ADMIN,
+    so a user namespace has to come with it -- the same shape as
+    test_go_isolation.py::test_isolation_pid.
+    """
+    require({'features': {'isolation': ['pid']}})
+
+    if not is_su:
+        require(
+            {
+                'features': {
+                    'isolation': [
+                        'unprivileged_userns_clone',
+                        'user',
+                        'mnt',
+                    ]
+                }
+            }
+        )
+
+    isolation = {'namespaces': {'pid': True}}
+
+    if not is_su:
+        isolation['namespaces']['mount'] = True
+        isolation['namespaces']['credential'] = True
+
+    client.load('phpinfo', isolation=isolation)
+
+    assert client.get()['status'] == 200, 'pid-isolated prototype'


### PR DESCRIPTION
Fixes #270, fixes #271.

Two sender/lifecycle defects in the same start path, one commit each.  Both
are the follow-up shape of 4c79840d ("port: authenticate PROCESS_READY by
the sender's kernel pid"): the same SCM_CREDENTIALS mechanism, applied to
the message that starts a worker and to the RPC stream that start carries.

## `application:` the prototype's START_PROCESS had no sender check (#270)

`nxt_main_start_process_handler()` has refused a START_PROCESS whose
kernel-validated pid is not the router's since #257
(`src/nxt_main_process.c:532`).  `nxt_proto_start_process_handler()` — the
handler that forks the application workers themselves — verified nothing.

Every worker holds the write end of the port that message arrives on:
`nxt_proc_keep_matrix[]` does not pair an APP with its prototype, but
`nxt_process_close_ports()` keeps the parent's port unconditionally
(`src/nxt_process.c:372`), and `nxt_port_handler()` dispatches on the wire
type alone.  So one compromised worker could make its own prototype fork
more workers — spending the process budget, and, once #268 has the prototype
answer for a child that dies, driving the router's start bookkeeping from the
inside.

The check has two arms, because the credential the kernel writes is relative
to the *receiver's* pid namespace and the prototype has two views of the
router:

| prototype | router's credential | rule |
|---|---|---|
| shares main's pid namespace | the router's global pid | `== rt->port_by_type[NXT_PROCESS_ROUTER]->pid` (main's whitelist) |
| `namespaces: {pid: true}` | `0` — the router is in an ancestor namespace and has no pid here | `== 0` |

The second arm is measured, not assumed: a socketpair across a `CLONE_NEWPID`
boundary delivers `SCM_CREDENTIALS` pid `0`, while a process *inside* the
namespace delivers its non-zero namespace-local pid.  Comparing against the
router's global pid there would refuse every legitimate start and the
application would simply never come up — see the test-teeth note below.  The
credential-0 set is exactly the one the prototype does not fork: its workers
get no clone flags of their own, so each is inside the namespace.  The
residual sender it admits is main, which is trusted and does not send
START_PROCESS.

A refused message is **not** answered.  The reply addressing at `failed:`
stays keyed on `msg->port_msg.pid` (as #270 asks) because the runtime port
hash is keyed on the global pid, which the isolated arm's credential cannot
supply; answering a forgery on a sender-chosen pid and port would let it
cancel an RPC of its own choosing.  Nothing is stranded by the silence — the
router never armed an RPC for a message it did not send.  The descriptors are
closed, since this handler owns them and the port read loop reclaims nothing
(`src/nxt_port_socket.c:1381`).

Compiled only under `NXT_USE_CMSG_PID`, like every sibling gate.

## `process:` the start stream was retired on READY, not on its reply (#271)

`process->stream` is the RPC the initiator armed.  While it is set,
`nxt_port_remove_notify_others()` puts it into the REMOVE_PID that reports the
process's death, and `nxt_router_remove_pid_handler()` turns a stream-bearing
REMOVE_PID into an RPC_ERROR (`src/nxt_router.c:1128-1133`).  A prototype's
worker kept `->stream` for its whole life, so every routine worker exit asked
the router to fail whatever RPC held that number — harmless while the number
is dead, and not permanently dead: stream ids come from one 32-bit counter
that every request draws on (`src/nxt_router.c:4767`).

Main avoided that, but in the wrong place: `nxt_main_process_sigchld_handler()`
cleared `->stream` for a child that had reached READY.  As #271 says, copying
that to the prototype was drafted and dropped in review, because READY is not
the moment the RPC is answered — `nxt_port_process_ready_handler()` sets the
state and only *then* calls `nxt_port_send_new_port()`, ignoring its return.

So this keys it on the reply instead.  `nxt_port_send_new_port()` now reports
whether the announcement that answers the start was accepted for delivery, and
the handler clears `->stream` only then.  That announcement is what retires the
registration — `nxt_router_new_port_handler()` feeds a stream-bearing NEW_PORT
to `nxt_port_rpc_handler()` (`src/nxt_router.c:768-771`) — so the stream is
spent exactly when it is cleared, and survives exactly the cases that still
need it: a failed write, and the queue-mapping arm that returns above the
announcement.  Main's sigchld clearing is removed rather than kept alongside:
it runs the same handler for its own children, and the new site is strictly
earlier and strictly narrower.

Two details that are easy to get wrong, and were:

**Only the router's announcement counts.**  The router owns the registration
for *every* start — it registers the RPC on its own port and then sends
START_PROCESS to main when a prototype must be forked and to the prototype when
a worker must (`nxt_router.c:5001`/`:459`, and `:3347`).  Main forks the
prototype but never owns the RPC for it.  So aggregating every peer is wrong in
the direction that costs correctness: the prototype announces a worker to main
*and* the router, and a failure to main with the router's write accepted would
keep a stream the router has already retired — the wrapped-counter hazard
again.  Other peers' failures are logged and do not change the answer.

**The stream announced is `process->stream`, not the one on the wire.**  A
child echoes the stream it inherited across the fork (`nxt_process.c:1142`), so
for a healthy child the two match — but the wire field is written by the
sender, and the gate from 4c79840d authenticates *who* sent a PROCESS_READY,
not what it says.  Taking the echoed value would let a child naming a different
stream (or zero) have the announcement carry a number no registration waits on
while this cleared the one that does: the router would never retire the real
start, and the REMOVE_PID fallback would carry nothing — a start pending
forever, i.e. worse than the bug being fixed.  A mismatch is logged, not
refused, since refusing would strand the start the receiver does know about.

## Tests

Extended in place, no new test files (so `auto/sources` and `nxt_tests.c` stay
untouched and out of the way of #268 and #280).

| test | on `origin/master` | on this branch |
|---|---|---|
| `nxt_main_start_process_reply_test.c` — a foreign sender to the prototype | **fails**: "did not refuse — the handler ran past the sender check and into the start path, and died there on signal 11" | passes |
| … — no router port in the prototype | (unreached) | passes |
| … — a worker inside a pid-isolated prototype | (unreached) | passes |
| `nxt_port_ready_test.c` — `->stream` survives when every peer's write failed | passes (nothing clears it) | passes |
| … — `->stream` is cleared once the announcement went out | **fails**: "the start stream survived an announcement that answered it…" | passes |
| … — a READY naming a foreign stream still announces the registered one | **fails**: announces `#3735928559`, not `#555819297` | passes |
| … — a READY naming stream 0 still announces the registered one | **fails** | passes |
| … — one peer's write failed: cleared iff the *router* got through | **fails**: "the router was announced to and retired the start, but the stream was kept because another peer's write failed" | passes |
| `test/test_php_isolation.py::test_php_isolation_pid_namespace` | passes (no gate) | passes |
| full `./build/tests` | passes | passes |
| `pytest test_php_application.py test_configuration.py test_php_isolation.py` (root) | — | 54 passed, 39 skipped |
| … the same, as a non-root user | 2 failed (pre-existing rootfs cases) | the same 2, plus the new pid-namespace case **passing** |

The three prototype refusal cases each run in a forked child: a handler that
does not refuse goes on to fork from a fixture with no application loaded, and
containing that keeps one broken gate from taking the test binary down.  The
parent reports a signalled child as the fall-through it is.

The new pytest was verified to have teeth rather than merely to pass: with the
isolated arm deleted — the shape a first draft of #270 would naturally take —
it fails with "Can't read response from server", the application never having
started.  The existing rootfs isolation cases ask for a pid namespace only
when the suite is *not* root, so as root (how CI runs it) nothing covered this;
the new case asks for one either way, and follows
`test_go_isolation.py::test_isolation_pid` in additionally requiring
unprivileged user namespaces and enabling the mount and credential ones when
the suite is not root, since `unshare(CLONE_NEWPID)` needs `CAP_SYS_ADMIN`.
Checked in both modes: it passes as root and as a normal user.  The two rootfs
failures in the non-root column are pre-existing — `origin/master` produces the
same two in the same container.

## Stacking

Both commits apply cleanly on top of #268 and #280, and the merged trees build
and pass the whole C suite, including each PR's own tests:

```
git merge-tree --write-tree --merge-base=origin/master <head> 5725d870   # PR #268
  -> 136fa33597106de378a132290861ceb80998360c   (no conflict)
git merge-tree --write-tree --merge-base=origin/master <head> 9caf38e7   # PR #280
  -> 62e969b4491c7c019e522b0cf182ea9ca8938530   (no conflict)
```

**#268 needs no hunk adjustment.**  Its `nxt_proto_child_exited()` answers the
CREATING case directly and clears `->stream` itself; this PR never clears it
for a child that has not reached READY, so the two are disjoint.  For a child
that *did* reach READY, #268 falls through to
`nxt_port_remove_notify_others()`, which under this PR carries stream 0 —
which is precisely what #271 asks for, so #268 gets the fix for free on that
path.  #268's `->stream_pid`/`->stream_port` fields and its edits to
`nxt_proto_start_process_handler()` are inside the handler body, below the
gate this PR adds at its top.

#280 is disjoint (`nxt_port_rpc.c`, `nxt_router.c`).

## Drafted CHANGES

To go in the `1.36.2` stanza (the one #268 opens):

```
    *) Bugfix: an application worker could ask its own prototype to start
       further workers. The prototype now verifies that a START_PROCESS
       message comes from the router, using the sender's kernel-validated
       PID, and refuses it otherwise.

    *) Bugfix: the exit of a healthy application worker asked the router to
       fail a start request that had already completed. The identifier of a
       completed start is now cleared once its reply has been sent, so that a
       later worker exit cannot cancel an unrelated request after the
       identifier counter wraps.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
