### PR TITLE
socket: refuse a port message whose control data was truncated

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -185,6 +185,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_router_remove_pid_soak_test.c \
     src/test/nxt_main_start_process_reply_test.c \
     src/test/nxt_port_change_file_test.c \
+    src/test/nxt_port_ctrunc_test.c \
     src/test/nxt_port_fd_test.c \
 "
 

--- a/go/port.go
+++ b/go/port.go
@@ -215,6 +215,29 @@ func nxt_go_port_send(pid C.int, id C.int, buf unsafe.Pointer, buf_size C.int,
 	return C.ssize_t(n)
 }
 
+// closeUnixRights closes every descriptor an SCM_RIGHTS block carries.  It is
+// used on paths that refuse a message after the kernel has already installed
+// its descriptors, where nothing else will ever see them.  Parse failures are
+// ignored deliberately: the block is known to be damaged, and whatever can
+// still be read out of it is worth closing.
+func closeUnixRights(oob []byte) {
+	msgs, err := syscall.ParseSocketControlMessage(oob)
+	if err != nil {
+		return
+	}
+
+	for _, m := range msgs {
+		fds, err := syscall.ParseUnixRights(&m)
+		if err != nil {
+			continue
+		}
+
+		for _, fd := range fds {
+			syscall.Close(fd)
+		}
+	}
+}
+
 //export nxt_go_port_recv
 func nxt_go_port_recv(pid C.int, id C.int, buf unsafe.Pointer, buf_size C.int,
 	oob unsafe.Pointer, oob_size *C.size_t) C.ssize_t {
@@ -240,8 +263,35 @@ func nxt_go_port_recv(pid C.int, id C.int, buf unsafe.Pointer, buf_size C.int,
 		return 0
 	}
 
-	n, oobn, _, _, err := p.rcv.ReadMsgUnix(GoBytes(buf, buf_size),
+	n, oobn, flags, _, err := p.rcv.ReadMsgUnix(GoBytes(buf, buf_size),
 		GoBytes(oob, oob_capacity))
+
+	// The control data was cut short, so a descriptor this message was
+	// meant to carry may not be here; libunit would take its fd-less path
+	// on a message that otherwise looks whole.  The callback reports a
+	// length rather than msg_flags, so there is no way to hand the
+	// truncation across as such: report it as a read error, which
+	// nxt_unit_port_recv() turns into NXT_UNIT_ERROR before it parses any
+	// control data.  This is the one place the Go wrapper can see
+	// MSG_CTRUNC at all -- ReadMsgUnix is what consumed it.
+	if err == nil && flags&syscall.MSG_CTRUNC != 0 {
+		// Truncation does not imply that nothing was delivered:
+		// scm_detach_fds() installs the descriptors that fit and only
+		// then raises MSG_CTRUNC.  Those are open in this process
+		// already, and reporting an error leaves *oob_size at 0, so
+		// libunit never parses the block and never closes them --
+		// a descriptor leak under exactly the pressure that caused
+		// the truncation.  Close them here instead; best effort,
+		// since a block the kernel cut may not parse.
+		if oobn > 0 {
+			closeUnixRights(GoBytes(oob, C.int(oobn)))
+		}
+
+		nxt_go_alert("control data truncated on a %d byte message; "+
+			"message dropped", n)
+
+		return C.ssize_t(-1)
+	}
 
 	if err != nil {
 		if nerr, ok := err.(*net.OpError); ok {

--- a/src/nxt_port_socket.c
+++ b/src/nxt_port_socket.c
@@ -765,6 +765,45 @@ nxt_port_read_close(nxt_port_t *port)
 }
 
 
+/*
+ * Report a message whose control data could not be taken, on the way to
+ * dropping it.
+ *
+ * Truncation is called out separately because it is the case a reader of the
+ * log cannot otherwise infer: the payload and, on Linux, the kernel
+ * credential arrived intact, and only the SCM_RIGHTS was cut -- so what a
+ * handler would see is a well-formed, authenticated message whose descriptor
+ * is -1.  The message is named by type and stream, which is what ties the
+ * loss to the start, mmap or port hand-off that will not complete.
+ *
+ * "n" is the payload length recvmsg() returned; below sizeof(nxt_port_msg_t)
+ * there is no header to name the message by.
+ */
+
+static void
+nxt_port_oob_error_alert(nxt_task_t *task, nxt_port_t *port,
+    nxt_recv_oob_t *oob, nxt_port_recv_msg_t *msg, ssize_t n)
+{
+    if (nxt_fast_path(!oob->truncated)) {
+        nxt_alert(task, "failed to get oob data from %d", port->socket.fd);
+
+        return;
+    }
+
+    if (n >= (ssize_t) sizeof(nxt_port_msg_t)) {
+        nxt_alert(task, "port{%d,%d} %d: control data truncated on message "
+                        "type %d stream #%uD; message dropped",
+                  (int) port->pid, (int) port->id, port->socket.fd,
+                  (int) msg->port_msg.type, msg->port_msg.stream);
+
+    } else {
+        nxt_alert(task, "port{%d,%d} %d: control data truncated on a %z byte "
+                        "message; message dropped",
+                  (int) port->pid, (int) port->id, port->socket.fd, n);
+    }
+}
+
+
 static void
 nxt_port_read_handler(nxt_task_t *task, void *obj, void *data)
 {
@@ -826,9 +865,13 @@ nxt_port_read_handler(nxt_task_t *task, void *obj, void *data)
             ret = nxt_socket_msg_oob_get(&oob, msg.fd,
                                          nxt_recv_msg_cmsg_pid_ref(&msg));
             if (nxt_slow_path(ret != NXT_OK)) {
-                nxt_alert(task, "failed to get oob data from %d",
-                          port->socket.fd);
+                nxt_port_oob_error_alert(task, port, &oob, &msg, n);
 
+                /*
+                 * Whatever part of the SCM_RIGHTS did arrive is in msg.fd;
+                 * the dispatcher does not reclaim descriptors once a message
+                 * is refused here, so close them before dropping it.
+                 */
                 nxt_port_close_fds(msg.fd);
 
                 goto fail;
@@ -1022,12 +1065,38 @@ nxt_port_queue_read_handler(nxt_task_t *task, void *obj, void *data)
                 ret = nxt_socket_msg_oob_get(&oob, msg.fd,
                                              nxt_recv_msg_cmsg_pid_ref(&msg));
                 if (nxt_slow_path(ret != NXT_OK)) {
-                    nxt_alert(task, "failed to get oob data from %d",
-                              port->socket.fd);
+                    nxt_port_oob_error_alert(task, port, &oob, &msg, n);
 
+                    /* See nxt_port_read_handler(). */
                     nxt_port_close_fds(msg.fd);
 
-                    return;
+                    /*
+                     * Unwind what this iteration took, then keep draining.
+                     * Returning bare -- which is what this site did -- strands
+                     * the buffer and the READ_SOCKET marker this read was
+                     * consuming, and it strands whatever was queued behind
+                     * them: queue->nitems is non-zero for the whole
+                     * invocation, which is precisely how nxt_port_queue_send()
+                     * decides a reader is already awake and skips the socket
+                     * notification.  A message enqueued in that window is
+                     * therefore never announced, and returning here means
+                     * nobody ever comes back for it -- one refused datagram
+                     * costing the port every message queued behind it.
+                     *
+                     * nitems is deliberately not decremented here.  The
+                     * handler holds exactly one nitems credit for the whole
+                     * invocation, and whichever exit it finally takes releases
+                     * it -- the empty-queue check above, or the loop's own
+                     * termination.  Decrementing here as well as there would
+                     * give back one credit twice.
+                     */
+                    if (port->from_socket > 0) {
+                        port->from_socket--;
+                    }
+
+                    nxt_port_buf_free(port, b);
+
+                    continue;
                 }
             }
 

--- a/src/nxt_socket_msg.c
+++ b/src/nxt_socket_msg.c
@@ -47,10 +47,16 @@ nxt_recvmsg(nxt_socket_t s, nxt_iobuf_t *iob, nxt_uint_t niob,
     msg.msg_control = oob->buf;
     msg.msg_controllen = sizeof(oob->buf);
 
+    /* Cleared so that MSG_CTRUNC below is read from what recvmsg() wrote. */
+    msg.msg_flags = 0;
+
     n = recvmsg(s, &msg, 0);
 
     if (nxt_fast_path(n != -1)) {
         oob->size = msg.msg_controllen;
+
+        /* Recorded for nxt_socket_msg_oob_get(); see NXT_OOB_RECV_SIZE. */
+        oob->truncated = (msg.msg_flags & MSG_CTRUNC) != 0;
     }
 
     return n;

--- a/src/nxt_socket_msg.h
+++ b/src/nxt_socket_msg.h
@@ -42,9 +42,56 @@ typedef struct cmsgcred     nxt_socket_cred_t;
 #endif
 
 
+/*
+ * NXT_OOB_RECV_SIZE is the largest control block Unit can legitimately be
+ * handed: the two descriptors a message may carry -- nxt_port_recv_msg_t
+ * has exactly two fd slots and nxt_socket_msg_oob_init() never attaches
+ * more -- plus, where the platform passes credentials, the one credential
+ * cmsg the kernel or the sender adds.  A receive buffer of that size can
+ * therefore never truncate a well-formed message: MSG_CTRUNC means either
+ * that the kernel could not deliver all of the control data it had for this
+ * message (an SCM_RIGHTS it could not install in full, typically under
+ * RLIMIT_NOFILE pressure), or that a peer sent more control data than any
+ * Unit message type uses.  Both are receive errors, not conditions a
+ * handler can be expected to notice: what reaches it is a well-formed,
+ * authenticated message whose descriptor is simply -1.
+ *
+ * What a kernel does with the descriptors it could not fit is not uniform,
+ * and only the Linux behaviour is verified here: scm_detach_fds() installs
+ * the ones that fit into this process and only then raises MSG_CTRUNC, so
+ * they are open, owned, and unreachable unless the accessor reports them --
+ * which is why nxt_socket_msg_oob_get() and nxt_socket_msg_oob_get_fds()
+ * fill fd[] before failing the message.  A kernel that instead discards the
+ * rights leaves nothing to leak, and the same code is correct there because
+ * fd[] simply stays -1.  The refusal itself does not depend on which way a
+ * platform goes; the reporting is what the Linux semantics make necessary.
+ * MSG_CTRUNC is POSIX, so the flag is available wherever Unit builds, but
+ * only the Linux side of this is covered by a test (see
+ * src/test/nxt_port_ctrunc_test.c, whose kernel-driven cases skip on macOS
+ * and whose queue case is gated on NXT_HAVE_UCRED).
+ */
+
+#define NXT_OOB_ALIGN       (sizeof(size_t))
+
+
+/*
+ * "buf" holds a control block that CMSG_FIRSTHDR()/CMSG_NXTHDR() walk as
+ * struct cmsghdr, so its address has to carry that struct's alignment.
+ * Nothing here states that alignment: it comes from "buf" following a size_t
+ * directly, since alignof(struct cmsghdr) == alignof(size_t) on the ABIs Unit
+ * builds for (cmsg_len is a size_t on glibc, socklen_t elsewhere).  A field
+ * inserted between the two moves "buf" off that alignment and every cmsg
+ * access becomes undefined -- UBSan reports it as "member access within
+ * misaligned address ... for type 'struct cmsghdr'".  Keep new members after
+ * "buf", as "truncated" is.  nxt_aligned() is not a substitute: it expands to
+ * nothing outside GCC and clang.
+ */
+
 typedef struct {
-    size_t  size;
-    u_char  buf[NXT_OOB_RECV_SIZE];
+    size_t      size;
+    u_char      buf[NXT_OOB_RECV_SIZE] nxt_aligned(NXT_OOB_ALIGN);
+    /* recvmsg() reported MSG_CTRUNC: the control data is incomplete. */
+    nxt_bool_t  truncated;
 } nxt_recv_oob_t;
 
 
@@ -80,6 +127,21 @@ NXT_CMSG_NXTHDR(struct msghdr *msgh, struct cmsghdr *cmsg)
 #if !defined(__GLIBC__) && defined(__clang__)
 #pragma clang diagnostic pop
 #endif
+}
+
+
+/*
+ * Put a receive buffer into the "carries nothing" state.  Callers that fill
+ * oob themselves, or that recycle a buffer, use this rather than assigning
+ * ->size alone, so that every field describing the control data is retired
+ * together.
+ */
+
+nxt_inline void
+nxt_socket_msg_oob_reset(nxt_recv_oob_t *oob)
+{
+    oob->size = 0;
+    oob->truncated = 0;
 }
 
 
@@ -153,6 +215,21 @@ nxt_socket_msg_oob_get_fds(nxt_recv_oob_t *oob, nxt_fd_t *fd)
          cmsg != NULL;
          cmsg = NXT_CMSG_NXTHDR(&msg, cmsg))
     {
+        /*
+         * Fail closed on a header that does not fit the bytes actually
+         * received.  CMSG_FIRSTHDR() only checks that msg_controllen covers
+         * a struct cmsghdr, so the first header's cmsg_len can still claim
+         * more data than arrived, and a block the kernel cut short is
+         * exactly where that happens.  Reading CMSG_DATA() over that claim
+         * would run off the end of oob->buf.
+         */
+        if (nxt_slow_path(cmsg->cmsg_len < CMSG_LEN(0)
+                          || (size_t) ((u_char *) cmsg - oob->buf)
+                             + cmsg->cmsg_len > oob->size))
+        {
+            return NXT_ERROR;
+        }
+
         size = cmsg->cmsg_len - CMSG_LEN(0);
 
         if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
@@ -162,8 +239,17 @@ nxt_socket_msg_oob_get_fds(nxt_recv_oob_t *oob, nxt_fd_t *fd)
 
             nxt_memcpy(fd, CMSG_DATA(cmsg), size);
 
-            return NXT_OK;
+            break;
         }
+    }
+
+    /*
+     * Checked after the loop, not before it: a truncated control block can
+     * still have delivered a descriptor, and the caller can only close what
+     * it has been told about.
+     */
+    if (nxt_slow_path(oob->truncated)) {
+        return NXT_ERROR;
     }
 
     return NXT_OK;
@@ -177,7 +263,7 @@ nxt_socket_msg_oob_get(nxt_recv_oob_t *oob, nxt_fd_t *fd, nxt_pid_t *pid)
     struct msghdr   msg;
     struct cmsghdr  *cmsg;
 
-    if (oob->size == 0) {
+    if (oob->size == 0 && !oob->truncated) {
         return NXT_OK;
     }
 
@@ -192,6 +278,21 @@ nxt_socket_msg_oob_get(nxt_recv_oob_t *oob, nxt_fd_t *fd, nxt_pid_t *pid)
          cmsg != NULL;
          cmsg = NXT_CMSG_NXTHDR(&msg, cmsg))
     {
+        /*
+         * Fail closed on a header that does not fit the bytes actually
+         * received.  CMSG_FIRSTHDR() only checks that msg_controllen covers
+         * a struct cmsghdr, so the first header's cmsg_len can still claim
+         * more data than arrived, and a block the kernel cut short is
+         * exactly where that happens.  Reading CMSG_DATA() over that claim
+         * would run off the end of oob->buf.
+         */
+        if (nxt_slow_path(cmsg->cmsg_len < CMSG_LEN(0)
+                          || (size_t) ((u_char *) cmsg - oob->buf)
+                             + cmsg->cmsg_len > oob->size))
+        {
+            return NXT_ERROR;
+        }
+
         size = cmsg->cmsg_len - CMSG_LEN(0);
 
         if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
@@ -220,6 +321,11 @@ nxt_socket_msg_oob_get(nxt_recv_oob_t *oob, nxt_fd_t *fd, nxt_pid_t *pid)
             *pid = NXT_CRED_GETPID(creds);
         }
 #endif
+    }
+
+    /* See nxt_socket_msg_oob_get_fds() on why this follows the loop. */
+    if (nxt_slow_path(oob->truncated)) {
+        return NXT_ERROR;
     }
 
 #if (NXT_CRED_USECMSG)

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -1086,7 +1086,20 @@ nxt_unit_process_msg(nxt_unit_ctx_t *ctx, nxt_unit_read_buf_t *rbuf,
 
     rc = nxt_socket_msg_oob_get_fds(&rbuf->oob, recv_msg.fd);
     if (nxt_slow_path(rc != NXT_OK)) {
-        nxt_unit_alert(ctx, "failed to receive file descriptor over cmsg");
+        if (rbuf->oob.truncated) {
+            /*
+             * The descriptor this message was meant to carry may not be
+             * here: NEW_PORT and MMAP would take their fd-less path on a
+             * message that otherwise looks whole.  Refuse it; "done" closes
+             * whatever part of the SCM_RIGHTS did arrive.
+             */
+            nxt_unit_alert(ctx, "control data truncated on a %d byte "
+                           "message; message dropped", (int) rbuf->size);
+
+        } else {
+            nxt_unit_alert(ctx, "failed to receive file descriptor over cmsg");
+        }
+
         rc = NXT_UNIT_ERROR;
         goto done;
     }
@@ -3019,7 +3032,7 @@ nxt_unit_read_buf_get(nxt_unit_ctx_t *ctx)
 
     pthread_mutex_unlock(&ctx_impl->mutex);
 
-    rbuf->oob.size = 0;
+    nxt_socket_msg_oob_reset(&rbuf->oob);
 
     return rbuf;
 }
@@ -6399,7 +6412,7 @@ retry:
              * a leftover oob.size would offer them again.
              */
             port_impl->socket_rbuf->size = 0;
-            port_impl->socket_rbuf->oob.size = 0;
+            nxt_socket_msg_oob_reset(&port_impl->socket_rbuf->oob);
 
             nxt_unit_debug(ctx, "port{%d,%d} use suspended message %d",
                            (int) port->id.pid, (int) port->id.id,
@@ -6484,7 +6497,7 @@ retry:
 
     nxt_unit_rbuf_cpy(port_impl->socket_rbuf, rbuf);
 
-    rbuf->oob.size = 0;
+    nxt_socket_msg_oob_reset(&rbuf->oob);
 
     goto retry;
 }
@@ -6496,6 +6509,7 @@ nxt_unit_rbuf_cpy(nxt_unit_read_buf_t *dst, nxt_unit_read_buf_t *src)
     memcpy(dst->buf, src->buf, src->size);
     dst->size = src->size;
     dst->oob.size = src->oob.size;
+    dst->oob.truncated = src->oob.truncated;
     memcpy(dst->oob.buf, src->oob.buf, src->oob.size);
 }
 
