### PR TITLE
main: store the state files atomically

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -184,6 +184,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_proto_wedge_test.c \
     src/test/nxt_router_remove_pid_soak_test.c \
     src/test/nxt_main_start_process_reply_test.c \
+    src/test/nxt_main_file_store_test.c \
     src/test/nxt_port_change_file_test.c \
     src/test/nxt_port_fd_test.c \
 "

--- a/src/nxt_file.c
+++ b/src/nxt_file.c
@@ -426,6 +426,65 @@ nxt_file_rename(nxt_file_name_t *old_name, nxt_file_name_t *new_name)
 }
 
 
+nxt_int_t
+nxt_file_sync(nxt_task_t *task, nxt_file_t *file)
+{
+    nxt_debug(task, "fsync(%FD, \"%FN\")", file->fd, file->name);
+
+    if (nxt_fast_path(fsync(file->fd) == 0)) {
+        return NXT_OK;
+    }
+
+    file->error = nxt_errno;
+
+    nxt_alert(task, "fsync(%FD, \"%FN\") failed %E",
+              file->fd, file->name, file->error);
+
+    return NXT_ERROR;
+}
+
+
+nxt_int_t
+nxt_file_dir_sync(nxt_task_t *task, nxt_file_name_t *name)
+{
+    int        fd;
+    nxt_int_t  ret;
+    nxt_err_t  err;
+
+    fd = open((char *) name, O_RDONLY | NXT_FILE_DIR_SYNC_FLAGS);
+    if (nxt_slow_path(fd == -1)) {
+        nxt_alert(task, "open(\"%FN\", O_RDONLY) failed %E", name, nxt_errno);
+        return NXT_ERROR;
+    }
+
+    nxt_debug(task, "fsync(%FD, \"%FN\") directory", fd, name);
+
+    ret = NXT_OK;
+
+    if (nxt_slow_path(fsync(fd) != 0)) {
+        err = nxt_errno;
+
+        /*
+         * Some file systems refuse to flush a directory descriptor at all;
+         * the rename() has still happened, so this is not a store failure.
+         */
+        if (err == NXT_EINVAL || err == NXT_EOPNOTSUPP) {
+            nxt_debug(task, "fsync(%FD, \"%FN\") directory unsupported %E",
+                      fd, name, err);
+
+        } else {
+            nxt_alert(task, "fsync(%FD, \"%FN\") directory failed %E",
+                      fd, name, err);
+            ret = NXT_ERROR;
+        }
+    }
+
+    nxt_fd_close(fd);
+
+    return ret;
+}
+
+
 /*
  * ioctl(FIONBIO) sets a non-blocking mode using one syscall,
  * thereas fcntl(F_SETFL, O_NONBLOCK) needs to learn the current state

--- a/src/nxt_file.h
+++ b/src/nxt_file.h
@@ -141,10 +141,43 @@ NXT_EXPORT nxt_int_t nxt_file_openat2(nxt_task_t *task, nxt_file_t *file,
 
 #endif /* NXT_HAVE_OPENAT2 */
 
+/*
+ * O_DIRECTORY, where the platform has it, keeps nxt_file_dir_sync() from
+ * opening something that is not a directory.  It is not in POSIX, so the
+ * flag is optional.
+ */
+#if defined(O_DIRECTORY)
+#define NXT_FILE_DIR_SYNC_FLAGS     O_DIRECTORY
+#else
+#define NXT_FILE_DIR_SYNC_FLAGS     0
+#endif
+
+
+/*
+ * O_NOFOLLOW, where the platform has it, keeps a create from opening a
+ * symbolic link left in place of the file.  O_EXCL already refuses one --
+ * POSIX has open() fail when O_CREAT and O_EXCL are set and the path names
+ * a link -- so this is the belt to that pair of braces, and optional.
+ */
+#if defined(O_NOFOLLOW)
+#define NXT_FILE_NOFOLLOW           O_NOFOLLOW
+#else
+#define NXT_FILE_NOFOLLOW           0
+#endif
+
+
 /* The file creation modes. */
 #define NXT_FILE_CREATE_OR_OPEN     O_CREAT
 #define NXT_FILE_OPEN               0
 #define NXT_FILE_TRUNCATE           (O_CREAT | O_TRUNC)
+
+/*
+ * Create the file or fail: never open something that is already there, and
+ * never follow a link to it.  For a path an unprivileged user could have
+ * got to first -- see nxt_main_file_store().
+ */
+#define NXT_FILE_CREATE_EXCLUSIVE                                             \
+    (O_CREAT | O_EXCL | NXT_FILE_NOFOLLOW)
 
 /* The file access rights. */
 #define NXT_FILE_DEFAULT_ACCESS     0644
@@ -181,6 +214,17 @@ NXT_EXPORT nxt_int_t nxt_file_chown(nxt_file_name_t *name, const char *owner,
     const char *group);
 NXT_EXPORT nxt_int_t nxt_file_rename(nxt_file_name_t *old_name,
     nxt_file_name_t *new_name);
