### PR TITLE
proxy: complete a bodyless upstream response on its headers

### DIFF
--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -2851,12 +2851,67 @@ nxt_h1p_peer_header_read_done(nxt_task_t *task, void *obj, void *data)
 
         h1p = peer->proto.h1;
 
-        if (h1p->chunked) {
-            if (r->resp.content_length != NULL) {
-                peer->status = NXT_HTTP_BAD_GATEWAY;
+        if (h1p->chunked && r->resp.content_length != NULL) {
+            peer->status = NXT_HTTP_BAD_GATEWAY;
+            break;
+        }
+
+        /*
+         * RFC 9112 Sect. 6.3: a response to HEAD, and any 204 or 304 response,
+         * is terminated by the first empty line after the header fields no
+         * matter what Content-Length or Transfer-Encoding say.  Such a response
+         * is complete right here, so neither arm the chunked parser nor set a
+         * remainder from a Content-Length that describes a body the upstream
+         * will never send.
+         *
+         * Without this the upstream -- which nxt_h1p_peer_header_send() always
+         * asks to "Connection: close" -- closes with h1p->remainder still at
+         * the advertised length, or with chunked_parse.last still clear;
+         * nxt_h1p_peer_closed() then reads that as a truncated body and sets
+         * r->truncated and r->inconsistent, and nxt_h1p_request_close() drops
+         * the client keep-alive over a response that was never short.  Any
+         * pipelined request already in the client's socket buffer is lost.
+         *
+         * Complete the response the way a body that reaches its declared
+         * length completes it in nxt_h1p_peer_body_process(): hand the
+         * request's last buffer to the ready handler and mark the peer closed,
+         * so nxt_http_proxy_send_body() closes the upstream connection and
+         * releases the request pool.
+         *
+         * The predicate is the "final response" one, not the full RFC list:
+         * a 1xx from an upstream is an interim response, and nothing here
+         * continues the exchange past it -- nxt_h1p_peer_header_parse() only
+         * reads a status line while peer->status is still NXT_HTTP_UNSET, so
+         * the 1xx is taken as the response and whatever follows is relayed as
+         * its body.  That is pre-existing and out of scope; ending the
+         * exchange on the 1xx header here would discard a final response that
+         * may already be sitting in this very buffer.
+         *
+         * "b" is not forwarded: bytes an upstream put after the header of a
+         * bodyless response are not a body.  It is handed to
+         * nxt_http_proxy_buf_mem_hold() rather than freed, because the
+         * response fields point their name/value into it and are read until
+         * the request is logged and closed; see the comment there.
+         */
+        if (nxt_http_request_is_bodyless_final(r, peer->status)) {
+            h1p->chunked = 0;
+            h1p->remainder = 0;
+
+            if (nxt_slow_path(nxt_http_proxy_buf_mem_hold(task, r, b)
+                              != NXT_OK))
+            {
+                peer->status = NXT_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
 
+            peer->body = nxt_http_buf_last(r);
+            peer->closed = 1;
+
+            r->state->ready_handler(task, r, peer);
+            return;
+        }
+
+        if (h1p->chunked) {
             h1p->chunked_parse.mem_pool = c->mem_pool;
 
         } else if (r->resp.content_length_n > 0) {
@@ -2866,6 +2921,20 @@ nxt_h1p_peer_header_read_done(nxt_task_t *task, void *obj, void *data)
         if (nxt_buf_mem_used_size(&b->mem) != 0) {
             nxt_h1p_peer_body_process(task, peer, b);
             return;
+        }
+
+        /*
+         * No body bytes arrived with the header, so nothing will relay "b" and
+         * nothing will run its completion handler.  Dropping it here -- which
+         * is what this path did -- stranded both the buffer and the
+         * r->mem_pool retain nxt_http_proxy_buf_mem_alloc() took, so the whole
+         * request pool was never destroyed.  Measured on the parent commit:
+         * two pools reach a zero retain per request on this path against three
+         * on the path where the body shares the header's read.
+         */
+        if (nxt_slow_path(nxt_http_proxy_buf_mem_hold(task, r, b) != NXT_OK)) {
+            peer->status = NXT_HTTP_INTERNAL_SERVER_ERROR;
+            break;
         }
 
         r->state->ready_handler(task, r, peer);

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -431,6 +431,10 @@ void nxt_http_request_ws_frame_start(nxt_task_t *task, nxt_http_request_t *r,
     nxt_buf_t *ws_frame);
 void nxt_http_request_send(nxt_task_t *task, nxt_http_request_t *r,
     nxt_buf_t *out);
+nxt_bool_t nxt_http_request_is_bodyless(nxt_http_request_t *r,
+    nxt_http_status_t status);
+nxt_bool_t nxt_http_request_is_bodyless_final(nxt_http_request_t *r,
+    nxt_http_status_t status);
 nxt_buf_t *nxt_http_buf_mem(nxt_task_t *task, nxt_http_request_t *r,
     size_t size);
 nxt_buf_t *nxt_http_buf_last(nxt_http_request_t *r);
@@ -519,6 +523,8 @@ nxt_int_t nxt_http_proxy_skip(void *ctx, nxt_http_field_t *field,
     uintptr_t data);
 nxt_buf_t *nxt_http_proxy_buf_mem_alloc(nxt_task_t *task, nxt_http_request_t *r,
     size_t size);
+nxt_int_t nxt_http_proxy_buf_mem_hold(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_buf_t *b);
 void nxt_http_proxy_buf_mem_free(nxt_task_t *task, nxt_http_request_t *r,
     nxt_buf_t *b);
 

--- a/src/nxt_http_proxy.c
+++ b/src/nxt_http_proxy.c
@@ -375,6 +375,76 @@ nxt_http_proxy_buf_mem_free(nxt_task_t *task, nxt_http_request_t *r,
 
 
 static void
+nxt_http_proxy_buf_mem_cleanup(nxt_task_t *task, void *obj, void *data)
+{
+    nxt_buf_t           *b;
+    nxt_event_engine_t  *engine;
+
+    b = obj;
+    engine = data;
+
+    /*
+     * Runs from nxt_mp_destroy(), which may be reached from a different task
+     * than the one current when the buffer was held, so "task" is not touched
+     * and the engine is carried in "data" instead.
+     */
+
+    nxt_event_engine_buf_mem_free(engine, b);
+}
+
+
+/*
+ * Keep an upstream read buffer alive for the rest of the request without
+ * holding the request pool hostage.
+ *
+ * A buffer that is relayed downstream needs none of this: its completion
+ * handler frees it and drops the retain.  One that is *not* relayed does --
+ * an upstream header block with no body bytes behind it, and the header of a
+ * response that RFC 9112 Sect. 6.3 gives no body at all.  Two things then have
+ * to hold at once:
+ *
+ *   - It must outlive the response.  peer->fields point their name/value into
+ *     this buffer (nxt_http_parse_fields) and nxt_http_proxy_header_read()
+ *     shallow-copies those field structs into r->resp, where
+ *     $response_header_* and "match" conditions read them until the request is
+ *     logged and closed.  Returning it to the engine cache when the response
+ *     completes would leave them pointing at reusable memory.
+ *
+ *   - It must not keep the retain nxt_http_proxy_buf_mem_alloc() took.  That
+ *     retain is dropped by a buffer completion, and a buffer that is never
+ *     relayed has no completion to run -- the pool would never reach zero and
+ *     the entire request pool would be stranded.
+ *
+ * A pool cleanup satisfies both: nxt_mp_destroy() runs it before freeing the
+ * pool's own blocks, so the field bytes stay valid for exactly as long as
+ * anything can read them, and not one request longer.
+ */
+
+nxt_int_t
+nxt_http_proxy_buf_mem_hold(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_buf_t *b)
+{
+    nxt_int_t  ret;
+
+    ret = nxt_mp_cleanup(r->mem_pool, nxt_http_proxy_buf_mem_cleanup, task, b,
+                         task->thread->engine);
+    if (nxt_slow_path(ret != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    /*
+     * The request itself holds a retain until nxt_http_request_close_handler(),
+     * so this cannot destroy the pool here -- which it must not, the cleanup
+     * just registered lives in it.
+     */
+
+    nxt_mp_release(r->mem_pool);
+
+    return NXT_OK;
+}
+
+
+static void
 nxt_http_proxy_error(nxt_task_t *task, void *obj, void *data)
 {
     nxt_http_peer_t     *peer;

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -22,7 +22,6 @@ static void nxt_http_request_forward_protocol(nxt_http_request_t *r,
 static void nxt_http_request_ready(nxt_task_t *task, void *obj, void *data);
 static void nxt_http_request_proto_info(nxt_task_t *task,
     nxt_http_request_t *r);
-static nxt_bool_t nxt_http_request_is_bodyless(nxt_http_request_t *r);
 static void nxt_http_request_drop_framing_fields(nxt_http_request_t *r);
 static nxt_buf_t *nxt_http_request_body_drop(nxt_task_t *task,
     nxt_http_request_t *r, nxt_buf_t *out);
@@ -707,7 +706,7 @@ nxt_http_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
      * verbatim and unframed, which a downstream parser reads as the start of
      * the next response.
      */
-    r->no_body = nxt_http_request_is_bodyless(r);
+    r->no_body = nxt_http_request_is_bodyless(r, r->status);
 
     /*
      * RFC 9110 Sect. 8.6: a server must not send Content-Length in a 1xx or
@@ -817,8 +816,38 @@ nxt_http_request_ws_frame_start(nxt_task_t *task, nxt_http_request_t *r,
 }
 
 
-static nxt_bool_t
-nxt_http_request_is_bodyless(nxt_http_request_t *r)
+/*
+ * A *final* response that RFC 9112 Sect. 6.3 gives no message body: 204, 304,
+ * or any response to HEAD.  1xx is excluded on purpose.  A 1xx is an interim
+ * response -- the exchange continues with a final response after it -- so
+ * "carries no body" and "ends the exchange" are different questions for it,
+ * and a caller that needs the second one must not be answered with the first.
+ *
+ * The status is a parameter rather than a read of r->status because the proxy
+ * has to answer this question before r->status exists.  The h1 peer reader
+ * decides how to frame the upstream body while the upstream status still lives
+ * in peer->status; nxt_http_proxy_header_read() copies it into r->status only
+ * one step later.
+ */
+
+nxt_bool_t
+nxt_http_request_is_bodyless_final(nxt_http_request_t *r,
+    nxt_http_status_t status)
+{
+    if (status < NXT_HTTP_OK) {
+        return 0;
+    }
+
+    if (status == NXT_HTTP_NO_CONTENT || status == NXT_HTTP_NOT_MODIFIED) {
+        return 1;
+    }
+
+    return r->method != NULL && nxt_str_eq(r->method, "HEAD", 4);
+}
+
+
+nxt_bool_t
+nxt_http_request_is_bodyless(nxt_http_request_t *r, nxt_http_status_t status)
 {
     /*
      * A 101 upgrade is a 1xx status, but the bytes that follow its header are
@@ -832,21 +861,15 @@ nxt_http_request_is_bodyless(nxt_http_request_t *r)
      * alone would leave an application that answers a WebSocket-upgrade
      * request with 204 plus a body on the unframed path.
      */
-    if (r->websocket_handshake && r->status == NXT_HTTP_SWITCHING_PROTOCOLS) {
+    if (r->websocket_handshake && status == NXT_HTTP_SWITCHING_PROTOCOLS) {
         return 0;
     }
 
-    if (r->status >= NXT_HTTP_CONTINUE && r->status < NXT_HTTP_OK) {
+    if (status >= NXT_HTTP_CONTINUE && status < NXT_HTTP_OK) {
         return 1;
     }
 
-    if (r->status == NXT_HTTP_NO_CONTENT
-        || r->status == NXT_HTTP_NOT_MODIFIED)
-    {
-        return 1;
-    }
-
-    return r->method != NULL && nxt_str_eq(r->method, "HEAD", 4);
+    return nxt_http_request_is_bodyless_final(r, status);
 }
 
 

--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -76,6 +76,7 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 | Port | Token | Mode (CLI) | Rust handler | pytest |
 |------|-------|-----------|--------------|--------|
+| 7978 | — | — (plain-Python upstream in the test file) | `test_proxy_head.py` (bodyless upstream response: header block only, then close — not a `fake_upstream` mode, reserved here so the 79xx block stays in one registry) |
 | 7979 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_keepalive_disabled` (duplicate upstream Content-Length disables downstream keepalive for a keep-alive client; complete body keeps its terminal chunk) — out of the 7983–7999 block below, which is exhausted; 7980–7982 are `fake_otlp`, so 7974–7979 is the free gap |
 | 7983 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_raw` (zero raw `Content-Length` occurrences on the wire, complete re-framed chunked body) |
 | 7984 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl` (duplicate upstream Content-Length → neither forwarded, body re-framed, #113) |
@@ -96,7 +97,7 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 > **7999 is not available here.** `test/test_proxy.py` and `test/test_proxy_chunked.py`
 > already bind `SERVER_PORT = 7999` for their own upstream, so this registry ends at
-> 7998. New `fake_upstream` slots go to the 7974–7979 gap (7980–7982 are `fake_otlp`).
+> 7998. New `fake_upstream` slots go to the 7974–7977 gap (7978–7979 are taken above, 7980–7982 are `fake_otlp`).
 
 A test pins its port as a module constant referencing this table:
 

--- a/test/test_proxy_head.py
+++ b/test/test_proxy_head.py
@@ -1,0 +1,284 @@
+"""Proxied responses that RFC 9112 Sect. 6.3 defines as having no body.
+
+nxt_h1p_peer_header_read_done() used to arm the upstream body framing from the
+upstream headers alone: Content-Length became h1p->remainder, Transfer-Encoding
+armed the chunked parser.  A response to HEAD, and any 204 or 304 response,
+carries no body no matter what those headers say, so the upstream -- which
+nxt_h1p_peer_header_send() always asks to "Connection: close" -- closed with the
+remainder still outstanding.  nxt_h1p_peer_closed() read that as a truncated
+body and set r->truncated/r->inconsistent, and nxt_h1p_request_close() then
+dropped the client keep-alive, losing any pipelined follow-up request.
+
+Each case pipelines two requests in a single write: the bodyless one, then a
+plain GET.  The second response arriving at all is the regression assertion.
+
+1xx is out of scope here: an upstream 1xx is an interim response, and nothing
+in the peer reader continues the exchange past it (that is pre-existing, see
+nxt_h1p_peer_header_parse), so it is left on the path it already had.
+
+These cases also cover the two exits an unrelayed upstream header buffer can
+take, but they cannot assert that it is released: a stranded request pool is
+invisible from the client side, and a stock build exposes no pool counter --
+nxt_debug is never assigned, so even a --debug build emits no "mp ... release"
+lines.  That was measured instead with a throwaway build that forces nxt_debug
+on and counts pools reaching a zero retain per request; see the commit message.
+
+See freeunitorg/freeunit#283 for the downstream half of the same rule.
+"""
+
+import select
+import socket
+
+import pytest
+
+from conftest import run_process
+from unit.applications.proto import ApplicationProto
+from unit.option import option
+from unit.utils import waitforsocket
+
+client = ApplicationProto()
+
+# Reserved in test/fake_upstream/README.md's port registry; 7980-7982
+# belong to test/fake_otlp.
+UPSTREAM_PORT = 7978
+
+# What the upstream answers, keyed by the request target Unit forwards.
+# Every one of these closes the connection right after writing what is here:
+# none of them ever sends the body its own headers advertise.
+UPSTREAM_RESPONSES = {
+    '/cl10': 'HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n',
+    '/chunked': 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n',
+    '/204': 'HTTP/1.1 204 No Content\r\nContent-Length: 10\r\n\r\n',
+    '/304': 'HTTP/1.1 304 Not Modified\r\nContent-Length: 10\r\n\r\n',
+    # Header block and 10 junk bytes in a single write, so the bytes land in
+    # the same read as the header.  A response to HEAD has no body, so they
+    # must be dropped rather than relayed -- and the buffer holding them takes
+    # a different exit from nxt_h1p_peer_header_read_done() than the cases
+    # above, which is where an earlier revision of this change stranded the
+    # request pool.
+    '/cl10junk': (
+        'HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nJUNKJUNKJU'
+    ),
+    # The trailing request of every pipeline; this one does have a body.
+    '/ok': 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK',
+}
+
+
+def run_server(server_port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.bind(('127.0.0.1', server_port))
+    sock.listen(10)
+
+    def recv_request(conn):
+        data = b''
+
+        while b'\r\n\r\n' not in data:
+            if not select.select([conn], [], [], 5)[0]:
+                break
+
+            part = conn.recv(4096)
+            if not part:
+                break
+
+            data += part
+
+        return data.decode('utf-8', errors='ignore')
+
+    while True:
+        conn, _ = sock.accept()
+
+        request = recv_request(conn)
+        target = request.split(' ')[1] if ' ' in request else ''
+
+        conn.sendall(
+            UPSTREAM_RESPONSES.get(
+                target, 'HTTP/1.1 500 Internal Server Error\r\n\r\n'
+            ).encode()
+        )
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_method_fixture():
+    run_process(run_server, UPSTREAM_PORT)
+    waitforsocket(UPSTREAM_PORT)
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {"action": {"proxy": f'http://127.0.0.1:{UPSTREAM_PORT}'}}
+            ],
+        }
+    ), 'bodyless proxy configuration'
+
+
+def pipeline(method, target):
+    """Send "<method> <target>" and a GET /ok back to back, read to EOF.
+
+    Both requests leave in one write, so the second is already sitting in the
+    listener's read buffer when the first response is generated: it can only be
+    answered if the connection survives that response.
+    """
+
+    request = (
+        f'{method} {target} HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Connection: keep-alive\r\n'
+        '\r\n'
+        'GET /ok HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Connection: close\r\n'
+        '\r\n'
+    )
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.settimeout(10)
+
+    try:
+        sock.connect(('127.0.0.1', 8080))
+        sock.sendall(request.encode())
+
+        data = b''
+        while True:
+            try:
+                part = sock.recv(4096)
+            except socket.timeout:
+                break
+
+            if not part:
+                break
+
+            data += part
+
+    finally:
+        sock.close()
+
+    return data.decode('utf-8', errors='ignore')
+
+
+def check_pipeline(raw, status):
+    """Assert the exact wire shape: bodyless header, then the whole GET /ok.
+
+    Splitting on the header terminator pins both halves at once -- a body
+    leaking out of the first response, a chunked terminator appended to it, or
+    a missing second response all change the number of parts or their content.
+    """
+
+    parts = raw.split('\r\n\r\n')
+
+    assert len(parts) == 3, f'expected two responses, got {raw!r}'
+
+    first, second, body = parts
+
+    assert first.startswith(
+        f'HTTP/1.1 {status}'
+    ), f'first response status line: {first!r}'
+    assert (
+        'close' not in first.lower()
+    ), f'keep-alive dropped on a bodyless response: {first!r}'
+    assert (
+        'transfer-encoding' not in first.lower()
+    ), f'chunked framing on a bodyless response: {first!r}'
+
+    assert second.startswith(
+        'HTTP/1.1 200'
+    ), f'pipelined request lost: {second!r}'
+    assert body == 'OK', f'pipelined response body: {body!r}'
+
+    return first
+
+
+def test_proxy_head_content_length():
+    """HEAD: the upstream advertises a body and sends none, then closes."""
+
+    first = check_pipeline(pipeline('HEAD', '/cl10'), 200)
+
+    # RFC 9110 Sect. 9.3.2: a HEAD response keeps the length the equivalent
+    # GET would report.
+    assert 'Content-Length: 10' in first, f'HEAD keeps Content-Length: {first!r}'
+
+
+def test_proxy_head_chunked():
+    """HEAD: the upstream announces chunked and sends no terminating chunk."""
+
+    check_pipeline(pipeline('HEAD', '/chunked'), 200)
+
+
+def test_proxy_head_trailing_bytes():
+    """HEAD: the upstream writes the header and 10 junk bytes together.
+
+    A response to HEAD has no body, so those bytes are not one: they must not
+    reach the client and must not be counted as a body.  They also put the
+    header buffer on the branch that used to hand it to
+    nxt_h1p_peer_body_process(), whose completion released it -- so this is the
+    case where simply returning early strands the buffer and, with it, the
+    request pool.  That leak is not observable from here (see the module
+    docstring); what is checked is that the bytes are dropped and the
+    connection survives.
+    """
+
+    first = check_pipeline(pipeline('HEAD', '/cl10junk'), 200)
+
+    assert 'Content-Length: 10' in first, f'HEAD keeps Content-Length: {first!r}'
+
+
+def test_proxy_get_204():
+    """204: Content-Length is advertised, no body follows, upstream closes."""
+
+    first = check_pipeline(pipeline('GET', '/204'), 204)
+
+    # RFC 9110 Sect. 8.6 forbids Content-Length on a 204; #283 drops it.
+    assert (
+        'content-length' not in first.lower()
+    ), f'Content-Length kept on 204: {first!r}'
+
+
+def test_proxy_get_304():
+    """304: Content-Length describes the cached body and is kept."""
+
+    first = check_pipeline(pipeline('GET', '/304'), 304)
+
+    assert 'Content-Length: 10' in first, f'304 keeps Content-Length: {first!r}'
+
+
+def test_proxy_head_response_header_variable(wait_for_record):
+    """The relayed header bytes stay readable after the response completes.
+
+    peer->fields point their name/value into the buffer the upstream header was
+    parsed from, and nxt_http_proxy_header_read() shallow-copies those field
+    structs into r->resp; $response_header_* reads them at access-log time.
+    This exercises that path on the early-complete branch, where the peer
+    connection is already closed by the time the record is written.
+
+    It is coverage, not a use-after-free detector: returning that buffer to the
+    engine cache early leaves the pointers dangling but does not reliably
+    corrupt them, so this passes either way.  The buffer must simply not be
+    freed there -- which is also what the normal path does.
+    """
+
+    assert 'success' in client.conf(
+        {
+            'path': f'{option.temp_dir}/access.log',
+            'format': '$request_line "$response_header_content_length"\n',
+        },
+        'access_log',
+    ), 'access_log format'
+
+    check_pipeline(pipeline('HEAD', '/cl10'), 200)
+
+    assert (
+        wait_for_record(r'HEAD /cl10 HTTP/1.1 "10"', 'access.log') is not None
+    ), 'Content-Length readable from the access log after the response'
+
+
+def test_proxy_get_body_still_relayed():
+    """Control: a status that does define a body still gets one."""
+
+    raw = pipeline('GET', '/ok')
+
+    assert raw.count('HTTP/1.1 200') == 2, f'expected two responses: {raw!r}'
+    assert raw.count('\r\n\r\nOK') == 2, f'both bodies relayed: {raw!r}'


### PR DESCRIPTION
Follow-up to #283, which fixed the downstream half of the same rule. This is the
upstream half, for a pre-existing proxy bug.

## The bug

`nxt_h1p_peer_header_read_done()` (`src/nxt_h1proto.c:2854`) armed the upstream
body framing from the upstream headers alone: a `Content-Length` became
`h1p->remainder`, a `Transfer-Encoding: chunked` armed `h1p->chunked_parse`.
Neither the request method nor the response status was consulted.

RFC 9112 Sect. 6.3 rule 1 says those headers do not frame anything here: a
response to HEAD, and any 204 or 304 response, ends at the first empty line
after the header fields whatever `Content-Length` or `Transfer-Encoding` say. So
the upstream sends the header block and nothing more -- and, because
`nxt_h1p_peer_header_send()` writes an unconditional `Connection: close` to every
upstream (`src/nxt_h1proto.c:2541`), it then closes.

`nxt_h1p_peer_closed()` (`src/nxt_h1proto.c:3172`) reads that close as a cut
body: `h1p->remainder` is still the advertised length, or `chunked_parse.last` is
still clear, so it sets `r->truncated` and `r->inconsistent`.
`nxt_h1p_request_close()` (`src/nxt_h1proto.c:1929`) then does
`h1p->keepalive &= !r->inconsistent`, and the client connection is torn down
after a response that was never short. Any request the client had already
pipelined into the same socket is lost -- and a proxied HEAD is the ordinary
case here, not a corner one.

Worth noting on the wire: the first response carries no `Connection: close`,
because `keepalive` is cleared in `nxt_h1p_request_close()` after the header is
already sent. The client gets no signal that its pipelined request will never be
answered.

## The fix

Decide it where the framing is chosen. #283 put the same rule in
`nxt_http_request_header_send()` for the response Unit sends downstream; this
shares that helper's status list rather than restating it. Its final-response
half is split out into `nxt_http_request_is_bodyless_final()`, which is not
static and takes the status as a parameter, because the peer reader has to ask
the question while the upstream status still lives in `peer->status`, one step
before `nxt_http_proxy_header_read()` (`src/nxt_http_proxy.c:256`) copies it
into `r->status`. `nxt_http_request_is_bodyless()` itself stays `static` and
keeps reading `r->status`.

For a bodyless upstream response the peer reader now neither arms the chunked
parser nor sets a remainder, and completes the response right there the way
`nxt_h1p_peer_body_process()` completes a body that reached its declared length:
`peer->body = nxt_http_buf_last(r)`, `peer->closed = 1`, then the ready handler.
`nxt_http_proxy_send_body()` relays that last buffer, closes the upstream
connection and releases the request pool.

## The upstream read buffer, and a pre-existing pool leak

The header buffer is not forwarded -- bytes an upstream put after the header of
a bodyless response are not a body -- and it cannot simply be freed or dropped
either. Both are bugs, in opposite directions:

- **Freeing it dangles the response fields.** `peer->fields` point their
  name/value into that buffer (`nxt_http_parse_fields`,
  `src/nxt_http_parse.c:813`) and `nxt_http_proxy_header_read()` shallow-copies
  those field structs into `r->resp`, where `$response_header_*` and `match`
  conditions read them until the request is logged and closed.
- **Dropping it strands the request pool.** `nxt_http_proxy_buf_mem_alloc()`
  retains `r->mem_pool` for every upstream read buffer, and that retain is
  released by a buffer completion -- which a buffer that is never relayed never
  gets.

`nxt_http_proxy_buf_mem_hold()` does both at once: an `nxt_mp_cleanup()` returns
the buffer to the engine when the pool is destroyed, so the field bytes stay
valid for exactly as long as anything can read them, and the alloc-time retain
is dropped so the pool can reach zero at all.

**That drop path is not new here**, which is why `hold()` is called from two
places. `nxt_h1p_peer_header_read_done()` has always dropped the buffer when the
header read carried no body bytes with it -- every 204 and 304, every response
to HEAD, and *any* upstream that writes its header and body in separate
segments. Measured with a throwaway build that forces `nxt_debug` on and counts
pools reaching a zero retain, over 200 proxied requests each:

    upstream shape                     master   this PR

    204, header block only              400        600
    HEAD, header block only             400        600
    HEAD, header + 10 trailing bytes    600        600
    200, header + body in one read      600        600

Three pools reach zero per request when nothing is stranded; 400 is two, the
missing one being the request pool. Both columns now read 600 throughout.

## Client-side framing

Unchanged and still correct. A HEAD response keeps the upstream's
`Content-Length` (RFC 9110 Sect. 9.3.2) because #283 only drops the framing
fields for 1xx and 204; a 304 keeps it too. Nothing follows the header block,
and rule 1 lets the client end the message there, so keep-alive is safe without
a `Content-Length` -- which is what a HEAD of a chunked upstream resource
produces, since the hop-by-hop `Transfer-Encoding` is not relayed.

The duplicate-framing guard is untouched: an upstream that sends both chunked
and `Content-Length` is still a 502, and it is still checked before this.

## Upstream 1xx is pre-existing and out of scope

The peer reader uses a narrower predicate, `nxt_http_request_is_bodyless_final()`:
HEAD, 204 and 304, but **not** 1xx. "Carries no body" and "ends the exchange" are
the same question downstream and different questions here, because a 1xx is an
interim response.

There is no upstream 1xx handling to build on: `nxt_h1p_peer_header_parse()`
(`src/nxt_h1proto.c:2941`) reads a status line only while `peer->status` is still
`NXT_HTTP_UNSET`, so a 1xx is already taken as *the* response and whatever
follows it is relayed as its body. That behaviour predates this PR and is left
exactly as it is. Ending the exchange on a 1xx header here would have been worse
than the status quo: it would discard a final response that may already be
sitting in the same read buffer. The 101 upgrade path is untouched either way --
`is_bodyless_final()` returns 0 for any status below 200.

## Review

**Round 1 (local Codex).** An earlier revision ended the exchange on 1xx and
freed the upstream header buffer. Both were flagged, plus a test port collision;
all three were verified against the code and folded:

- **1xx** -- confirmed there is no continue-after-1xx logic on master before
  changing anything (`peer->status` is initialised to `NXT_HTTP_UNSET` once at
  `src/nxt_h1proto.c:2358` and the parser never re-arms), so no such logic was
  invented here; the branch was narrowed to HEAD/204/304 instead.
- **Header buffer lifetime** -- confirmed `field->name`/`field->value` are set
  from the parse buffer at `src/nxt_http_parse.c:813-814` and that the free
  preceded both the field copy into `r->resp` and the downstream header
  serialization, i.e. a use-after-free by construction. Replacing the free with
  `nxt_http_proxy_buf_mem_hold()` is what surfaced the pre-existing pool leak on
  the ordinary path, since the two need the same treatment. For honesty about
  the UAF's severity: it is latent, not deterministic. With the free restored,
  4800 concurrent proxied HEADs logging `$response_header_content_length`
  produced zero corrupt records, and ASan cannot see it because the buffer
  returns to the engine's own cache rather than to `free()`.
- **Test port** -- 7982 is reserved for `grpc_sampling_zero` in
  `test/fake_otlp/README.md`; the test moved to 7978 and is registered in
  `test/fake_upstream/README.md`, the registry for the 79xx block.

**Round 2 (@claude).** Landed as a follow-up PR, since this merged first -- four
mechanical changes, no behaviour change:
`nxt_http_request_is_bodyless()` stays `static` and loses its `status` parameter
(only `_final()` needs external linkage); `nxt_mp_cleanup()` is given `&r->task`
rather than the peer connection's task, which is freed with that connection long
before the pool cleanup runs; the port-registry row was short a cell; this
description was rewritten to match `hold()`.

That review also asked for `peer->closed = 1` to move after the header is
relayed, on the grounds that `nxt_http_proxy_error()`'s `if (!peer->closed)`
guard would otherwise skip `peer_close()` and the `nxt_mp_release()` on an
allocation failure in `nxt_http_proxy_header_read()`. The leak is real but it is
**not a regression**, and the change is not safe as described:

- `r->state` is still `header_read_state` when `nxt_h1p_peer_header_read_done()`
  calls `nxt_h1p_peer_body_process()`, so on plain master a response whose header
  and whole body arrive in one read already sets `peer->closed = 1`
  (`src/nxt_h1proto.c:3094`) and *then* enters `nxt_http_proxy_header_read()`.
  The OOM-only leak exists there today; this PR adds a fourth caller to an
  existing pattern rather than breaking an invariant.
- Moving the assignment after `ready_handler` would not work: the chain
  (`header_read` -> `nxt_http_request_header_send` -> `nxt_http_proxy_send_body`)
  is synchronous, and `send_body` would then take its `!peer->closed` branch and
  re-arm a read on an upstream that has already closed -- reintroducing exactly
  the truncation this PR fixes.

Left for a separate change that touches only `nxt_http_proxy_error()`.

## Test

`test/test_proxy_head.py` pipelines two requests in a single write -- the
bodyless one and a plain GET -- against a raw upstream that answers with the
header block alone and closes. The second response arriving is the regression
assertion. Cases: HEAD with `Content-Length: 10`; HEAD with
`Transfer-Encoding: chunked`; GET to 204 with `Content-Length`; GET to 304 with
`Content-Length`; plus a body-still-relayed control.

Negative control against the parent commit: every bodyless case fails on the
keep-alive assertion, with only the first response on the wire; the control
still passes.

One case has the upstream write its header and 10 junk bytes in a single send,
so the bytes land in the same read as the header -- the exit where the buffer
used to reach `nxt_h1p_peer_body_process()`. Another reads the relayed
`Content-Length` back through `$response_header_content_length` in the access
log, covering the field pointers on this new path. It is coverage rather than a
use-after-free detector, and is labelled as such.

Nothing asserts on the pool, on either `hold()` path: a stranded request pool is
invisible from the client side and a stock build exposes no counter for it,
hence the throwaway instrumented build above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yvdUQNuqtejYkcdnFQ5db