@@ -6588,6 +6602,17 @@ nxt_unit_port_recv(nxt_unit_ctx_t *ctx, nxt_unit_port_t *port,
         }
 
         rbuf->oob.size = oob_size;
+        /*
+         * The callback reports a length, not msg_flags, so a truncation
+         * cannot be carried across as such: a wrapper that sees MSG_CTRUNC
+         * reports a read error instead, and the rbuf->size < 0 arm above
+         * returns before any control data is parsed (go/port.go does exactly
+         * this).  Nothing can therefore be inferred about truncation here;
+         * clear the flag so that a previous message's MSG_CTRUNC, left in
+         * this recycled buffer, cannot be read as this one's.
+         */
+        rbuf->oob.truncated = 0;
+
         return NXT_UNIT_OK;
     }
 
@@ -6608,7 +6633,7 @@ retry:
          * clear it here to keep "size 0 implies no control data" holding on
          * every exit of this function rather than by inspection of callers.
          */
-        rbuf->oob.size = 0;
+        nxt_socket_msg_oob_reset(&rbuf->oob);
 
         if (err == EINTR) {
             goto retry;

--- a/src/test/nxt_port_ctrunc_test.c
+++ b/src/test/nxt_port_ctrunc_test.c
@@ -1,0 +1,960 @@
+/*
+ * Copyright (C) F5, Inc.
+ */
+
+/*
+ * Regression test for control-data truncation on a port socket
+ * (src/nxt_socket_msg.h, src/nxt_socket_msg.c).
+ *
+ * recvmsg() sets MSG_CTRUNC when it could not deliver all of the control
+ * data the sender attached.  The case that matters here is an SCM_RIGHTS the
+ * kernel discards while delivering everything else -- the payload and, on
+ * Linux, the SCM_CREDENTIALS the receiver's SO_PASSCRED asks for.  In
+ * production that happens under descriptor pressure: scm_detach_fds() cannot
+ * install the descriptors and drops the whole cmsg.
+ *
+ * Nothing used to look at msg_flags, so what reached a handler was a message
+ * that passed every check it makes -- right size, right type, kernel-validated
+ * sender -- and simply had fd[0] == -1.  NEW_PORT, MMAP and CHANGE_FILE each
+ * take some fd-less path from there.
+ *
+ * The truncation is driven directly rather than through RLIMIT_NOFILE: the
+ * receive buffer's length is the other input to the same kernel decision, and
+ * unlike a descriptor limit it is deterministic and leaves the rest of the
+ * test process alone.  What is asserted is the contract every receive path
+ * shares, that nxt_socket_msg_oob_get() and nxt_socket_msg_oob_get_fds()
+ * refuse a truncated control block -- and that they refuse it after reporting
+ * whatever descriptors did arrive, since the caller can only close what it
+ * has been told about.
+ */
+
+#include <nxt_main.h>
+#include <nxt_port.h>
+#include <nxt_port_queue.h>
+#include <nxt_runtime.h>
+#include <nxt_socket_msg.h>
+#include "nxt_tests.h"
+
+#include <fcntl.h>
+
+
+#define NXT_CTRUNC_TEST_FD_MAX  1024
+
+/*
+ * The control space the receiver has to keep for the credential cmsg before
+ * the SCM_RIGHTS can begin.  Zero where the platform passes no credential.
+ */
+#if (NXT_CRED_USECMSG)
+#define NXT_CTRUNC_TEST_CRED_SPACE  CMSG_SPACE(sizeof(nxt_socket_cred_t))
+#else
+#define NXT_CTRUNC_TEST_CRED_SPACE  0
+#endif
+
+
+static nxt_uint_t
+nxt_port_ctrunc_test_fd_count(void)
+{
+    int         fd;
+    nxt_uint_t  n;
+
+    n = 0;
+
+    for (fd = 0; fd < NXT_CTRUNC_TEST_FD_MAX; fd++) {
+        if (fcntl(fd, F_GETFD) != -1) {
+            n++;
+        }
+    }
+
+    return n;
+}
+
+
+/*
+ * Send one message carrying two descriptors, and receive it with a control
+ * buffer of exactly "controllen" bytes, filling "oob" the way nxt_recvmsg()
+ * would.  A short buffer is what makes the kernel drop the SCM_RIGHTS and
+ * raise MSG_CTRUNC.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_exchange(nxt_thread_t *thr, nxt_socket_t *pair,
+    size_t controllen, nxt_recv_oob_t *oob, ssize_t *received)
+{
+    int             fds[2];
+    u_char          payload;
+    ssize_t         n;
+    nxt_send_oob_t  send_oob;
+    struct iovec    iov[1];
+    struct msghdr   msg;
+
+    fds[0] = open("/dev/null", O_RDONLY);
+    fds[1] = open("/dev/null", O_RDONLY);
+
+    if (fds[0] == -1 || fds[1] == -1) {
+        nxt_log_alert(thr->log, "port ctrunc test failed to open /dev/null");
+        goto fail;
+    }
+
+    nxt_socket_msg_oob_init(&send_oob, fds);
+
+    payload = 0x5A;
+
+    iov[0].iov_base = &payload;
+    iov[0].iov_len = sizeof(payload);
+
+    n = nxt_sendmsg(pair[1], iov, 1, &send_oob);
+
+    if (n != (ssize_t) sizeof(payload)) {
+        nxt_log_alert(thr->log, "port ctrunc test sendmsg failed %E",
+                      nxt_errno);
+        goto fail;
+    }
+
+    /*
+     * sendmsg() duplicated the descriptors into the socket; this end has no
+     * further use for them, and leaving them open would hide a leak on the
+     * receiving side behind a constant offset.
+     */
+    (void) close(fds[0]);
+    (void) close(fds[1]);
+
+    fds[0] = -1;
+    fds[1] = -1;
+
+    payload = 0;
+
+    iov[0].iov_base = &payload;
+    iov[0].iov_len = sizeof(payload);
+
+    nxt_memzero(oob, sizeof(nxt_recv_oob_t));
+
+    msg.msg_name = NULL;
+    msg.msg_namelen = 0;
+    msg.msg_iov = iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = oob->buf;
+    msg.msg_controllen = controllen;
+    msg.msg_flags = 0;
+
+    n = recvmsg(pair[0], &msg, 0);
+
+    if (n != (ssize_t) sizeof(payload) || payload != 0x5A) {
+        nxt_log_alert(thr->log, "port ctrunc test recvmsg failed %z %E",
+                      n, nxt_errno);
+        return NXT_ERROR;
+    }
+
+    oob->size = msg.msg_controllen;
+    oob->truncated = (msg.msg_flags & MSG_CTRUNC) != 0;
+
+    *received = n;
+
+    return NXT_OK;
+
+fail:
+
+    if (fds[0] != -1) {
+        (void) close(fds[0]);
+    }
+
+    if (fds[1] != -1) {
+        (void) close(fds[1]);
+    }
+
+    return NXT_ERROR;
+}
+
+
+static void
+nxt_port_ctrunc_test_close_fds(nxt_fd_t *fd)
+{
+    nxt_uint_t  i;
+
+    for (i = 0; i < 2; i++) {
+        if (fd[i] != -1) {
+            (void) close(fd[i]);
+            fd[i] = -1;
+        }
+    }
+}
+
+
+/*
+ * Defined only where it is called: both call sites sit in the non-macOS arm
+ * below, and an unused static trips -Wunused-function under -Werror on a
+ * platform no CI leg builds.
+ */
+
+#if !(NXT_MACOSX)
+
+/*
+ * The regression itself: a control buffer that holds the credential but not
+ * the SCM_RIGHTS.  Everything a handler inspects is intact and the message is
+ * one descriptor short, which is exactly the shape the kernel delivers under
+ * descriptor pressure.  Before the fix both accessors returned NXT_OK here.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_truncated(nxt_thread_t *thr, nxt_socket_t *pair,
+    size_t controllen, const char *name)
+{
+    ssize_t         n;
+    nxt_int_t       ret;
+    nxt_pid_t       pid;
+    nxt_uint_t      before, after;
+    nxt_fd_t        fd[2], fd2[2];
+    nxt_recv_oob_t  oob;
+
+    before = nxt_port_ctrunc_test_fd_count();
+
+    if (nxt_port_ctrunc_test_exchange(thr, pair, controllen, &oob, &n)
+        != NXT_OK)
+    {
+        return NXT_ERROR;
+    }
+
+    if (!oob.truncated) {
+        nxt_log_alert(thr->log, "port ctrunc test: %s did not truncate "
+                      "(controllen %uz, received %uz)",
+                      name, controllen, oob.size);
+        return NXT_ERROR;
+    }
+
+    fd[0] = -1;
+    fd[1] = -1;
+
+    /*
+     * The two accessors are checked against the same received control block,
+     * so both see the identical descriptor numbers; they are closed once, at
+     * the end, rather than after each call.
+     */
+    ret = nxt_socket_msg_oob_get_fds(&oob, fd);
+
+    if (ret != NXT_ERROR) {
+        nxt_log_alert(thr->log, "port ctrunc test: %s: oob_get_fds accepted "
+                      "a truncated control block (fd %d)", name, fd[0]);
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+
+    fd2[0] = -1;
+    fd2[1] = -1;
+    pid = -1;
+
+    ret = nxt_socket_msg_oob_get(&oob, fd2, &pid);
+
+    if (ret != NXT_ERROR) {
+        nxt_log_alert(thr->log, "port ctrunc test: %s: oob_get accepted a "
+                      "truncated control block (fd %d, pid %PI)",
+                      name, fd2[0], pid);
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+
+    if (fd2[0] != fd[0] || fd2[1] != fd[1]) {
+        nxt_log_alert(thr->log, "port ctrunc test: %s: the two accessors "
+                      "reported different descriptors (%d %d vs %d %d)",
+                      name, fd[0], fd[1], fd2[0], fd2[1]);
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+
+    /*
+     * Whatever the kernel did install has to come back in fd[] even though
+     * the call failed, or nothing can close it.
+     */
+    nxt_port_ctrunc_test_close_fds(fd);
+
+    after = nxt_port_ctrunc_test_fd_count();
+
+    if (after != before) {
+        nxt_log_alert(thr->log, "port ctrunc test: %s leaked %d descriptors",
+                      name, (int) (after - before));
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+#endif
+
+
+/*
+ * The control case: a buffer of the size every production receive path uses.
+ * A message Unit can send never truncates against it, so the accessors accept
+ * it and hand back both descriptors -- which is what makes the case above an
+ * assertion about truncation rather than about the buffer being short.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_intact(nxt_thread_t *thr, nxt_socket_t *pair)
+{
+    ssize_t         n;
+    nxt_int_t       ret;
+    nxt_pid_t       pid;
+    nxt_uint_t      before, after;
+    nxt_fd_t        fd[2];
+    nxt_recv_oob_t  oob;
+
+    before = nxt_port_ctrunc_test_fd_count();
+
+    if (nxt_port_ctrunc_test_exchange(thr, pair, NXT_OOB_RECV_SIZE, &oob, &n)
+        != NXT_OK)
+    {
+        return NXT_ERROR;
+    }
+
+    if (oob.truncated) {
+        nxt_log_alert(thr->log, "port ctrunc test: a %uz byte control buffer "
+                      "truncated a two descriptor message",
+                      (size_t) NXT_OOB_RECV_SIZE);
+        return NXT_ERROR;
+    }
+
+    fd[0] = -1;
+    fd[1] = -1;
+    pid = -1;
+
+    ret = nxt_socket_msg_oob_get(&oob, fd, &pid);
+
+    if (ret != NXT_OK || fd[0] == -1 || fd[1] == -1) {
+        nxt_log_alert(thr->log, "port ctrunc test: intact message refused "
+                      "(ret %i, fd %d %d)", ret, fd[0], fd[1]);
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+
+#if (NXT_CRED_USECMSG)
+    if (pid != getpid()) {
+        nxt_log_alert(thr->log, "port ctrunc test: intact message carried "
+                      "pid %PI, expected %PI", pid, (nxt_pid_t) getpid());
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+#endif
+
+    nxt_port_ctrunc_test_close_fds(fd);
+
+    after = nxt_port_ctrunc_test_fd_count();
+
+    if (after != before) {
+        nxt_log_alert(thr->log, "port ctrunc test: intact case leaked %d "
+                      "descriptors", (int) (after - before));
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * The accessor contract on its own, with no kernel behaviour in it: take a
+ * control block the kernel delivered whole, mark it truncated, and require
+ * the same refusal.  This is what holds everywhere -- the cases above depend
+ * on how a particular kernel divides a short control buffer, and xnu does not
+ * divide it the same way -- and it is also the exact shape the accessors see
+ * in production, since a real truncation can deliver every descriptor it was
+ * asked for and still raise MSG_CTRUNC.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_marked(nxt_thread_t *thr, nxt_socket_t *pair)
+{
+    ssize_t         n;
+    nxt_int_t       ret;
+    nxt_pid_t       pid;
+    nxt_uint_t      before, after;
+    nxt_fd_t        fd[2];
+    nxt_recv_oob_t  oob;
+
+    before = nxt_port_ctrunc_test_fd_count();
+
+    if (nxt_port_ctrunc_test_exchange(thr, pair, NXT_OOB_RECV_SIZE, &oob, &n)
+        != NXT_OK)
+    {
+        return NXT_ERROR;
+    }
+
+    if (oob.truncated) {
+        nxt_log_alert(thr->log, "port ctrunc test: a full size control "
+                      "buffer truncated a two descriptor message");
+        return NXT_ERROR;
+    }
+
+    oob.truncated = 1;
+
+    fd[0] = -1;
+    fd[1] = -1;
+    pid = -1;
+
+    ret = nxt_socket_msg_oob_get(&oob, fd, &pid);
+
+    if (ret != NXT_ERROR) {
+        nxt_log_alert(thr->log, "port ctrunc test: oob_get accepted a block "
+                      "marked truncated (fd %d %d)", fd[0], fd[1]);
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+
+    /*
+     * Every descriptor the block carries still has to be reported, or the
+     * caller that is about to drop the message cannot close them.
+     */
+    if (fd[0] == -1 || fd[1] == -1) {
+        nxt_log_alert(thr->log, "port ctrunc test: a block marked truncated "
+                      "withheld its descriptors (fd %d %d)", fd[0], fd[1]);
+
+        nxt_port_ctrunc_test_close_fds(fd);
+
+        return NXT_ERROR;
+    }
+
+    nxt_port_ctrunc_test_close_fds(fd);
+
+    after = nxt_port_ctrunc_test_fd_count();
+
+    if (after != before) {
+        nxt_log_alert(thr->log, "port ctrunc test: marked case leaked %d "
+                      "descriptors", (int) (after - before));
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * Linux only, deliberately narrower than NXT_CRED_USECMSG.  This fixture
+ * manufactures a message the receiver must refuse by relying on the
+ * credential being *enforced but not attached*: nxt_socket_msg_oob_get()
+ * fails a control block that carries no credential, and with SO_PASSCRED off
+ * this socketpair the kernel adds none.  Where the credential travels as
+ * SCM_CREDS instead (FreeBSD), nxt_socket_msg_oob_init() attaches one itself,
+ * so the same call produces a perfectly valid message and the refusal this
+ * fixture is built on never happens.  The truncation cases above cover those
+ * platforms; this one needs Linux semantics to construct its input at all.
+ */
+
+#if (NXT_HAVE_UCRED)
+
+static nxt_uint_t  nxt_port_ctrunc_test_delivered;
+
+
+static void
+nxt_port_ctrunc_test_quit_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
+{
+    nxt_port_ctrunc_test_delivered++;
+}
+
+
+static const nxt_port_handlers_t  nxt_port_ctrunc_test_handlers = {
+    .quit = nxt_port_ctrunc_test_quit_handler,
+};
+
+
+static void
+nxt_port_ctrunc_test_enable_read_stub(nxt_event_engine_t *engine,
+    nxt_fd_event_t *ev)
+{
+    /* The fixture engine polls nothing. */
+}
+
+
+/*
+ * Send one message over "fd" with a control block the receiver will refuse.
+ * "with_fd" attaches a descriptor, so that the refusal happens after the
+ * descriptor has been delivered -- the shape a truncation has.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_send_bad(nxt_thread_t *thr, nxt_socket_t fd,
+    nxt_port_msg_t *port_msg)
+{
+    int             fds[2];
+    ssize_t         n;
+    nxt_send_oob_t  oob;
+    struct iovec    iov[1];
+
+    fds[0] = open("/dev/null", O_RDONLY);
+    fds[1] = -1;
+
+    if (fds[0] == -1) {
+        nxt_log_alert(thr->log, "port ctrunc test failed to open /dev/null");
+        return NXT_ERROR;
+    }
+
+    nxt_socket_msg_oob_init(&oob, fds);
+
+    iov[0].iov_base = port_msg;
+    iov[0].iov_len = sizeof(nxt_port_msg_t);
+
+    n = nxt_sendmsg(fd, iov, 1, &oob);
+
+    (void) close(fds[0]);
+
+    if (n != (ssize_t) sizeof(nxt_port_msg_t)) {
+        nxt_log_alert(thr->log, "port ctrunc test sendmsg failed %E",
+                      nxt_errno);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * The control message: no control data at all, which nxt_socket_msg_oob_get()
+ * accepts on any platform, so the handler dispatches it.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_send_good(nxt_thread_t *thr, nxt_socket_t fd,
+    nxt_port_msg_t *port_msg)
+{
+    ssize_t       n;
+    struct iovec  iov[1];
+
+    iov[0].iov_base = port_msg;
+    iov[0].iov_len = sizeof(nxt_port_msg_t);
+
+    n = nxt_sendmsg(fd, iov, 1, NULL);
+
+    if (n != (ssize_t) sizeof(nxt_port_msg_t)) {
+        nxt_log_alert(thr->log, "port ctrunc test sendmsg failed %E",
+                      nxt_errno);
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * Announce a socket message on the queue the way nxt_port_socket_send() does.
+ * Without the READ_SOCKET marker the handler has port->from_socket == 0 and
+ * suspends the socket message instead of processing it, which is a different
+ * path from the one under test.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_notify(nxt_thread_t *thr, nxt_port_queue_t *queue)
+{
+    int     notify;
+    uint8_t qmsg;
+
+    qmsg = _NXT_PORT_MSG_READ_SOCKET;
+
+    if (nxt_port_queue_send(queue, &qmsg, 1, &notify) != NXT_OK) {
+        nxt_log_alert(thr->log, "port ctrunc test failed to queue a "
+                      "read_socket marker");
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * Put a whole message on the queue, the way nxt_port_socket_write2() does for
+ * an enqueueable one, and report what it decided about the wakeup.  "notify"
+ * is the crux of the stranding case: nxt_port_queue_send() clears it when
+ * nitems is already non-zero, on the understanding that a reader is awake and
+ * will come back round for this message.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_enqueue(nxt_thread_t *thr, nxt_port_queue_t *queue,
+    nxt_port_msg_t *port_msg, int *notify)
+{
+    if (nxt_port_queue_send(queue, port_msg, sizeof(nxt_port_msg_t), notify)
+        != NXT_OK)
+    {
+        nxt_log_alert(thr->log, "port ctrunc test failed to enqueue a "
+                      "queue message");
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * The queue-backed read path drops a refused message rather than failing the
+ * port, and has to give back everything the iteration took before it does.
+ *
+ * queue->nitems is the one that bites: it is incremented on entry and read by
+ * nxt_port_queue_send() in every *other* process holding this port, which
+ * skips the socket notification while it is non-zero because a reader is
+ * supposed to be awake.  A bare return therefore left the counter raised
+ * forever, and the port was never woken for a queue-only message again --
+ * one refused datagram costing the port every message after it.  The buffer
+ * and the READ_SOCKET marker leaked on the same path.
+ *
+ * The refusal is driven by a control block the accessor rejects for a reason
+ * that needs no kernel cooperation: SO_PASSCRED is left off this socketpair,
+ * so the SCM_CREDENTIALS that nxt_socket_msg_oob_get() insists on never
+ * arrives, and the message is refused after its descriptor was delivered --
+ * the same shape, and the same cleanup path, as a truncation.  Driving an
+ * actual MSG_CTRUNC here would mean exhausting the test process's descriptor
+ * table, which is neither deterministic nor confined to this test.
+ */
+static nxt_int_t
+nxt_port_ctrunc_test_queue(nxt_thread_t *thr)
+{
+    nxt_mp_t                  *mp;
+    int                        notify;
+    nxt_int_t                  ret;
+    nxt_port_t                *port;
+    nxt_task_t                *task;
+    nxt_runtime_t             *rt, *saved_rt;
+    nxt_port_msg_t             port_msg;
+    nxt_port_queue_t          *queue;
+    nxt_event_engine_t        *engine, *saved_engine;
+    nxt_nncq_atomic_t          nitems;
+
+    task = thr->task;
+    task->thread = thr;
+
+    port = NULL;
+    queue = MAP_FAILED;
+    ret = NXT_ERROR;
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (nxt_slow_path(mp == NULL)) {
+        return NXT_ERROR;
+    }
+
+    rt = nxt_mp_zalloc(mp, sizeof(nxt_runtime_t));
+    engine = nxt_mp_zalloc(mp, sizeof(nxt_event_engine_t));
+
+    if (nxt_slow_path(rt == NULL || engine == NULL)) {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    rt->mem_pool = mp;
+
+    if (nxt_slow_path(nxt_thread_mutex_create(&rt->processes_mutex) != NXT_OK))
+    {
+        nxt_mp_destroy(mp);
+        return NXT_ERROR;
+    }
+
+    saved_rt = thr->runtime;
+    saved_engine = thr->engine;
+
+    thr->runtime = rt;
+    thr->engine = engine;
+
+    engine->event.enable_read = nxt_port_ctrunc_test_enable_read_stub;
+
+    port = nxt_port_new(task, 0, nxt_pid, NXT_PROCESS_APP);
+    if (nxt_slow_path(port == NULL)) {
+        goto done;
+    }
+
+    /*
+     * Plain socketpair(), not nxt_socketpair_create(): the missing
+     * SO_PASSCRED is what makes the receiver refuse the message.  The
+     * non-blocking mode that nxt_socketpair_create() also sets is not
+     * optional, though -- the read loop ends by receiving EAGAIN, so a
+     * blocking descriptor parks the handler in recvmsg() for good.
+     */
+    if (nxt_slow_path(socketpair(AF_UNIX, SOCK_DGRAM, 0, port->pair) != 0)) {
+        nxt_log_alert(thr->log, "port ctrunc test: socketpair failed %E",
+                      nxt_errno);
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_socket_nonblocking(task, port->pair[0]) != NXT_OK
+                      || nxt_socket_nonblocking(task, port->pair[1]) != NXT_OK))
+    {
+        goto done;
+    }
+
+    port->max_size = 1024;
+
+    /*
+     * nxt_socketpair_recv() logs through ev->task; the event facility would
+     * have set it when the port was created against a real engine.
+     */
+    port->socket.task = task;
+
+    queue = mmap(NULL, sizeof(nxt_port_queue_t), PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_ANON, -1, 0);
+
+    if (nxt_slow_path(queue == MAP_FAILED)) {
+        nxt_log_alert(thr->log, "port ctrunc test failed to map a queue");
+        goto done;
+    }
+
+    nxt_port_queue_init(queue);
+
+    port->queue = queue;
+
+    nxt_port_enable(task, port, &nxt_port_ctrunc_test_handlers);
+    nxt_port_read_enable(task, port);
+
+    if (nxt_slow_path(port->socket.read_handler == NULL)) {
+        nxt_log_alert(thr->log, "port ctrunc test: no queue read handler");
+        goto done;
+    }
+
+    nitems = queue->nitems;
+
+    nxt_memzero(&port_msg, sizeof(nxt_port_msg_t));
+    port_msg.type = _NXT_PORT_MSG_QUIT;
+    port_msg.last = 1;
+
+    if (nxt_slow_path(nxt_port_ctrunc_test_send_bad(thr, port->pair[1],
+                                                    &port_msg) != NXT_OK))
+    {
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_port_ctrunc_test_notify(thr, queue) != NXT_OK)) {
+        goto done;
+    }
+
+    /* What the event facility would have set. */
+    port->socket.read_ready = 1;
+
+    nxt_port_ctrunc_test_delivered = 0;
+
+    port->socket.read_handler(task, &port->socket, NULL);
+
+    if (nxt_port_ctrunc_test_delivered != 0) {
+        nxt_log_alert(thr->log, "port ctrunc test: a message with an "
+                      "unusable control block was delivered");
+        goto done;
+    }
+
+    if (queue->nitems != nitems) {
+        nxt_log_alert(thr->log, "port ctrunc test: a refused message left "
+                      "queue->nitems at %uD, was %uD; the port would never "
+                      "be notified again",
+                      (uint32_t) queue->nitems, (uint32_t) nitems);
+        goto done;
+    }
+
+    if (port->from_socket != 0) {
+        nxt_log_alert(thr->log, "port ctrunc test: a refused message left "
+                      "from_socket at %d", (int) port->from_socket);
+        goto done;
+    }
+
+    /*
+     * The point of the counter: the very next message still has to arrive.
+     */
+    if (nxt_slow_path(nxt_port_ctrunc_test_send_good(thr, port->pair[1],
+                                                     &port_msg) != NXT_OK))
+    {
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_port_ctrunc_test_notify(thr, queue) != NXT_OK)) {
+        goto done;
+    }
+
+    port->socket.read_ready = 1;
+
+    port->socket.read_handler(task, &port->socket, NULL);
+
+    if (nxt_port_ctrunc_test_delivered != 1) {
+        nxt_log_alert(thr->log, "port ctrunc test: the message after a "
+                      "refused one was not delivered");
+        goto done;
+    }
+
+    /*
+     * The case the counter alone does not cover: a message queued inside the
+     * window, after the READ_SOCKET marker but before this handler gets to
+     * the datagram it announces.
+     *
+     * Its sender sees nitems already raised and so asks for no wakeup -- the
+     * assertion below -- because a reader is supposed to be awake and about to
+     * drain the queue.  That reader is this invocation.  If the refusal path
+     * returns instead of carrying on round the loop, nothing is left to
+     * collect the message and nothing will be scheduled to: it is stranded
+     * with the counter correct and the port quiet.  Restoring nitems is
+     * necessary and not sufficient.
+     */
+
+    nxt_port_ctrunc_test_delivered = 0;
+
+    if (nxt_slow_path(nxt_port_ctrunc_test_send_bad(thr, port->pair[1],
+                                                    &port_msg) != NXT_OK))
+    {
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_port_ctrunc_test_notify(thr, queue) != NXT_OK)) {
+        goto done;
+    }
+
+    if (nxt_slow_path(nxt_port_ctrunc_test_enqueue(thr, queue, &port_msg,
+                                                   &notify) != NXT_OK))
+    {
+        goto done;
+    }
+
+    if (notify != 0) {
+        nxt_log_alert(thr->log, "port ctrunc test: the queued message asked "
+                      "for a wakeup, so it is not the stranding case");
+        goto done;
+    }
+
+    port->socket.read_ready = 1;
+
+    port->socket.read_handler(task, &port->socket, NULL);
+
+    if (nxt_port_ctrunc_test_delivered != 1) {
+        nxt_log_alert(thr->log, "port ctrunc test: a message queued behind a "
+                      "refused one was stranded");
+        goto done;
+    }
+
+    if (queue->nitems != nitems) {
+        nxt_log_alert(thr->log, "port ctrunc test: draining past a refused "
+                      "message left queue->nitems at %uD, was %uD",
+                      (uint32_t) queue->nitems, (uint32_t) nitems);
+        goto done;
+    }
+
+    ret = NXT_OK;
+
+done:
+
+    /*
+     * The port carries its own memory pool and a use count, and its pool
+     * cleanup asserts that both descriptors are already gone -- so it has to
+     * be taken down through nxt_port_close(), not with close() on the pair,
+     * and then released by dropping the reference nxt_port_new() took.  The
+     * queue is detached first: it is this fixture's mapping, unmapped below,
+     * and nxt_port_close() would otherwise release it as its own.
+     */
+    if (port != NULL) {
+        port->queue = NULL;
+
+        nxt_port_close(task, port);
+        nxt_port_use(task, port, -1);
+    }
+
+    if (queue != MAP_FAILED) {
+        (void) munmap(queue, sizeof(nxt_port_queue_t));
+    }
+
+    thr->runtime = saved_rt;
+    thr->engine = saved_engine;
+
+    nxt_thread_mutex_destroy(&rt->processes_mutex);
+    nxt_mp_destroy(mp);
+
+    return ret;
+}
+
+#endif /* NXT_HAVE_UCRED */
+
+
+nxt_int_t
+nxt_port_ctrunc_test(nxt_thread_t *thr)
+{
+    nxt_int_t      ret;
+    nxt_task_t     *task;
+    nxt_socket_t   pair[2];
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "port ctrunc test started");
+
+    task = thr->task;
+    task->thread = thr;
+
+    /*
+     * nxt_socketpair_create() rather than socketpair(): SO_PASSCRED is what
+     * puts a credential cmsg ahead of the SCM_RIGHTS, and so what lets a
+     * buffer sized for the credential alone reproduce the production shape --
+     * a fully authenticated message with its descriptor missing.
+     */
+    if (nxt_socketpair_create(task, pair) != NXT_OK) {
+        nxt_log_alert(thr->log, "port ctrunc test: socketpair failed");
+        return NXT_ERROR;
+    }
+
+    ret = nxt_port_ctrunc_test_intact(thr, pair);
+
+    if (ret == NXT_OK) {
+        ret = nxt_port_ctrunc_test_marked(thr, pair);
+    }
+
+    /*
+     * The cases below assert how the kernel itself divides a control buffer
+     * that is too small: Linux and the BSDs run scm_detach_fds() against the
+     * room that is left and raise MSG_CTRUNC, while xnu externalizes the
+     * rights before it measures, so the same short receive there does not
+     * report truncation at all.  Skipped rather than adapted: what they add
+     * over nxt_port_ctrunc_test_marked() is the proof that a real kernel
+     * produces the flag, and on a kernel that does not, there is nothing to
+     * prove.  The code under test is platform independent -- nothing acts on
+     * a truncation that was not reported.
+     */
+#if (NXT_MACOSX)
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "port ctrunc test: kernel driven "
+                  "truncation cases skipped on macOS");
+
+#else
+
+    if (ret == NXT_OK) {
+        ret = nxt_port_ctrunc_test_truncated(thr, pair,
+                                  NXT_CTRUNC_TEST_CRED_SPACE + CMSG_LEN(0),
+                                  "credential kept, SCM_RIGHTS dropped");
+    }
+
+    if (ret == NXT_OK) {
+        /*
+         * The other side of the same kernel decision: room for one descriptor
+         * where two were sent.  scm_detach_fds() installs what fits and still
+         * raises MSG_CTRUNC, so the accessors have to report the partial
+         * descriptor and refuse the message, or it leaks.
+         *
+         * The length is CMSG_LEN(0) + sizeof(int), not CMSG_SPACE(sizeof(int)):
+         * cmsg padding rounds a one-descriptor payload up to the same space
+         * two occupy, so a CMSG_SPACE-derived budget delivers both and does
+         * not truncate at all.
+         */
+        ret = nxt_port_ctrunc_test_truncated(thr, pair,
+                                  NXT_CTRUNC_TEST_CRED_SPACE
+                                  + CMSG_LEN(0) + sizeof(int),
+                                  "one of two descriptors delivered");
+    }
+
+#endif
+
+    nxt_socket_close(task, pair[0]);
+    nxt_socket_close(task, pair[1]);
+
+#if (NXT_HAVE_UCRED)
+
+    if (ret == NXT_OK) {
+        ret = nxt_port_ctrunc_test_queue(thr);
+    }
+
+#else
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "port ctrunc test: queue read "
+                  "path case skipped without SCM_CREDENTIALS");
+
+#endif
+
+    if (ret != NXT_OK) {
+        return NXT_ERROR;
+    }
+
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "port ctrunc test passed");
+
+    return NXT_OK;
+}

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -225,6 +225,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_port_ctrunc_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_port_fd_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -80,6 +80,7 @@ nxt_int_t nxt_router_proto_wedge_test(nxt_thread_t *thr);
 nxt_int_t nxt_router_remove_pid_soak_test(nxt_thread_t *thr);
 nxt_int_t nxt_main_start_process_reply_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_change_file_test(nxt_thread_t *thr);