+
+/*
+ * Flush an open file, respectively a directory named by path, to stable
+ * storage.  A durable replace is: write the temporary file, nxt_file_sync()
+ * it, nxt_file_rename() it over the destination, then nxt_file_dir_sync()
+ * the directory that holds them -- without the last step the rename itself
+ * may not survive a power loss.
+ */
+NXT_EXPORT nxt_int_t nxt_file_sync(nxt_task_t *task, nxt_file_t *file);
+NXT_EXPORT nxt_int_t nxt_file_dir_sync(nxt_task_t *task,
+    nxt_file_name_t *name);
 
 NXT_EXPORT nxt_int_t nxt_fd_nonblocking(nxt_task_t *task, nxt_fd_t fd);
 NXT_EXPORT nxt_int_t nxt_fd_blocking(nxt_task_t *task, nxt_fd_t fd);

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -62,8 +62,10 @@ static void nxt_main_process_whoami_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 static void nxt_main_port_conf_store_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
-static nxt_int_t nxt_main_file_store(nxt_task_t *task, const char *tmp_name,
-    const char *name, u_char *buf, size_t size);
+static nxt_int_t nxt_main_file_store(nxt_task_t *task, const char *dir,
+    const char *tmp_name, const char *name, u_char *buf, size_t size);
+static nxt_int_t nxt_main_file_store_inherit(nxt_task_t *task,
+    nxt_file_t *tmp, const char *name);
 static void nxt_main_port_access_log_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 
@@ -729,6 +731,20 @@ nxt_main_test_run_start_process_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg)
 {
     nxt_main_start_process_handler(task, msg);
+}
+
+
+/*
+ * Public wrapper that lets src/test/nxt_main_file_store_test.c drive the
+ * static nxt_main_file_store() against a scratch directory -- used to
+ * verify that the store is atomic and never damages the existing file
+ * (issue #215).
+ */
+nxt_int_t
+nxt_main_test_run_file_store(nxt_task_t *task, const char *dir,
+    const char *tmp_name, const char *name, u_char *buf, size_t size)
+{
+    return nxt_main_file_store(task, dir, tmp_name, name, buf, size);
 }
 
 #endif
@@ -1889,7 +1905,7 @@ nxt_main_port_conf_store_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     if (nxt_conf_ver != NXT_VERNUM) {
         n = nxt_sprintf(ver, ver + NXT_INT_T_LEN, "%d", NXT_VERNUM) - ver;
 
-        ret = nxt_main_file_store(task, rt->ver_tmp, rt->ver, ver, n);
+        ret = nxt_main_file_store(task, rt->state, rt->ver_tmp, rt->ver, ver, n);
         if (nxt_slow_path(ret != NXT_OK)) {
             goto error;
         }
@@ -1897,7 +1913,7 @@ nxt_main_port_conf_store_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
         nxt_conf_ver = NXT_VERNUM;
     }
 
-    ret = nxt_main_file_store(task, rt->conf_tmp, rt->conf, p, size);
+    ret = nxt_main_file_store(task, rt->state, rt->conf_tmp, rt->conf, p, size);
 
     if (nxt_fast_path(ret == NXT_OK)) {
         goto cleanup;
@@ -1920,34 +1936,208 @@ cleanup:
 }
 
 
+/*
+ * Replace "name" with "size" bytes of "buf" atomically: the content goes to
+ * "tmp_name", which the caller places in "dir" beside the destination, is
+ * flushed, and only then rename(2)d over "name", so a reader sees either
+ * the whole old file or the whole new one.  "dir" is flushed after the
+ * rename, without which the rename may not survive a power loss.  Every
+ * failure before the rename unlinks the temporary and leaves the existing
+ * "name" untouched.
+ *
+ * Because the replacement arrives by rename(), a "name" that was a symlink
+ * is replaced by a regular file rather than followed -- the price of
+ * atomicity.  A symlinked state *directory* is unaffected: "dir" and
+ * "tmp_name" resolve through it just as "name" does.
+ *
+ * The temporary is created 0600 as before; when the destination already
+ * exists, its mode and ownership are carried over to the replacement, so a
+ * state file an administrator has re-permissioned keeps its settings.
+ */
 static nxt_int_t
