### PR TITLE
test(configuration): retry the bind in test_listeners_port_release

### DIFF
--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,4 +1,5 @@
 import socket
+import time
 
 import pytest
 
@@ -333,7 +334,6 @@ def test_listeners_addr_error_2(skip_alert):
 
 def test_listeners_port_release():
     for _ in range(10):
-        fail = False
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
@@ -346,15 +346,28 @@ def test_listeners_port_release():
 
             resp = client.conf({"listeners": {}, "applications": {}})
 
-            try:
-                s.bind(('127.0.0.1', 8080))
-                s.listen()
+            # The router closes the listening descriptor before it
+            # acknowledges the removal, but close(2) only drops the closing
+            # thread's reference to the open file.  Every other router
+            # thread that had the descriptor armed for accept(2) may still
+            # hold a transient kernel reference to it, and the address
+            # leaves the bind hash only when the last one is dropped, which
+            # happens asynchronously.  A client therefore has to retry, so
+            # the test retries too; a listener that is genuinely never
+            # closed still fails here.
+            deadline = time.monotonic() + 5
 
-            except OSError:
-                fail = True
+            while True:
+                try:
+                    s.bind(('127.0.0.1', 8080))
+                    s.listen()
+                    break
 
-            if fail:
-                pytest.fail('cannot bind or listen to the address')
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        pytest.fail('cannot bind or listen to the address')
+
+                    time.sleep(0.01)
 
             assert 'success' in resp, 'port release'
 


### PR DESCRIPTION
Closes the open question left by #276, which noted a second, pre-existing
window that its fix neither introduced nor removed: `test_listeners_port_release`
still failed at about 1% of runs under load on both trees, with the debug log
showing the router's `close(2)` correctly preceding the controller's reply.

This is that window. It is not an ordering defect, and it is not fixable in the
product.

## Mechanism

The router keeps one listening descriptor and arms it on every engine thread:
`nxt_router_listen_socket_ready()` stores it once (`src/nxt_router.c:3138`),
`nxt_router_listen_socket_create()` runs per engine (`src/nxt_router.c:3935-3968`),
and `nxt_listen_event()` copies the same descriptor number into each engine's
listen event (`src/nxt_conn_accept.c:38-48`). Exactly one `close(2)` happens, on
the last engine to release (`src/nxt_router.c:4260-4290`), and since #276 it
precedes the acknowledgement. There is no `dup()`/`dup2()`/`F_DUPFD` on a
listening descriptor anywhere in `src/`, and `SO_REUSEPORT` is never used — so
Unit's accounting is correct and complete.

The kernel does not free the address at `close(2)`. Unit's engine threads share
one file descriptor table, so every `accept4(2)` or `epoll_ctl(2)` a sibling
thread performs on that descriptor takes a real reference to the socket's open
file (`__fget_light` falls back to `__fget` when `files_struct` is shared).
`close(2)` drops only the closing thread's reference; the address leaves the
kernel's bind hash at the final release of the open file, which for a sibling
thread is deferred to that thread's own return to user space. Under load that
thread may be descheduled, so a `bind(2)` issued immediately after the
acknowledgement can still fail with `EADDRINUSE`.

## Evidence

At the instant of the failed bind the address is in `TCP_LISTEN` (`st` `0A` in
`/proc/net/tcp`) while **no process holds a descriptor for it** — all 19
captured samples reported `NO HOLDER among ALL pids`, from an all-pid
`/proc/*/fd` inode scan, including windows of 38 ms, 76 ms and 95 ms. The
observed window ranged from 65 µs to 95 ms.

An isolated reproducer, with no Unit code involved, binds and listens on
`127.0.0.1:18080`, runs *N* threads on that descriptor, closes it, and
immediately re-binds the address with `SO_REUSEADDR`:

| arm | rounds | EADDRINUSE |
| --- | --- | --- |
| 8 sibling threads in `accept4()` **on the closed descriptor** | 2000 | **501 (25.05%)** |
| 8 sibling threads in `epoll_ctl(ADD/DEL)` on the closed descriptor | 2000 | 24 (1.20%) |
| 8 sibling threads in `accept4()` **on an unrelated descriptor** (control) | 2000 | **0 (0.00%)** |
| no sibling threads at all (control) | 2000 | **0 (0.00%)** |

The controls hold thread count and syscall rate fixed and vary only whether the
syscall targets the descriptor being closed, isolating the shared open-file
reference from scheduling noise.

`SO_REUSEADDR`, which the test already sets, is irrelevant here: it permits
binding over `TIME_WAIT`, not over a socket still in `TCP_LISTEN`. No connection
is ever made to this listener, so `TIME_WAIT` is not involved.

## What this changes

A real client re-binding a released address has to retry, so the test retries
too, for up to five seconds. A listener that is genuinely never closed — the
regression class this test exists to catch — still fails it.

## Validation

Docker, `debian:trixie-slim`, `--openssl --tests --debug` plus the python
module, default engine count (8 on this host), 16× CPU load.

Each run is 10 add/remove cycles, so 300 runs is 3000 bind attempts per arm.
Every failure was classified by whether the output carried `cannot bind or
listen to the address`.

| under 16× load, 300 runs | master (`94553347`) | this branch |
| --- | --- | --- |
| **`cannot bind or listen`** (this defect) | **2** | **0** |
| any other failure | 0 | 0 |

| other cells (this branch, idle) | result |
| --- | --- |
| `test_listeners_port_release`, 100 runs | 100 pass, 0 fail |
| `test_configuration.py` (full) | 33 passed, 5 skipped |
| `test_listener_drain.py` (full) | 2 passed, 1 skipped |

`test_configuration.py` and `test_listener_drain.py` match the counts #276
recorded, so the early acknowledgement the drain feature depends on is
untouched.

## Honest limitation

The defect #276 fixed also produced a short window — the close followed the
acknowledgement within the same call — so a retrying test would not have caught
it either. This test can be strict or non-flaky, but not both: the bind is a
proxy for an ordering property the kernel does not let a client observe
reliably. Testing that ordering directly means asserting on the debug log, that
`socket close(<fd>)` precedes the controller's reply, which is how #276 was
actually validated and is deterministic. That is worth a follow-up; this change
restores the test's value as a leak guard in the meantime.

Refs #292 (mechanism and reproducer), follow-up to #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCehiiAnBKsYuNrDAaZERh
