### PR TITLE
pkg(eol): fix the Ubuntu dates, and stop reading Debian LTS as its EOL

### DIFF
--- a/EOL.md
+++ b/EOL.md
@@ -66,6 +66,13 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
 † Past upstream EOL; in FreeUnit grace period.
 ‡ Default Python shipped by this OS is itself past upstream EOL. FreeUnit does not backport fixes to that Python version.
 
+The "Upstream EOL" column is always the end of *standard* support, per the LTS
+rule below — never an extended-maintenance date. Which endoflife.date field that
+is depends on the vendor, so `pkg/eol/` picks per category: Ubuntu's `eol` is the
+end of standard security maintenance (ESM excluded), while Debian's `eol` became
+the end of **LTS** in September 2026, and the Debian Security Team's window — the
+one this table tracks — moved to that API's `support` field.
+
 ## Dependency Support
 
 Build-time and bundled libraries. These are **not** matrix variants — nothing in

--- a/EOL.md
+++ b/EOL.md
@@ -48,9 +48,9 @@ EOL dates are tracked at [endoflife.date](https://endoflife.date).
 | CentOS Stream | 10 | 2030-05 | 2033-05 | 3.13 |
 | Amazon Linux | 2 (EOL) † | 2026-06 | 2029-06 | 3.7 ‡ |
 | Amazon Linux | 2023 | 2029-06 | 2032-06 | 3.11 |
-| Ubuntu (LTS) | 22.04 | 2027-04 | 2030-04 | 3.10 |
+| Ubuntu (LTS) | 22.04 | 2027-06 | 2030-06 | 3.10 |
 | Ubuntu (LTS) | 24.04 | 2029-05 | 2032-05 | 3.12 |
-| Ubuntu (LTS) | 26.04 | 2031-04 | 2034-04 | 3.13 |
+| Ubuntu (LTS) | 26.04 | 2031-05 | 2034-05 | 3.13 |
 | Debian | 11 (bullseye) (EOL) † | 2024-08 | 2027-08 | 3.9 |
 | Debian | 12 (bookworm) (EOL) † | 2026-07 | 2029-07 | 3.11 |
 | Debian | 13 (trixie) | 2028-08 | 2031-08 | 3.13 |

--- a/pkg/eol.json
+++ b/pkg/eol.json
@@ -22,9 +22,9 @@
       {"version": "2023", "eol": "2029-06", "supported_until": "2032-06", "default_python": "3.11"}
     ],
     "ubuntu": [
-      {"version": "22.04", "eol": "2027-04", "supported_until": "2030-04", "default_python": "3.10", "lts": true},
+      {"version": "22.04", "eol": "2027-06", "supported_until": "2030-06", "default_python": "3.10", "lts": true},
       {"version": "24.04", "eol": "2029-05", "supported_until": "2032-05", "default_python": "3.12", "lts": true},
-      {"version": "26.04", "eol": "2031-04", "supported_until": "2034-04", "default_python": "3.13", "lts": true}
+      {"version": "26.04", "eol": "2031-05", "supported_until": "2034-05", "default_python": "3.13", "lts": true}
     ],
     "debian": [
       {"version": "11", "eol": "2024-08", "supported_until": "2027-08", "default_python": "3.9",  "codename": "bullseye", "note": "EOL"},

--- a/pkg/eol/README.md
+++ b/pkg/eol/README.md
@@ -32,27 +32,29 @@ Exit codes: `0` = clean or warnings only · `1` = errors found (drift, expiry, o
 
 Errors include the **expiry gate**: any runtime or OS entry whose `supported_until` is already in the past (EOL + grace elapsed) is a hard error and must be dropped from `pkg/eol.json`.
 
-## Current EOL Status (2026-07-13)
+## Current EOL Status (2026-09-08)
 
 All dates verified against endoflife.date API. No errors. Warnings below are proximity/past-EOL alerts only — every entry is still inside its grace window.
 
+Dates are compared per category against the field that carries *standard* support: `support` for Debian (its `eol` became the end of LTS in September 2026), `eol` for everything else.
+
 ### Runtimes — warnings
 
-None. All shipped runtimes are within (or ahead of) upstream EOL; `node 20` is already flagged `(EOL)` in the matrix.
+None. All shipped runtimes are within (or ahead of) upstream EOL; `go 1.25`, `node 20` and `perl 5.38` are already flagged `(EOL)` in the matrix.
 
 ### OS — warnings
 
 | Entry | Note |
 |-------|------|
 | debian 11 | Past EOL (2024-08), grace until 2027-08 |
-| fedora 40, 41, 42 | Past EOL (2025-05 / 2025-12 / 2026-05), grace active |
+| fedora 40, 41, 42 | Past EOL (2025-05 / 2025-12 / 2026-05), grace until 2028-05 / 2028-12 / 2029-05 |
 | amazonlinux 2 | Past EOL (2026-06), grace until 2029-06 |
 | alpine 3.20 | Past EOL (2026-04), grace until 2029-04 |
-| debian 12 | EOL now (2026-07), grace until 2029-07 |
-| fedora 43, 44 | EOL in ~5 / ~11 months |
-| alpine 3.21, 3.22 | EOL in ~4 / ~10 months |
-| centos_stream 9 | EOL in ~10 months (2027-05) |
-| ubuntu 22.04 | EOL in ~9 months (2027-04) |
+| debian 12 | Past EOL (2026-07), grace until 2029-07 |
+| fedora 43, 44 | EOL in ~3 / ~9 months |
+| alpine 3.21, 3.22 | EOL in ~2 / ~8 months |
+| centos_stream 9 | EOL in ~8 months (2027-05) |
+| ubuntu 22.04 | EOL in ~9 months (2027-06) |
 
 ## Architecture
 

--- a/pkg/eol/src/main.rs
+++ b/pkg/eol/src/main.rs
@@ -204,6 +204,22 @@ fn fetch_api(category: &str) -> Result<String, String> {
 // API date lookup
 // ---------------------------------------------------------------------------
 
+/// endoflife.date field holding the date FreeUnit's policy is anchored to.
+///
+/// EOL.md: the three-year OS extension runs from *standard* EOL, never from
+/// extended maintenance. For every vendor but one that is the API's `eol`.
+/// Debian is the exception: in September 2026 endoflife.date redefined Debian's
+/// `eol` to the end of LTS (`eolFrom` in the v1 API) and moved the end of
+/// regular security-team support — the date the policy means — to `support`
+/// (`eoasFrom`). Reading `eol` for Debian would silently re-anchor the grace
+/// window to LTS and keep bullseye in the matrix two years past policy.
+fn api_eol_field(category: &str) -> &'static str {
+    match category {
+        "debian" => "support",
+        _ => "eol",
+    }
+}
+
 /// Result of an API EOL lookup: Ok(Some(date)), Ok(None) (version not found in API),
 /// or Err (network/parse failure).
 fn api_eol_date(category: &str, version: &str) -> Result<Option<String>, String> {
@@ -223,7 +239,7 @@ fn api_eol_date(category: &str, version: &str) -> Result<Option<String>, String>
             None => continue,
         };
         if cycle == version {
-            if let Some(eol_val) = entry.get("eol") {
+            if let Some(eol_val) = entry.get(api_eol_field(category)) {
                 match eol_val {
                     serde_json::Value::String(s) => {
                         // Normalize to YYYY-MM (API may return YYYY-MM or YYYY-MM-DD)
@@ -1148,5 +1164,16 @@ mod tests {
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].severity, Severity::Error);
         assert!(r[0].message.contains("unparseable"));
+    }
+
+    #[test]
+    fn debian_is_compared_against_the_support_field() {
+        // Debian's API `eol` became the end of LTS in September 2026; the
+        // policy anchors on the end of regular security support, which the API
+        // now calls `support`. Every other category still means `eol`.
+        assert_eq!(api_eol_field("debian"), "support");
+        assert_eq!(api_eol_field("ubuntu"), "eol");
+        assert_eq!(api_eol_field("alpine"), "eol");
+        assert_eq!(api_eol_field("python"), "eol");
     }
 }


### PR DESCRIPTION
The weekly EOL check has been red since Monday. This makes `cargo run --release
--manifest-path pkg/eol/Cargo.toml -- --ci` exit 0 again.

Refs #178 — that issue is the bot's recurring ticket (opened 2026-07-27, one
comment every Monday since). A green scheduled run does not touch it: the
"open or update tracking issue" step is gated on a non-zero exit, so it neither
comments nor closes. Since the bot looks for an *open* issue by title, closing
#178 after this merges is what makes the next failure open a fresh ticket.

## Two problems, one data fix and one validator fix

**1. Ubuntu 22.04 / 26.04 dates were wrong** — the two errors in the 2026-09-07
comment:

| variant | matrix had | actual | now |
|---|---|---|---|
| ubuntu 22.04 | 2027-04 | 2027-06 | 2027-06 |
| ubuntu 26.04 | 2031-04 | 2031-05 | 2031-05 |

**2. endoflife.date redefined Debian's `eol`** — and the validator followed it
into the wrong window. Running the validator today produces *five* errors, not
two: three Debian ones that Monday's report does not have. Between the scheduled
run of 2026-09-07 and 2026-09-08, `eol` stopped meaning the end of regular
security support and started meaning the end of **LTS**, with the old value
moved to `support`:

| variant | matrix (unchanged) | `eol` / `eolFrom` — now end of LTS | `support` / `eoasFrom` — security team |
|---|---|---|---|
| debian 11 bullseye | 2024-08 | 2026-08-31 | 2024-08-14 |
| debian 12 bookworm | 2026-07 | 2028-06-30 | 2026-07-11 |
| debian 13 trixie | 2028-08 | 2030-06-30 | 2028-08-09 |

The matrix was right and the comparison was wrong. `EOL.md` is explicit that the
three-year OS extension "applies to standard EOL, not extended security
maintenance dates", so adopting the new `eol` would have re-anchored the grace
window to LTS and kept bullseye in the matrix until 2029-08 instead of 2027-08 —
two extra years of an unsupported variant.

So `pkg/eol/src/main.rs` now picks the field per category — `support` for Debian,
`eol` for everyone else — and **`pkg/eol.json`'s Debian rows are untouched**. The
mapping is a four-line `match` with the reason written next to it, plus a unit
test, because the failure mode is silent: both fields parse, and the wrong one
merely moves a date.

*(An earlier revision of this PR did the opposite — changed the Debian data to
match the new `eol`. Thanks to the Codex review for catching that it broke the
stated policy.)*

## Sources checked

Not taken from endoflife.date alone. All three, fetched 2026-09-08:

| source | ubuntu 22.04 | ubuntu 26.04 |
|---|---|---|
| endoflife.date `/api/ubuntu.json` (`eol`) | 2027-06-01 | 2031-05-29 |
| Canonical, [list of releases](https://ubuntu.com/project/docs/release-team/list-of-releases/) — where `wiki.ubuntu.com/Releases` now redirects (`End of Standard Support`) | Jun 2027 | May 2031 |
| Canonical, [release cycle](https://ubuntu.com/about/release-cycle) (`Standard security maintenance`) | May 2027 | May 2031 |

The two Canonical pages disagree with each other by a month on 22.04 (the
release-cycle chart is month-granular and rounds; the release list is the more
precise page). endoflife.date agrees with the release list on both versions.
`pkg/eol.json` follows endoflife.date, and not because it wins on authority: it
is the source `pkg/eol/src/main.rs` fetches, so any other value — including a
defensible "May 2027" — is a permanently red CI gate. Nothing is lost by it here,
since it matches Canonical's own release list. The matrix's old 2027-04/2031-04
were wrong under *all three* sources; they look like release date + 5 years,
which is not how Canonical dates the window.

Alpine, cross-checked because the bot warns on 3.20/3.21/3.22 —
[alpinelinux.org/releases](https://alpinelinux.org/releases/) gives end of
support 2026-04-01 / 2026-11-01 / 2027-05-01, matching both endoflife.date and
the matrix exactly. **No Alpine change needed**; those are proximity warnings,
not drift.

## Validator output

Before (this branch's base, run today — note the three Debian errors that
Monday's comment did not have):

```
exit=1  errors 5
error debian 11    matrix EOL 2024-08 ahead of actual 2026-08
error debian 12    matrix EOL 2026-07 ahead of actual 2028-06
error debian 13    matrix EOL 2028-08 ahead of actual 2030-06
error ubuntu 22.04 matrix EOL 2027-04 ahead of actual 2027-06
error ubuntu 26.04 matrix EOL 2031-04 ahead of actual 2031-05
```

After — Debian now compares matrix against `support` and matches exactly
(2024-08 / 2026-07 / 2028-08; trixie is silent because it is neither drifted nor
near EOL):

```
$ cargo run --quiet --release --manifest-path pkg/eol/Cargo.toml -- --ci
exit=0   errors 0   warnings 13
warning alpine 3.20       matrix 2026-04  actual 2026-04  EOL in ~-5 months
warning alpine 3.21       matrix 2026-11  actual 2026-11  EOL in ~2 months
warning alpine 3.22       matrix 2027-05  actual 2027-05  EOL in ~8 months
warning amazonlinux 2     matrix 2026-06  actual 2026-06  EOL in ~-3 months
warning centos_stream 9   matrix 2027-05  actual 2027-05  EOL in ~8 months
warning debian 11         matrix 2024-08  actual 2024-08  EOL in ~-25 months
warning debian 12         matrix 2026-07  actual 2026-07  EOL in ~-2 months
warning fedora 40         matrix 2025-05  actual 2025-05  EOL in ~-16 months
warning fedora 41         matrix 2025-12  actual 2025-12  EOL in ~-9 months
warning fedora 42         matrix 2026-05  actual 2026-05  EOL in ~-4 months
warning fedora 43         matrix 2026-12  actual 2026-12  EOL in ~3 months
warning fedora 44         matrix 2027-06  actual 2027-06  EOL in ~9 months
warning ubuntu 22.04      matrix 2027-06  actual 2027-06  EOL in ~9 months
```

`cargo test --manifest-path pkg/eol/Cargo.toml`: 8 passed, 0 failed (7 existing
plus the new field-mapping test). The eol-check workflow runs no fmt or clippy
step, so none is mirrored here.

Every warning is a variant inside its grace window (`supported_until` still in
the future), which the validator does not fail on and this PR does not touch.
Dropping fedora 40-42, amazonlinux 2, alpine 3.20 and debian 11/12 from the
matrix is a separate maintainer decision.

`EOL.md` mirrors the two Ubuntu rows and gains a footnote on which API field
carries standard support per vendor. The last commit redoes the dated status
snapshot in `pkg/eol/README.md`, which was stamped 2026-07-13 and still quoted a
date this PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