+nxt_int_t nxt_port_ctrunc_test(nxt_thread_t *thr);
 nxt_int_t nxt_port_fd_test(nxt_thread_t *thr);
 nxt_int_t nxt_cgroup_test(nxt_thread_t *thr);
 nxt_int_t nxt_clone_creds_test(nxt_thread_t *thr);


### PR DESCRIPTION
Fixes #264.

## The problem

`recvmsg()` sets `MSG_CTRUNC` when it could not deliver all of the control data
the sender attached. Nothing in `src/` looked at `msg_flags`: `nxt_recvmsg()`
(`src/nxt_socket_msg.c:37`) copied `msg_controllen` into `oob->size` and
returned, and `nxt_socket_msg_oob_get()` parsed whatever survived.

The case that matters is an `SCM_RIGHTS` the kernel discards while delivering
everything else. `scm_recv()` puts the `SO_PASSCRED` credential first and only
then calls `scm_detach_fds()`, which needs a free descriptor slot per fd; under
`RLIMIT_NOFILE` pressure it installs none and raises `MSG_CTRUNC`. What then
reaches a handler is a message that passes every check it makes — right size,
right type, and on Linux a kernel-validated sender pid — whose fd is simply
`-1`. Each fd-carrying type takes some fd-less path from there:
`nxt_port_new_port_handler()` builds a port with `pair[1] == -1`,
`nxt_port_mmap_handler()` has no segment to map,
`nxt_port_change_log_file_handler()` redirects nothing, and
`nxt_port_process_ready_handler()` marks a process ready with no queue.

