### PR TITLE
http: review follow-ups to the bodyless upstream response

### DIFF
--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -431,8 +431,6 @@ void nxt_http_request_ws_frame_start(nxt_task_t *task, nxt_http_request_t *r,
     nxt_buf_t *ws_frame);
 void nxt_http_request_send(nxt_task_t *task, nxt_http_request_t *r,
     nxt_buf_t *out);
-nxt_bool_t nxt_http_request_is_bodyless(nxt_http_request_t *r,
-    nxt_http_status_t status);
 nxt_bool_t nxt_http_request_is_bodyless_final(nxt_http_request_t *r,
     nxt_http_status_t status);
 nxt_buf_t *nxt_http_buf_mem(nxt_task_t *task, nxt_http_request_t *r,

--- a/src/nxt_http_proxy.c
+++ b/src/nxt_http_proxy.c
@@ -384,9 +384,9 @@ nxt_http_proxy_buf_mem_cleanup(nxt_task_t *task, void *obj, void *data)
     engine = data;
 
     /*
-     * Runs from nxt_mp_destroy(), which may be reached from a different task
-     * than the one current when the buffer was held, so "task" is not touched
-     * and the engine is carried in "data" instead.
+     * The engine is carried in "data": nxt_mp_destroy() has none to hand.
+     * "task" is passed only so the pointer nxt_mp_cleanup() stores stays
+     * inside the pool being destroyed -- do not dereference it here.
      */
 
     nxt_event_engine_buf_mem_free(engine, b);
@@ -426,8 +426,16 @@ nxt_http_proxy_buf_mem_hold(nxt_task_t *task, nxt_http_request_t *r,
 {
     nxt_int_t  ret;
 
-    ret = nxt_mp_cleanup(r->mem_pool, nxt_http_proxy_buf_mem_cleanup, task, b,
-                         task->thread->engine);
+    /*
+     * &r->task, not "task": nxt_mp_cleanup() stores the task pointer in the
+     * work item and hands it back at destroy time, and the peer connection's
+     * task is freed with that connection well before the request pool.
+     * &r->task lives in the pool being destroyed, which nxt_mp_destroy() runs
+     * its cleanups before freeing.
+     */
+
+    ret = nxt_mp_cleanup(r->mem_pool, nxt_http_proxy_buf_mem_cleanup, &r->task,
+                         b, task->thread->engine);
     if (nxt_slow_path(ret != NXT_OK)) {
         return NXT_ERROR;
     }

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -22,6 +22,7 @@ static void nxt_http_request_forward_protocol(nxt_http_request_t *r,
 static void nxt_http_request_ready(nxt_task_t *task, void *obj, void *data);
 static void nxt_http_request_proto_info(nxt_task_t *task,
     nxt_http_request_t *r);
+static nxt_bool_t nxt_http_request_is_bodyless(nxt_http_request_t *r);
 static void nxt_http_request_drop_framing_fields(nxt_http_request_t *r);
 static nxt_buf_t *nxt_http_request_body_drop(nxt_task_t *task,
     nxt_http_request_t *r, nxt_buf_t *out);
@@ -706,7 +707,7 @@ nxt_http_request_header_send(nxt_task_t *task, nxt_http_request_t *r,
      * verbatim and unframed, which a downstream parser reads as the start of
      * the next response.
      */
-    r->no_body = nxt_http_request_is_bodyless(r, r->status);
+    r->no_body = nxt_http_request_is_bodyless(r);
 
     /*
      * RFC 9110 Sect. 8.6: a server must not send Content-Length in a 1xx or
@@ -846,8 +847,8 @@ nxt_http_request_is_bodyless_final(nxt_http_request_t *r,
 }
 
 
-nxt_bool_t
-nxt_http_request_is_bodyless(nxt_http_request_t *r, nxt_http_status_t status)
+static nxt_bool_t
+nxt_http_request_is_bodyless(nxt_http_request_t *r)
 {
     /*
      * A 101 upgrade is a 1xx status, but the bytes that follow its header are
@@ -861,15 +862,15 @@ nxt_http_request_is_bodyless(nxt_http_request_t *r, nxt_http_status_t status)
      * alone would leave an application that answers a WebSocket-upgrade
      * request with 204 plus a body on the unframed path.
      */
-    if (r->websocket_handshake && status == NXT_HTTP_SWITCHING_PROTOCOLS) {
+    if (r->websocket_handshake && r->status == NXT_HTTP_SWITCHING_PROTOCOLS) {
         return 0;
     }
 
-    if (status >= NXT_HTTP_CONTINUE && status < NXT_HTTP_OK) {
+    if (r->status >= NXT_HTTP_CONTINUE && r->status < NXT_HTTP_OK) {
         return 1;
     }
 
-    return nxt_http_request_is_bodyless_final(r, status);
+    return nxt_http_request_is_bodyless_final(r, r->status);
 }
 
 

--- a/test/fake_upstream/README.md
+++ b/test/fake_upstream/README.md
@@ -76,7 +76,7 @@ single `grep` finds every side of a case. E.g. token `chunked_response`:
 
 | Port | Token | Mode (CLI) | Rust handler | pytest |
 |------|-------|-----------|--------------|--------|
-| 7978 | — | — (plain-Python upstream in the test file) | `test_proxy_head.py` (bodyless upstream response: header block only, then close — not a `fake_upstream` mode, reserved here so the 79xx block stays in one registry) |
+| 7978 | — | — (plain-Python upstream in the test file) | — | `test_proxy_head.py` (bodyless upstream response: header block, with or without trailing bytes, then close — not a `fake_upstream` mode, reserved here so the 79xx block stays in one registry) |
 | 7979 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_keepalive_disabled` (duplicate upstream Content-Length disables downstream keepalive for a keep-alive client; complete body keeps its terminal chunk) — out of the 7983–7999 block below, which is exhausted; 7980–7982 are `fake_otlp`, so 7974–7979 is the free gap |
 | 7983 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl_raw` (zero raw `Content-Length` occurrences on the wire, complete re-framed chunked body) |
 | 7984 | `dup_cl` | `dup-cl` | `respond_dup_cl` | `test_proxy_dup_cl` (duplicate upstream Content-Length → neither forwarded, body re-framed, #113) |

--- a/test/test_proxy_head.py
+++ b/test/test_proxy_head.py
@@ -16,12 +16,18 @@ plain GET.  The second response arriving at all is the regression assertion.
 in the peer reader continues the exchange past it (that is pre-existing, see
 nxt_h1p_peer_header_parse), so it is left on the path it already had.
 
-These cases also cover the two exits an unrelayed upstream header buffer can
-take, but they cannot assert that it is released: a stranded request pool is
-invisible from the client side, and a stock build exposes no pool counter --
-nxt_debug is never assigned, so even a --debug build emits no "mp ... release"
-lines.  That was measured instead with a throwaway build that forces nxt_debug
-on and counts pools reaching a zero retain per request; see the commit message.
+These cases also drive both shapes the header read can take -- with and
+without body bytes alongside the header -- but they cannot assert that the
+unrelayed header buffer is released: a stranded request pool is invisible from
+the client side, and a stock build exposes no pool counter -- nxt_debug is
+never assigned, so even a --debug build emits no "mp ... release" lines.  That
+was measured instead with a throwaway build that forces nxt_debug on and counts
+pools reaching a zero retain per request; see the commit message.
+
+The same hold covers a third path nothing here reaches: an ordinary proxied
+response whose body arrives in a read after the header, which stranded the pool
+on master as well.  It is unobservable from the client for the same reason, and
+is covered by that measurement rather than by an assertion.
 
 See freeunitorg/freeunit#283 for the downstream half of the same rule.
 """
@@ -52,10 +58,10 @@ UPSTREAM_RESPONSES = {
     '/304': 'HTTP/1.1 304 Not Modified\r\nContent-Length: 10\r\n\r\n',
     # Header block and 10 junk bytes in a single write, so the bytes land in
     # the same read as the header.  A response to HEAD has no body, so they
-    # must be dropped rather than relayed -- and the buffer holding them takes
-    # a different exit from nxt_h1p_peer_header_read_done() than the cases
-    # above, which is where an earlier revision of this change stranded the
-    # request pool.
+    # must be dropped rather than relayed -- and the buffer holding them
+    # reaches the bodyless branch of nxt_h1p_peer_header_read_done() with
+    # bytes still in it, unlike the cases above, which is where an earlier
+    # revision of this change stranded the request pool.
     '/cl10junk': (
         'HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nJUNKJUNKJU'
     ),


### PR DESCRIPTION
Review follow-ups to #295, which merged before they landed. All mechanical --
no behaviour change, `test_proxy_head.py` still 7/7.

- **`nxt_http_request_is_bodyless()` is `static` again** and takes no `status`
  parameter. It has one caller, in its own translation unit, and only ever asks
  about `r->status`. Only `nxt_http_request_is_bodyless_final()` -- which the h1
  peer reader calls with `peer->status`, before `r->status` exists -- needs
  external linkage, so `nxt_http.h` declares just that one.

- **`nxt_http_proxy_buf_mem_hold()` registers its pool cleanup with `&r->task`.**
  `nxt_mp_cleanup()` stores the task pointer in the work item
  (`src/nxt_mp.c:1081`) and hands it back when `nxt_mp_destroy()` runs the
  cleanup. The task passed there belonged to the upstream connection, which is
  destroyed well before the request pool -- a dangling pointer that stayed
  harmless only because the handler ignores it. `&r->task` lives in the pool
  being destroyed, and `nxt_mp_destroy()` runs its cleanups before freeing any
  block, so it is valid for exactly as long as the handler can run. The comment
  apologising for the old pointer shrinks to one line.

- **Port-registry row.** The 7978 row was a cell short of the table's five
  columns, so `test_proxy_head.py` rendered under **Rust handler**.

- **Test docstring.** It named two of the three exits an unrelayed upstream
  header buffer can take; the third -- an ordinary proxied response whose body
  arrives in a read after the header, which stranded the request pool on master
  too -- is now named there with the same caveat that it is not observable from
  the client.

The one code change that review asked for before merge is deliberately not
here: see the reply on #295. Its premise (that `peer->closed` is only ever set
after the header is relayed) does not hold on master, and the remedy it
proposes would re-arm a read on a closed upstream and undo #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4FnpWQ2ntR4eb6GYUeMUr
