### PR TITLE
test(python): make the prototype-kill test skip outside its window

### DIFF
--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -486,18 +486,15 @@ nxt_router_start_app_process_handler(nxt_task_t *task, nxt_port_t *port,
      * REMOVE_PID the router gets for the prototype carries no stream (it
      * had already reached READY itself, see nxt_main_process.c) and
      * nxt_port_rpc_remove_peer() finds nothing to fail, so the attempt's
-     * pending_processes slot is never given back.  With spare 0 that alone
-     * exceeds max_pending_processes, nxt_router_app_can_start() stays false
-     * for good, and no later request can even ask for a new prototype --
-     * only the start handler does that, and it is what can_start gates.
+     * pending_processes slot is never given back.
      *
-     * With the peer set, nxt_port_rpc_remove_peer() runs
-     * nxt_router_app_port_error() exactly once (it clears ->peer, deletes
-     * the stream and frees the registration), which releases the slot and
-     * fails the ack-waiting requests when no process is left.  For a
-     * prototype start the peer is the main process, which is harmless: its
-     * death is fatal anyway, and a prototype dying before READY is already
-     * reported by the stream-bearing REMOVE_PID.
+     * For a prototype start the peer is the main process, which is
+     * harmless: its death is fatal anyway, and a prototype dying before
+     * READY is already reported by the stream-bearing REMOVE_PID.
+     *
+     * The setter cannot report a failed insert: it logs and leaves ->peer
+     * at -1 (src/nxt_port_rpc.c:301), so a pool allocation failure here
+     * restores the peerless registration -- as at every other call site.
      */
     nxt_port_rpc_ex_set_peer(task, port, app_joint_rpc, dport->pid);
 

--- a/test/test_python_application.py
+++ b/test/test_python_application.py
@@ -1114,8 +1114,11 @@ def test_python_prototype_killed_mid_start(skip_alert, findall):
 
     The app module sleeps in its *import* (test/python/slow_start/wsgi.py),
     which is what widens the PROCESS_CREATED -> READY window enough to aim
-    at.  A kill that lands outside the window makes the test skip rather
-    than assert something it did not drive.
+    at.  Landing inside that window is a precondition, not an assertion:
+    the worker has to be discovered well before the window closes, and
+    /status has to still count the start as pending right before the kill.
+    A runner loaded enough to miss either skips rather than reporting a
+    failure the test did not drive.
     """
 
     client.load(
@@ -1156,22 +1159,41 @@ def test_python_prototype_killed_mid_start(skip_alert, findall):
 
         # Wait for the worker to exist: killing the prototype before it has
         # forked would carry the original start stream and let an unfixed
-        # router pass this test by the other route.  Then a short pause puts
-        # the worker mid-import: past PROCESS_CREATED, well before READY.
+        # router pass this test by the other route.  Bounded at 2s, inside
+        # the 4s import window: exhausting it means the fork stalled past
+        # the window, which leaves nothing for the kill to aim at.  Then a
+        # short pause puts the worker mid-import: past PROCESS_CREATED and
+        # before READY.
         workers = []
-        for _ in range(100):
+        for _ in range(40):
             workers = _child_pids(pid)
             if workers:
                 break
             time.sleep(0.05)
 
-        assert workers, 'the prototype never forked a worker'
+        if not workers:
+            pytest.skip('the prototype forked no worker within the window')
 
         time.sleep(0.3)
 
-        # The worker is still importing the module.  Its own teardown noise
-        # is scoped to its pid below rather than skipped by shape, so an
-        # alert from any other process still fails the test.
+        # The worker must still be importing for the kill to land where this
+        # test aims it.  "starting" is app->pending_processes, which the
+        # router gives back only once the worker's port arrives ready, so
+        # anything but the one pending start means the window has closed --
+        # the request would then be served with 200 and the assertions below
+        # would report the wrong thing.
+        starting = client.conf_get('/status')['applications']['slow_start'][
+            'processes'
+        ]['starting']
+
+        if starting != 1:
+            pytest.skip(
+                f'the start left the import window: starting == {starting}'
+            )
+
+        # Its own teardown noise is scoped to the worker's pid below rather
+        # than skipped by shape, so an alert from any other process still
+        # fails the test.
 
         subprocess.call(['kill', '-9', pid])
         skip_alert(fr'process {pid} exited on signal 9')
@@ -1183,8 +1205,11 @@ def test_python_prototype_killed_mid_start(skip_alert, findall):
             # prototype -- which the kill already closed.  All of that is
             # the pre-existing consequence of killing a prototype, not
             # something this test's subject produces; it happens on the
-            # unfixed router too.
-            skip_alert(fr'\b{worker}#{worker} ')
+            # unfixed router too.  Both log prefixes are pid#tid
+            # (src/nxt_unit.c:7319, src/nxt_app_log.c:63), and the two are
+            # equal only for a main thread on Linux -- scope by the pid,
+            # which is the point of this skip, and let the tid be.
+            skip_alert(fr'\b{worker}#\d+ ')
 
         # The kill retires the start RPC, which releases the slot and -- no
         # process being left -- fails the waiting request instead of letting


### PR DESCRIPTION
Follow-up to the review on #288 (https://github.com/freeunitorg/freeunit/pull/288#issuecomment-5587987275), which merged before the fixes landed.

Accepted:

- The docstring of `test_python_prototype_killed_mid_start()` promised a skip that did not exist; a runner slow enough to let the worker reach READY failed at `assert resp == [503]` and pointed at the fix, not the runner. There is now a real guard: `/status` must still report one pending start immediately before the kill (`starting` is `app->pending_processes`, given back only at worker-port-ready), else `pytest.skip`. The discovery loop is bounded at 2 s, inside the 4 s import window rather than the 5 s it allowed, and its timeout skips too. The docstring matches the test.
- `skip_alert(r'\b{worker}#{worker} ')` read the pid#tid log prefix as if the fields were equal, true only for a main thread on Linux. Both `src/nxt_unit.c` and `src/nxt_app_log.c` emit that shape. Now `\b{pid}#\d+ `.
- `set_peer` cannot report a failed insert (leaves `->peer` at -1), which restores the peerless registration #288 removed: noted in the comment. Pre-existing, shared with every call site; signature unchanged. The comment also loses the two paragraphs that restated the commit message.

Rejected: the CHANGES nit. Entries are written at release time in this repo.

Verified: `build/tests` exit 0 (42 subtests); the python test passes 3/3 on pro4s-2, skips when the guard is forced false, and fails when the alert pattern is broken, so neither check is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fep6NC1SeCwVcvYrWt7k2f