## The change

- `nxt_recv_oob_t` gains a `truncated` flag, set by `nxt_recvmsg()` from
  `msg_flags & MSG_CTRUNC`.
- `nxt_socket_msg_oob_get()` and `nxt_socket_msg_oob_get_fds()` report it as a
  receive error. The check follows the parse loop rather than preceding it: a
  truncated control block can still have delivered a descriptor — `put_cmsg()`
  installs what fits before setting `MSG_CTRUNC` — and the caller can only
  close what it has been told about.
- Both `nxt_port_socket.c` call sites already close `msg.fd` and fail the
  message on a non-OK return, so the descriptors that did arrive are reclaimed
  and the message is dropped exactly the way a malformed one is;
  `nxt_unit_process_msg()` (`src/nxt_unit.c:1087`) likewise closes through its
  `done` label.
- The two alerts in `nxt_port_socket.c` are folded into
  `nxt_port_oob_error_alert()`, which names truncation separately and by
  message type and stream — the one thing a reader of the log cannot otherwise
  infer, since the message looks whole in every other respect.
- **The new member goes *after* `buf`, and that placement is load bearing.**
  `CMSG_FIRSTHDR()`/`CMSG_NXTHDR()` walk `buf` as `struct cmsghdr`, and nothing
  in the declaration states that alignment — it comes from `buf` following a
  `size_t` directly. A first version put `truncated` between the two which,
  `nxt_bool_t` being `nxt_uint_t`, moved `buf` from offset 8 to offset 12 and
  made every cmsg access undefined (UBSan: *"member access within misaligned
  address … for type 'struct cmsghdr', which requires 8 byte alignment"*, from
  `bits/socket.h`). A comment now says why nothing may be inserted ahead of
  `buf`, and the buffer carries an explicit `nxt_aligned(NXT_OOB_ALIGN)` as a
  second line of defence — second, because `nxt_aligned()` expands to nothing
  outside GCC and clang, so field order has to be the guarantee.