-nxt_main_file_store(nxt_task_t *task, const char *tmp_name, const char *name,
-    u_char *buf, size_t size)
+nxt_main_file_store(nxt_task_t *task, const char *dir, const char *tmp_name,
+    const char *name, u_char *buf, size_t size)
 {
+    size_t      written;
     ssize_t     n;
     nxt_int_t   ret;
     nxt_file_t  file;
 
     nxt_memzero(&file, sizeof(nxt_file_t));
 
-    file.name = (nxt_file_name_t *) name;
+    file.name = (nxt_file_name_t *) tmp_name;
 
-    ret = nxt_file_open(task, &file, NXT_FILE_WRONLY, NXT_FILE_TRUNCATE,
-                        NXT_FILE_OWNER_ACCESS);
+    /*
+     * Without a log level nxt_file_open() reports nothing, and a failed
+     * store would be diagnosable only from the caller's summary alert.
+     * NXT_LOG_ALERT is zero, which is the "say nothing" value, so the
+     * loudest usable level here is NXT_LOG_ERR.
+     */
+    file.log_level = NXT_LOG_ERR;
+
+    /*
+     * Unlink first, then create exclusively, rather than opening the
+     * temporary with O_TRUNC.  The name is predictable and the store runs
+     * as root, so if --statedir is writable by anyone else that user can
+     * put a symbolic link there ahead of us: O_TRUNC would follow it and
+     * truncate whatever it addresses, and the rename below would then
+     * install the link as the state file.  O_EXCL refuses a link outright
+     * and refuses a regular file somebody hard-linked to a target we must
+     * not write, which O_NOFOLLOW alone would not.
+     *
+     * A leftover temporary from an interrupted store is still simply
+     * replaced -- that is what the unlink is for.  The window between the
+     * two is not a hole: something recreated in it makes the create fail,
+     * which loses the store and keeps the target, rather than the other
+     * way round.
+     */
+    if (nxt_slow_path(unlink(tmp_name) != 0 && nxt_errno != NXT_ENOENT)) {
+        nxt_alert(task, "unlink(\"%FN\") failed %E", file.name, nxt_errno);
+
+        return NXT_ERROR;
+    }
+
+    ret = nxt_file_open(task, &file, NXT_FILE_WRONLY,
+                        NXT_FILE_CREATE_EXCLUSIVE, NXT_FILE_OWNER_ACCESS);
     if (nxt_slow_path(ret != NXT_OK)) {
         return NXT_ERROR;
     }
 
-    n = nxt_file_write(&file, buf, size, 0);
+    /*
+     * pwrite() is allowed to store less than it was asked for, and this
+     * store exists to survive a partial one: resume from where it stopped
+     * rather than turning a short write into a failed store.  A zero return
+     * carries no errno and cannot make progress, so it ends the loop.
+     */
+    for (written = 0; written < size; written += n) {
+        n = nxt_file_write(&file, buf + written, size - written, written);
+
+        if (nxt_slow_path(n <= 0)) {
+            /* nxt_file_write() logs the errno; a zero return has none. */
+            if (n == 0) {
+                nxt_alert(task, "write(\"%FN\") stored %uz of %uz bytes",
+                          file.name, written, size);
+            }
+
+            goto fail;
+        }
+    }
+
+    if (nxt_slow_path(nxt_main_file_store_inherit(task, &file, name)
+                      != NXT_OK))
+    {
+        goto fail;
+    }
+
+    /*
+     * rename() already orders the name change for readers; what this buys
+     * is the data reaching stable storage before the name points at it, so
+     * a crash cannot leave conf.json naming a file whose blocks were never
+     * written.
+     */
+    if (nxt_slow_path(nxt_file_sync(task, &file) != NXT_OK)) {
+        goto fail;
+    }
 
     nxt_file_close(task, &file);
+    file.fd = NXT_FILE_INVALID;
 
-    if (nxt_slow_path(n != (ssize_t) size)) {
+    if (nxt_slow_path(nxt_file_rename(file.name, (nxt_file_name_t *) name)
+                      != NXT_OK))
+    {
         (void) nxt_file_delete(file.name);
         return NXT_ERROR;
     }
 
-    return nxt_file_rename(file.name, (nxt_file_name_t *) name);
+    /* The destination is in place; a failed flush only costs durability. */
+    (void) nxt_file_dir_sync(task, (nxt_file_name_t *) dir);
+
+    return NXT_OK;
+
+fail:
+
+    if (file.fd != NXT_FILE_INVALID) {
+        nxt_file_close(task, &file);
+    }
+
+    (void) nxt_file_delete(file.name);
+
+    return NXT_ERROR;
+}
+
+
+/*
+ * Carry the destination's mode and ownership onto the temporary that is
+ * about to replace it.  A destination that does not exist yet, or that is
+ * not a regular file, keeps the 0600 the temporary was created with.
+ */
+static nxt_int_t
+nxt_main_file_store_inherit(nxt_task_t *task, nxt_file_t *tmp,
+    const char *name)
+{
+    nxt_file_info_t  fi;
+
+    /*
+     * lstat(), not nxt_file_info(), which stat()s a name and therefore
+     * follows a symbolic link.  The temporary is created exclusively
+     * because --statedir may be writable by another user; that same user
+     * can point the destination at a file of their own, and a stat() here
+     * would copy its ownership and mode onto the replacement -- aim it at
+     * something 0666 and conf.json comes back world-writable, and stays
+     * that way, because every later store inherits it again.
+     *
+     * On the path this is for -- an administrator's re-permissioned state
+     * file -- lstat() and stat() agree.
+     */
+    if (lstat(name, &fi) != 0) {
+        if (nxt_errno == NXT_ENOENT) {
+            return NXT_OK;
+        }
+
+        /*
+         * The temporary is written and 0600 is a serviceable result, so
+         * an unreadable destination costs the inheritance and not the
+         * store: refusing to persist the configuration at all is the worse
+         * outcome, which is the same trade the fchown() below makes.
+         */
+        nxt_log(task, NXT_LOG_INFO, "lstat(\"%FN\") failed %E",
+                (nxt_file_name_t *) name, nxt_errno);
+
+        return NXT_OK;
+    }
+
+    /*
+     * Only a regular file donates anything.  A symbolic link, or a
+     * destination somebody replaced with a device or a directory, leaves
+     * the temporary on the 0600 it was created with; the rename replaces
+     * whatever is there either way.
+     */
+    if (!S_ISREG(fi.st_mode)) {
+        return NXT_OK;
+    }
+
+    /*
+     * Ownership first, mode second.  A successful chown() clears set-user-ID
+     * and set-group-ID on a regular file -- Linux does it to root's chown()
+     * too -- so doing it the other way round would drop exactly the bits
+     * "fi.st_mode & 07777" is here to carry over.
+     *
+     * Main runs as root, so this normally succeeds; when it cannot change
+     * the owner the store still proceeds -- refusing to persist the
+     * configuration would be the worse failure.
+     */
+    if (nxt_slow_path(fchown(tmp->fd, fi.st_uid, fi.st_gid) != 0)) {
+        nxt_log(task, NXT_LOG_INFO, "fchown(%FD, \"%FN\") failed %E",
+                tmp->fd, tmp->name, nxt_errno);
+    }
+
+    if (nxt_slow_path(fchmod(tmp->fd, fi.st_mode & 07777) != 0)) {
+        nxt_alert(task, "fchmod(%FD, \"%FN\") failed %E",
+                  tmp->fd, tmp->name, nxt_errno);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
 }
 
 

--- a/src/nxt_main_process.h
+++ b/src/nxt_main_process.h
@@ -37,6 +37,8 @@ extern const nxt_sig_event_t  nxt_process_signals[];
 void nxt_main_test_process_new_failures(nxt_uint_t failures);
 void nxt_main_test_run_start_process_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
+nxt_int_t nxt_main_test_run_file_store(nxt_task_t *task, const char *dir,
+    const char *tmp_name, const char *name, u_char *buf, size_t size);
 #endif
 
 

--- a/src/test/nxt_main_file_store_test.c
+++ b/src/test/nxt_main_file_store_test.c
@@ -1,0 +1,421 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for issue #215: nxt_main_file_store()
+ * (src/nxt_main_process.c) ignored its "tmp_name" argument, opening the
+ * destination itself with NXT_FILE_TRUNCATE and finishing with a rename()
+ * of the file onto itself.  The state file was rewritten in place, and the
+ * short-write path unlinked what was then the live conf.json.
+ *
+ * Four invariants, each observed rather than inferred:
+ *
+ *   - a store replaces the destination by rename(2), pinned down by the
+ *     inode number changing.  An in-place rewrite keeps the inode, so this
+ *     case alone separates the fixed function from the old one;
+ *   - no temporary survives a successful store, including a stale one from
+ *     an interrupted run left in the way;
+ *   - a store that cannot create its temporary reports NXT_ERROR and leaves
+ *     the destination byte-for-byte intact -- the shape of an ENOSPC or a
+ *     read-only state directory, where the old code destroyed the
+ *     configuration it was asked to update;
+ *   - an existing destination keeps its mode across the replacement.
+ *
+ * Ownership is not asserted: the test does not require root, and chown() to
+ * another uid is not available to an unprivileged run.
+ */
+
+#include <nxt_main.h>
+#include <nxt_runtime.h>
+#include <nxt_main_process.h>
+#include "nxt_tests.h"
+
+#include <sys/stat.h>
+
+
+#define nxt_main_file_store_test_fail(thr, ...)                               \
+    do {                                                                      \
+        nxt_log_alert((thr)->log, "main file store test: " __VA_ARGS__);       \
+        goto done;                                                            \
+    } while (0)
+
+
+static nxt_int_t
+nxt_main_file_store_test_content(const char *name, char *buf, size_t size,
+    ssize_t *len)
+{
+    int      fd;
+    ssize_t  n;
+
+    fd = open(name, O_RDONLY);
+    if (nxt_slow_path(fd == -1)) {
+        return NXT_ERROR;
+    }
+
+    n = read(fd, buf, size);
+
+    close(fd);
+
+    if (nxt_slow_path(n < 0)) {
+        return NXT_ERROR;
+    }
+
+    *len = n;
+
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_main_file_store_test_holds(const char *name, const char *expected)
+{
+    char     buf[256];
+    size_t   len;
+    ssize_t  n;
+
+    if (nxt_slow_path(nxt_main_file_store_test_content(name, buf, sizeof(buf),
+                                                       &n)
+                      != NXT_OK))
+    {
+        return NXT_ERROR;
+    }
+
+    len = nxt_strlen(expected);
+
+    if (nxt_slow_path((size_t) n != len || memcmp(buf, expected, len) != 0)) {
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_main_file_store_test_plant(const char *name, const char *content,
+    mode_t mode)
+{
+    int      fd;
+    size_t   len;
+    ssize_t  n;
+
+    fd = open(name, O_WRONLY | O_CREAT | O_TRUNC, mode);
+    if (nxt_slow_path(fd == -1)) {
+        return NXT_ERROR;
+    }
+
+    len = nxt_strlen(content);
+
+    n = write(fd, content, len);
+
+    close(fd);
+
+    /* open() honours the umask; the test needs the exact mode. */
+    if (nxt_slow_path(n != (ssize_t) len || chmod(name, mode) != 0)) {
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_main_file_store_test_store(nxt_task_t *task, const char *dir,
+    const char *tmp_name, const char *name, const char *content)
+{
+    return nxt_main_test_run_file_store(task, dir, tmp_name, name,
+                                        (u_char *) content,
+                                        nxt_strlen(content));
+}
+
+
+nxt_int_t
+nxt_main_file_store_test(nxt_thread_t *thr)
+{
+    char         dir[NXT_MAX_PATH_LEN], name[NXT_MAX_PATH_LEN];
+    char         tmp_name[NXT_MAX_PATH_LEN], nowhere[NXT_MAX_PATH_LEN];
+    char         victim[NXT_MAX_PATH_LEN];
+    ino_t        first_ino;
+    const char   *tmpdir;
+    nxt_int_t    ret;
+    nxt_task_t   *task;
+    struct stat  st;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "main file store test started");
+
+    task = thr->task;
+    task->thread = thr;
+
+    tmpdir = getenv("TMPDIR");
+    if (tmpdir == NULL || tmpdir[0] != '/') {
+        tmpdir = "/tmp";
+    }
+
+    (void) nxt_sprintf((u_char *) dir, (u_char *) dir + sizeof(dir),
+                       "%s/nxt_main_file_store_test.XXXXXX%Z", tmpdir);
+
+    if (nxt_slow_path(mkdtemp(dir) == NULL)) {
+        nxt_log_alert(thr->log, "main file store test: mkdtemp(\"%s\") "
+                      "failed %E", dir, nxt_errno);
+        return NXT_ERROR;
+    }
+
+    ret = NXT_ERROR;
+
+    (void) nxt_sprintf((u_char *) name, (u_char *) name + sizeof(name),
+                       "%s/conf.json%Z", dir);
+    (void) nxt_sprintf((u_char *) tmp_name,
+                       (u_char *) tmp_name + sizeof(tmp_name),
+                       "%s/conf.json.tmp%Z", dir);
+    (void) nxt_sprintf((u_char *) nowhere,
+                       (u_char *) nowhere + sizeof(nowhere),
+                       "%s/absent/conf.json.tmp%Z", dir);
+    (void) nxt_sprintf((u_char *) victim,
+                       (u_char *) victim + sizeof(victim),
+                       "%s/victim%Z", dir);
+
+    /* A first store into an empty directory creates the destination. */
+
+    if (nxt_main_file_store_test_store(task, dir, tmp_name, name,
+                                       "{\"one\":1}") != NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "the first store failed");
+    }
+
+    if (nxt_main_file_store_test_holds(name, "{\"one\":1}") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" does not hold what the "
+                                      "first store wrote", name);
+    }
+
+    if (stat(name, &st) != 0) {
+        nxt_main_file_store_test_fail(thr, "stat(\"%s\") failed %E", name,
+                                      nxt_errno);
+    }
+
+    first_ino = st.st_ino;
+
+    /*
+     * A stale temporary sits in the way, standing in for a store that was
+     * interrupted before its rename: it must be overwritten silently and
+     * must not survive.
+     */
+
+    if (nxt_main_file_store_test_plant(tmp_name, "stale", 0600) != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "could not plant a stale "
+                                      "temporary");
+    }
+
+    if (nxt_main_file_store_test_store(task, dir, tmp_name, name,
+                                       "{\"two\":2}") != NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "the second store failed");
+    }
+
+    if (nxt_main_file_store_test_holds(name, "{\"two\":2}") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" does not hold what the "
+                                      "second store wrote", name);
+    }
+
+    if (stat(tmp_name, &st) == 0) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" was left behind by a "
+                                      "successful store", tmp_name);
+    }
+
+    if (stat(name, &st) != 0) {
+        nxt_main_file_store_test_fail(thr, "stat(\"%s\") failed %E", name,
+                                      nxt_errno);
+    }
+
+    if (st.st_ino == first_ino) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" kept inode %uL across a "
+                                      "store -- the file was rewritten in "
+                                      "place, so a crash mid-write leaves "
+                                      "it truncated", name,
+                                      (uint64_t) first_ino);
+    }
+
+    /*
+     * A store that cannot create its temporary -- the path names a
+     * directory that does not exist, the shape of a full or read-only state
+     * directory -- must report the failure and leave the destination as it
+     * was.
+     */
+
+    if (nxt_main_file_store_test_store(task, dir, nowhere, name,
+                                       "{\"three\":3}") == NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "a store whose temporary cannot "
+                                      "be created reported success");
+    }
+
+    if (nxt_main_file_store_test_holds(name, "{\"two\":2}") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "a failed store damaged \"%s\"",
+                                      name);
+    }
+
+    /* An existing destination keeps its mode across the replacement. */
+
+    if (chmod(name, 0640) != 0) {
+        nxt_main_file_store_test_fail(thr, "chmod(\"%s\") failed %E", name,
+                                      nxt_errno);
+    }
+
+    if (nxt_main_file_store_test_store(task, dir, tmp_name, name,
+                                       "{\"four\":4}") != NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "the mode-preserving store "
+                                      "failed");
+    }
+
+    if (stat(name, &st) != 0 || (st.st_mode & 07777) != 0640) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" came back with mode "
+                                      "0x%04xd, expected the 0640 (0x1a0) it had",
+                                      name, (unsigned) (st.st_mode & 07777));
+    }
+
+    /*
+     * Set-user-ID survives too.  The replacement carries the mode over with
+     * fchmod() and the ownership with fchown(), and a chown() of a regular
+     * file clears set-user-ID -- so doing them in that order would drop the
+     * bit while appearing to preserve the mode.  An unchanged owner is
+     * enough to trigger it, which is why this is assertable without root.
+     */
+
+    if (chmod(name, 04640) != 0) {
+        nxt_main_file_store_test_fail(thr, "chmod(\"%s\") failed %E", name,
+                                      nxt_errno);
+    }
+
+    if (nxt_main_file_store_test_store(task, dir, tmp_name, name,
+                                       "{\"setid\":1}") != NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "the set-user-ID preserving store "
+                                      "failed");
+    }
+
+    if (stat(name, &st) != 0 || (st.st_mode & 07777) != 04640) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" came back with mode "
+                                      "0x%04xd, expected the 04640 (0x9a0) "
+                                      "it had -- chown() after chmod() "
+                                      "clears set-user-ID", name,
+                                      (unsigned) (st.st_mode & 07777));
+    }
+
+    if (chmod(name, 0640) != 0) {
+        nxt_main_file_store_test_fail(thr, "chmod(\"%s\") failed %E", name,
+                                      nxt_errno);
+    }
+
+    /*
+     * The temporary's name is predictable and the store runs as root, so a
+     * state directory writable by anyone else is a place to leave a symbolic
+     * link under that name and have the store follow it.  Opening with
+     * O_TRUNC did: it truncated whatever the link addressed and the rename
+     * then installed the link as the state file.  The store must write the
+     * state file and leave the link's target alone.
+     */
+
+    if (nxt_main_file_store_test_plant(victim, "precious", 0600) != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "could not plant the link target");
+    }
+
+    (void) unlink(tmp_name);
+
+    if (symlink(victim, tmp_name) != 0) {
+        nxt_main_file_store_test_fail(thr, "symlink(\"%s\", \"%s\") failed "
+                                      "%E", victim, tmp_name, nxt_errno);
+    }
+
+    if (nxt_main_file_store_test_store(task, dir, tmp_name, name,
+                                       "{\"five\":5}") != NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "a store whose temporary was a "
+                                      "symbolic link failed");
+    }
+
+    if (nxt_main_file_store_test_holds(victim, "precious") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "the store followed the link and "
+                                      "wrote through it to \"%s\"", victim);
+    }
+
+    if (nxt_main_file_store_test_holds(name, "{\"five\":5}") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" does not hold what the "
+                                      "store past a link wrote", name);
+    }
+
+    if (lstat(name, &st) != 0 || !S_ISREG(st.st_mode)) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" is not a regular file -- "
+                                      "the link was installed as the state "
+                                      "file", name);
+    }
+
+    (void) unlink(victim);
+
+    /*
+     * The destination can be a symbolic link as well, and there the danger
+     * is not the write -- the rename replaces the link whatever it points
+     * at -- but the inheritance.  Reading the destination's mode with
+     * stat() follows the link, so a link to a file of the other user's own
+     * hands them the mode of the conf.json that replaces it: aim it at
+     * something 0666 and every later store inherits that again.
+     */
+
+    if (nxt_main_file_store_test_plant(victim, "bait", 0666) != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "could not plant the mode bait");
+    }
+
+    (void) unlink(name);
+
+    if (symlink(victim, name) != 0) {
+        nxt_main_file_store_test_fail(thr, "symlink(\"%s\", \"%s\") failed "
+                                      "%E", victim, name, nxt_errno);
+    }
+
+    if (nxt_main_file_store_test_store(task, dir, tmp_name, name,
+                                       "{\"six\":6}") != NXT_OK)
+    {
+        nxt_main_file_store_test_fail(thr, "a store onto a linked "
+                                      "destination failed");
+    }
+
+    if (nxt_main_file_store_test_holds(victim, "bait") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "the store wrote through the "
+                                      "linked destination to \"%s\"", victim);
+    }
+
+    if (nxt_main_file_store_test_holds(name, "{\"six\":6}") != NXT_OK) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" does not hold what the "
+                                      "store onto a link wrote", name);
+    }
+
+    if (lstat(name, &st) != 0 || !S_ISREG(st.st_mode)) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" is not a regular file "
+                                      "after a store onto a link", name);
+    }
+
+    if ((st.st_mode & 07777) != 0600) {
+        nxt_main_file_store_test_fail(thr, "\"%s\" came back with mode "
+                                      "0x%04xd, expected the 0600 (0x180) "
+                                      "the temporary was created with -- the "
+                                      "store inherited the link target's "
+                                      "mode", name,
+                                      (unsigned) (st.st_mode & 07777));
+    }
+
+    (void) unlink(victim);
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "main file store test passed");
+
+    ret = NXT_OK;
+
+done:
+
+    (void) unlink(name);
+    (void) unlink(tmp_name);
+    (void) unlink(victim);
+    (void) rmdir(dir);
+
+    return ret;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -221,6 +221,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_main_file_store_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_change_file_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -79,6 +79,7 @@ nxt_int_t nxt_router_start_fail_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_proto_wedge_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_remove_pid_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_main_start_process_reply_test(nxt_thread_t *thr);
+nxt_int_t nxt_main_file_store_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);