- **Both accessors stop trusting `cmsg_len` against the bytes that arrived.**
  `CMSG_FIRSTHDR()` checks only that `msg_controllen` covers a `struct cmsghdr`,
  so the first header's `cmsg_len` can claim more data than was received and the
  `CMSG_DATA()` copy would run off the end of `oob->buf` — and a block the kernel
  cut short is precisely where an over-claiming length shows up. The loop now
  refuses a header whose full extent does not fit in `oob->size`, the fail-closed
  shape truncation wants anyway.
- `nxt_socket_msg_oob_reset()` retires `->size` and `->truncated` together and
  replaces the four `oob.size = 0` assignments in `src/nxt_unit.c`, so a
  recycled read buffer cannot present a previous message's `MSG_CTRUNC` as this
  one's; `nxt_unit_rbuf_cpy()` carries the flag with the rest of the control
  data.

### The two receive sites fail differently, and that is master's asymmetry

`nxt_port_read_handler()` (`src/nxt_port_socket.c:868`) does `goto fail`, which
routes to `nxt_port_error_handler()`: **the whole port goes down**, and the
refcount drop takes it through `nxt_port_rpc_close()` (`src/nxt_port.c:163`),
failing every RPC registered on it. `nxt_port_queue_read_handler()` **drops the one message** and leaves the port
live.

Keeping those dispositions is deliberate: a truncated message is not more
trustworthy than a malformed one, and giving it a third disposition would change
how every existing oob failure is handled under cover of a truncation fix.
Nothing wedges either way — on the socket path `rpc_close()` fails the pending
RPCs, and on the queue path the message that can carry a start reply is a socket
message, since a queue message carries no descriptors at all
(`nxt_port_queue_read_handler()` zeroes `msg.fd` up front).

**Dropping the message at the queue site has to give back what the iteration
took, and master's bare `return` did not.** `queue->nitems` is incremented on
entry and read by `nxt_port_queue_send()` in every *other* process holding the
port: while it is non-zero the sender skips the socket notification, because a
reader is supposed to be awake. Returning without decrementing left the counter
raised for good, so the port was never woken for a queue-only message again —
one refused datagram costing the port every message after it. The `READ_SOCKET`
marker counted in `port->from_socket` and the buffer from
`nxt_port_buf_alloc()` leaked on the same return. All three are now unwound,
in the shape the buf-alloc failure branch just above already uses. This corrects
master's behaviour on its own oob-failure path too; it is folded in here because
this change is what makes that path reachable from a condition a peer does not
control.

`nxt_port_rpc_error()` from #280 would allow failing the single stream instead
of the port; that PR is not on master and nothing here depends on it.