--- a/test/syscalls/baseline-linux-glibc.txt
+++ b/test/syscalls/baseline-linux-glibc.txt
@@ -20,8 +20,11 @@ epoll_wait
 eventfd2
 execve
 exit_group
+fchmod
+fchown
 fcntl
 fstat
+fsync
 ftruncate
 getdents64
 getegid

--- a/test/syscalls/baseline-linux-musl.txt
+++ b/test/syscalls/baseline-linux-musl.txt
@@ -18,9 +18,12 @@ epoll_pwait
 eventfd2
 execve
 exit_group
+fchmod
+fchown
 fcntl
 fork
 fstat
+fsync
 ftruncate
 futex
 getdents64
@@ -33,6 +36,7 @@ getsockopt
 gettid
 ioctl
 listen
+lstat
 membarrier
 mkdir
 mmap

--- a/test/syscalls/capture.sh
+++ b/test/syscalls/capture.sh
@@ -156,6 +156,23 @@ done
 grep -q 'syscall drift canary' "$WORK/body.txt" \
     || die "served body is not the canary file"
 
+# A second PUT, so the capture covers storing over state files that already
+# exist.  The first one writes conf.json and version into an empty statedir,
+# where nxt_main_file_store_inherit() finds no destination and returns before
+# it reads or copies anything -- so a single PUT never reaches the fchmod()
+# and fchown() that carry a destination's mode and ownership onto its
+# replacement, and the syscalls of the most privileged path in the store
+# would be invisible to this gate.  The settings block is here only to make
+# the configuration differ from the one above; the listener and routes are
+# untouched, so the canary served above still describes what is running.
+sed -e 's/^{$/{\n    "settings": {"http": {"header_read_timeout": 30}},/' \
+    "$WORK/config.json" > "$WORK/config2.json"
+
+curl -sS --fail --max-time 10 --unix-socket "$SOCK" \
+    -X PUT --data-binary "@$WORK/config2.json" \
+    http://localhost/config >"$WORK/put2.log" 2>&1 \
+    || { cat "$WORK/put2.log" >&2; die "the second configuration was rejected"; }
+
 # Stop the daemon and let it run its teardown path *inside* the trace, so
 # shutdown syscalls are part of the captured set.  Signal unitd, not strace
 # (see unit_pid above), then wait for strace itself to reap and flush.