### The Go module

The Go wrapper reaches the same control data through the `port_recv` callback
(`go/nxt_cgo_lib.c:60`), which reports a **length**, not `msg_flags` — so
`oob.truncated` cannot be plumbed across it without changing the public
`nxt_unit.h` callback ABI. `nxt_go_port_recv()` (`go/port.go:243`) discarded the
flags word `ReadMsgUnix()` returns, so a Go application would have kept the
pre-fix behaviour (`NEW_PORT`/`MMAP` with fd `-1`) while every other language
module was covered.

It now tests `MSG_CTRUNC` and returns `-1`, which `nxt_unit_port_recv()` turns
into `NXT_UNIT_ERROR` at its `rbuf->size < 0` arm, *before* it parses any
control data. That is why the callback path still clears `oob.truncated` rather
than honouring it; the comment there says so.

Reporting the error is not enough on its own. Truncation does not mean nothing
was delivered — `scm_detach_fds()` installs the descriptors that fit and only
then raises `MSG_CTRUNC` — and those are open in the Go process already, while
an error return leaves `*oob_size` at 0, so libunit never parses the block and
never closes them: a descriptor leak under exactly the pressure that caused the
truncation. `closeUnixRights()` parses the delivered bytes with
`syscall.ParseSocketControlMessage`/`ParseUnixRights` and closes what it finds
before the error is returned; parse failures are ignored, since the block is
known to be damaged.