--- a/test/test_state_store.py
+++ b/test/test_state_store.py
@@ -1,0 +1,141 @@
+"""Persistence of the state directory (issue #215).
+
+The controller hands each accepted configuration to the main process, which
+writes it to <statedir>/conf.json.  That write used to go straight into
+conf.json with O_TRUNC, so a store that could not finish left the file
+truncated -- and the short-write path unlinked it outright, which is what
+this test observes on the unfixed code: a configuration too large for the
+filesystem leaves no conf.json at all.
+
+The failure is arranged by putting the state directory on a 64 KiB tmpfs,
+which needs root and CAP_SYS_ADMIN (pytest as root in a --privileged
+container) as well as --restart; the test skips otherwise.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from conftest import unit_run, unit_stop
+from unit.applications.proto import ApplicationProto
+from unit.log import Log
+
+client = ApplicationProto()
+
+
+SMALL_CONF = {
+    "listeners": {"*:8080": {"pass": "routes"}},
+    "routes": [{"action": {"return": 200}}],
+}
+
+
+def big_conf(routes):
+    """Far more than the 64 KiB the filesystem below has."""
+
+    return {
+        "listeners": {"*:8080": {"pass": "routes"}},
+        "routes": [
+            {"match": {"uri": f"/{'p' * 200}{i}"}, "action": {"return": 200}}
+            for i in range(routes)
+        ],
+    }
+
+
+def wait_for_stored(statedir, expected, wait=100):
+    """The store is asynchronous: the controller answers the PUT and only
+    then asks the main process to persist it."""
+
+    conf_json = statedir / 'conf.json'
+
+    for _ in range(wait):
+        try:
+            conf = json.loads(conf_json.read_text(encoding='utf-8'))
+            if conf.get('listeners') == expected['listeners']:
+                return conf
+        except (OSError, ValueError):
+            pass
+
+        time.sleep(0.1)
+
+    return None
+
+
+def test_state_store_full_filesystem(skip_alert):
+    """A store that runs out of space must not damage the stored config."""
+
+    if os.geteuid() != 0:
+        pytest.skip('requires root to mount a tmpfs')
+
+    unit_stop()
+
+    statedir = Path(tempfile.mkdtemp(prefix='unit-state-'))
+
+    mounted = subprocess.run(
+        ['mount', '-t', 'tmpfs', '-o', 'size=64k', 'none', str(statedir)],
+        check=False,
+        capture_output=True,
+    )
+
+    if mounted.returncode != 0:
+        pytest.skip(f'could not mount a tmpfs: {mounted.stderr.decode()}')
+
+    # The two alerts the failed store is expected to log.
+    skip_alert(
+        r'failed to store current configuration',
+        r'write\(.*conf\.json\.tmp',
+    )
+
+    try:
+        # main creates and writes everything here as root, so this only has
+        # to be traversable.  0777 would be the very condition the store is
+        # hardened against -- a state directory another user can plant a
+        # symbolic link in.
+        os.chmod(statedir, 0o755)
+
+        unit_run(state_dir=str(statedir))
+
+        # The configuration that must survive.
+        assert 'success' in client.conf(SMALL_CONF), 'the small store'
+        assert wait_for_stored(statedir, SMALL_CONF) is not None, 'stored'
+
+        stored = (statedir / 'conf.json').read_bytes()
+
+        assert 'success' in client.conf(big_conf(400)), 'the large PUT'
+
+        # The store is attempted asynchronously; wait for it to give up.
+        Log.wait_for_record(r'failed to store current configuration')
+
+        # The store failed; the previously stored configuration is intact,
+        # byte for byte, and still parses.
+        after = (statedir / 'conf.json').read_bytes()
+
+        assert after == stored, (
+            'conf.json was damaged by a store that could not complete'
+        )
+        assert json.loads(after)['listeners'] == SMALL_CONF['listeners']
+
+        # And nothing was left half-written next to it.
+        assert [p.name for p in statedir.iterdir() if '.tmp' in p.name] == []
+
+        # "version" goes through the same function and is stored first, so a
+        # store that damaged it would leave the state directory unloadable
+        # even with conf.json intact.
+        version = statedir / 'version'
+
+        assert version.is_file(), 'version survived the failed store'
+        assert version.read_bytes().strip() != b'', 'version is not empty'
+
+    finally:
+        unit_stop()
+        subprocess.run(
+            ['umount', str(statedir)], check=False, capture_output=True
+        )
+        # A failed umount would make rmdir() raise out of the finally and
+        # mask whichever assertion above actually failed.
+        shutil.rmtree(statedir, ignore_errors=True)


### PR DESCRIPTION
Fixes #215

`nxt_main_file_store()` (`src/nxt_main_process.c:1924`) took a `tmp_name` argument and never used it. It set `file.name` from `name`, opened the destination itself with `NXT_FILE_TRUNCATE`, wrote into it, and finished with `nxt_file_rename(file.name, name)` — a rename of the file onto itself. `conf.json` and `version` were replaced in place, with a window in which the destination was truncated to zero and only partly rewritten. Restoring a truncated state file degrades to an *empty* configuration with only a log alert (`src/nxt_controller.c:196`), so an interrupted store could silently bring the daemon back serving nothing.

The short-write path was worse than the crash case: it did `nxt_file_delete(file.name)`, which under that spelling was the live `conf.json`. A store that ran out of space removed the existing good configuration outright, with no crash required. That is not a theoretical reading — it is what the new pytest observes on the unfixed code: with the state directory on a 64 KiB tmpfs, a configuration too large to store leaves **no `conf.json` at all**.

## The fix

`nxt_main_file_store()` now writes `tmp_name`, `fsync()`s it, `rename(2)`s it over the destination and `fsync()`s the containing directory. Every failure before the rename unlinks the temporary and leaves the destination untouched. The directory flush is what makes the rename survive a power loss; its own failure is not treated as a store failure, since the destination is already in place, and `EINVAL`/`EOPNOTSUPP` (filesystems that refuse to flush a directory descriptor) are tolerated.

The two callers (`src/nxt_main_process.c:1892`, `:1900`) pass `rt->state`, the directory both paths are built from (`src/nxt_runtime.c:927-961`). The temporary names they already passed are unchanged, so this is not a configuration or layout change.

`nxt_file_sync()` and `nxt_file_dir_sync()` are new in `src/nxt_file.c`. `O_DIRECTORY` is used where the platform has it; POSIX-only, no Windows path.

### Behaviour change worth calling out

Because the replacement now arrives by `rename(2)`, **a `conf.json` or `version` that was a symlink is replaced by a regular file** rather than followed. That is the price of atomicity, and it is the behaviour the temporary-file plumbing always intended. A symlinked state *directory* is unaffected: `rt->state`, the temporary and the destination all resolve through it alike, so the temporary is still created beside the file it replaces.

### Diagnosability

The `nxt_file_t` was `memzero`'d, so `log_level` was `0` — the "say nothing" value — and `nxt_file_open()` reported nothing at all. `NXT_LOG_ALERT` is itself `0` and cannot be used, so `NXT_LOG_ERR` is set before the open. A short `pwrite()` carries no errno and was therefore silent even inside `nxt_file_write()`; it is now logged with both byte counts. On the tmpfs the test builds, a failed store says:

```
[alert] write("/.../conf.json.tmp") stored 57344 of 99543 bytes
[alert] failed to store current configuration
```

and a temporary that cannot be created says:

```
[error] open("/.../absent/conf.json.tmp") failed (2: No such file or directory)
```

### Mode and ownership

The temporary is created 0600 as before; when the destination already exists, its mode and owner are carried onto the replacement, so a state file an administrator has re-permissioned is not reverted to 0600. Main runs as root, so the `fchown()` normally succeeds; a failure is logged at INFO and the store proceeds — refusing to persist the configuration would be the worse outcome.

## Out of scope

The controller answers the configuration request **before** the store is attempted, because `CONF_STORE` carries no reply (`src/nxt_controller.c:604-663`). A store that fails is therefore still reported to the client as a success, and only the log says otherwise. That is the second half of the issue; threading a reply back through that path is a separate change and is not in this PR.

## Tests

`src/test/nxt_main_file_store_test.c` drives the store through a new `NXT_TESTS` wrapper (the same pattern `nxt_main_start_process_reply_test.c` already uses) and pins down four invariants:

- the destination's **inode changes** across a store — an in-place truncate-and-write keeps it, so this alone separates the fixed function from the old one;
- no temporary survives a successful store, including a stale one planted in the way;
- a store whose temporary cannot be created returns `NXT_ERROR` and leaves the destination byte-for-byte intact;
- an existing 0640 destination comes back 0640.

`test/test_state_store.py` covers the end-to-end path: with the state directory on a 64 KiB tmpfs (`--restart`, root, `--privileged`), a configuration far too large to store leaves the previously stored one intact, byte for byte, with no temporary beside it.

| test | branch | master |
|---|---|---|
| `./build/tests` (whole C suite) | PASS | **FAIL** — `main file store test: ".../conf.json.tmp" was left behind` |
| `test_state_store_full_filesystem` | PASS | **FAIL** — `FileNotFoundError: .../conf.json`; the failed store deleted the live configuration |

Built and run in Docker (`php:8.4-cli-trixie`, `linux/amd64`, `--privileged`): `./configure --debug --tests && ./configure php && make -j4 && make tests && ./build/tests`, then `pytest --restart test/test_state_store.py` as root. The master column is master with only the test files and the test wrapper overlaid, so it exercises the unfixed `nxt_main_file_store()`.

## CHANGES

```
*) Bugfix: the state files were written in place rather than through
   their temporary, so an interrupted or failed store could truncate or
   delete the stored configuration.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