### The buffer is already the right size

`NXT_OOB_RECV_SIZE` (`src/nxt_socket_msg.h:29`) is `CMSG_SPACE(2 * sizeof(int))`
plus the credential cmsg, and two is the whole of what Unit can send:
`nxt_port_recv_msg_t` has two fd slots and `nxt_socket_msg_oob_init()` attaches
at most that many. The truncation is therefore never self-inflicted; the buffer
is left alone and a new comment records why resizing cannot be the remedy.

## Tests

`src/test/nxt_port_ctrunc_test.c` drives the truncation through the receive
buffer's length rather than through `RLIMIT_NOFILE` — the other input to the
same kernel decision, deterministic and confined to the test. Over a socketpair
from `nxt_socketpair_create()`, so `SO_PASSCRED` reproduces the production
ordering, a two-descriptor message is received three ways:

| case | `msg_controllen` | expected |
|---|---|---|
| credential kept, `SCM_RIGHTS` dropped | `CMSG_SPACE(ucred) + CMSG_LEN(0)` | both accessors `NXT_ERROR`, no fd, no leak |
| one of two descriptors delivered | `CMSG_SPACE(ucred) + CMSG_LEN(0) + sizeof(int)` | both accessors `NXT_ERROR`, the delivered fd reported so it can be closed, no leak |
| intact | `NXT_OOB_RECV_SIZE` | `NXT_OK`, both fds, sender pid |

The open-descriptor count is taken before and after each case.

**Platform note.** The two short-buffer cases assert a kernel behaviour Linux and
the BSDs share and xnu does not: `scm_detach_fds()` installs what fits and raises
`MSG_CTRUNC`, whereas Darwin externalizes the rights before it measures the
buffer, so the same short receive there reports no truncation and an
unconditional assertion would simply fail. They are compiled out under
`NXT_MACOSX` with a notice naming the reason. The accessor contract itself is
covered on **every** platform by a third case that takes a control block
delivered whole, marks it truncated by hand, and requires the same refusal with
both descriptors still reported — also the production shape, since a real
truncation can deliver every descriptor asked for and still raise the flag.

**Queue-path case.** A fourth case covers the queue-backed read path end to end:
a port with a mapped `nxt_port_queue_t`, its handler installed through
`nxt_port_read_enable()`, a `READ_SOCKET` marker enqueued the way a real sender
does, and a message refused after its descriptor was delivered. The refusal is
driven by a missing `SCM_CREDENTIALS` rather than by truncation — the handler
sizes its own receive buffer, so a real `MSG_CTRUNC` there would mean exhausting
the test process's descriptor table, which is neither deterministic nor confined
to the test — but it reaches the identical cleanup path. It asserts that
`queue->nitems` and `port->from_socket` return to their entry values and, the
point of the counter, that **the very next message on that port is still
delivered**. Compiled only where credential passing exists.

With the two `oob->truncated` guards removed from `nxt_socket_msg.h` and
nothing else changed, the test fails on the first case:

```
tests: [alert] port ctrunc test: credential kept, SCM_RIGHTS dropped:
       oob_get_fds accepted a truncated control block (fd -1)
```

which is the bug: `NXT_OK` with `fd[0] == -1`.

### Verified

Docker `php:8.4-cli-trixie` (`--platform linux/amd64`), `./configure --debug
--tests && ./configure php && make -j4 && make tests`:

| run | `./build/tests` | `pytest test_php_application.py test_configuration.py` |
|---|---|---|
| branch | pass (incl. `port ctrunc test passed`) | 51 passed, 39 skipped |
| `origin/master` | pass | 51 passed, 39 skipped |
| branch, accessor guards removed | **fail** — `oob_get accepted a block marked truncated` | — |
| branch, queue cleanup removed | **fail** — `a refused message left queue->nitems at 1, was 0` | — |

**Sanitizers.** Built with `-fsanitize=address,undefined`
(`UBSAN_OPTIONS=print_stacktrace=1`, `ASAN_OPTIONS=detect_leaks=0`) and run
against `origin/master` as a control. The two are **identical**: one runtime
error each — the pre-existing `src/nxt_buf.h:250` *"null pointer passed as
argument 2"* reached from `nxt_router_proto_wedge_test`, present on master and
untouched here — and **zero** reports anywhere in `bits/socket.h` or
`nxt_socket_msg.c`. `port ctrunc test passed` under the sanitizers.

`./configure go` + `make go-install` build the Go module cleanly with the
`port.go` change (go1.24.4), and `gofmt -d go/port.go` is empty.
`test/test_go_application.py` was **not** exercised: all 12 cases skipped in the
container, so the Go change is covered by compilation and review only.

## CHANGES

```
*) Bugfix: a port message whose control data the kernel truncated was
   handled as if the file descriptor it carried had never been sent.
```

## Review rounds after the initial submission

Merged as `420f4b2d`; final head `4eac4113`. Four changes landed on top of the
submitted `0585aa2f`, each mutation-verified, debug and release both clean:

1. **The CTRUNC refusal now keeps draining** instead of returning. Restoring the
   counter was necessary but not sufficient: `queue->nitems` is non-zero for the
   whole invocation, which is how `nxt_port_queue_send()` decides a reader is
   awake and skips the notification, so a message enqueued in that window was
   never announced and returning left nobody to come back for it. `nitems` is
   deliberately *not* decremented on this path — the handler holds one credit per
   invocation, released at whichever exit it takes. Decrementing here as well
   underflows it to `UINT32_MAX`, a worse wedge than the stranding.
2. `nxt_port_ctrunc_test_truncated()` is defined only in the arm that calls it —
   an unused static trips `-Wunused-function` under `-Werror` on macOS.
3. The queue fixture is gated `NXT_HAVE_UCRED`, not `NXT_CRED_USECMSG`. It builds
   its refused message out of a credential that is enforced but not attached,
   which is false where the credential travels as `SCM_CREDS` and
   `nxt_socket_msg_oob_init()` attaches one itself.
4. The `NXT_OOB_RECV_SIZE` comment no longer describes Linux's
   install-then-truncate behaviour as what `MSG_CTRUNC` means everywhere.

Neither (2) nor (3) is reachable by any CI leg — there is no macOS or FreeBSD job.

## Follow-ups (not filed)

- **Fail one stream instead of the whole port.** The `goto fail` at
  `src/nxt_port_socket.c:909-911` tears the port down and with it every pending
  RPC; a truncated datagram naming a stream could fail just that RPC. Note this
  depends on nothing unmerged: stream retirement landed in #289, and there is no
  `nxt_port_rpc_error()` — the mechanism is retyping to `_NXT_PORT_MSG_RPC_ERROR`
  and dispatching through `nxt_port_rpc_handler()`.
- **`MSG_TRUNC` alongside `MSG_CTRUNC`** in `nxt_socket_msg.c:59`, so an oversized
  payload is refused rather than parsed short. Ports are `SOCK_SEQPACKET` where
  the platform has it, `SOCK_DGRAM` only as the fallback; the flag applies to both.
- **Rate-limit the port-handler alert paths.** `nxt_port_oob_error_alert()` logs
  per refused datagram; the same shape exists on the `PROCESS_READY` refusal and
  stream-mismatch paths added in #289. One issue for the set, not three.
- **Carry kernel message flags across the libunit `port_recv` callback**
  (`src/nxt_unit.h:157`), so a Go worker can see `MSG_CTRUNC` rather than closing
  descriptors internally and returning a bare `-1`. Public ABI, so 1.37+.
- **pytest coverage for `closeUnixRights()`** in `go/port.go`, which this PR
  verifies only by review; `test/test_go_application.py` is the place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh