### PR TITLE
test(router): assert the listener close precedes the acknowledgement

### DIFF
--- a/.github/sanitizer-allowlist.txt
+++ b/.github/sanitizer-allowlist.txt
@@ -30,3 +30,10 @@ src/nxt_http_route\.c:[0-9]+:[0-9]+: runtime error: null pointer passed as argum
 
 # freeunitorg/freeunit#200 -- same class in nxt_cpymem(): memcpy(dst, NULL, 0).
 src/nxt_string\.h:[0-9]+:[0-9]+: runtime error: null pointer passed as argument 2, which is declared to never be null
+
+# freeunitorg/freeunit#200 -- same class in nxt_is_tstr(): memchr(NULL, c, 0)
+# on a zero-length nxt_str_t, twice, one per character it looks for.  Reached
+# from the configuration validator.  Measured with the python leg's test set:
+# only test_configuration.py sends a configuration that gets there, so the
+# entry arrived with that file.
+src/nxt_tstr\.h:[0-9]+:[0-9]+: runtime error: null pointer passed as argument 1, which is declared to never be null

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -131,6 +131,14 @@ jobs:
             # hard ASan failure here instead of an intermittent "[alert]" line
             # in one runtime's log.  It self-skips every runtime that is not
             # built into this leg's unitd.
+            #
+            # test_configuration drives the control API only and is here for
+            # test_listeners_close_before_reply: it reads the router's
+            # nxt_debug() records to assert that a removed listener's
+            # descriptor is closed before the removal is acknowledged
+            # (#276), and skips on any build without --debug.  Every
+            # build-test leg is a release build, so this leg is the only one
+            # in which that test runs rather than skips.
             tests: >-
               test/test_graceful_reload.py
               test/test_listener_drain.py
@@ -140,6 +148,7 @@ jobs:
               test/test_chunked.py
               test/test_conn_recycle.py
               test/test_app_lifecycle.py
+              test/test_configuration.py
           - runtime: php
             apt: ""
             configure: php

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4153,7 +4153,8 @@ nxt_router_worker_thread_exit(nxt_task_t *task)
  * pattern in nxt_router_worker_thread_quit()).
  */
 
-static void nxt_router_listen_socket_close_ready(nxt_socket_conf_joint_t *joint);
+static void nxt_router_listen_socket_close_ready(nxt_task_t *task,
+    nxt_socket_conf_joint_t *joint);
 static void nxt_router_listen_socket_close_finish(nxt_task_t *task,
     nxt_listen_event_t *lev);
 
@@ -4226,7 +4227,7 @@ nxt_router_listen_socket_close(nxt_task_t *task, void *obj, void *data)
         nxt_debug(task, "engine %p: listen socket %d drain pending, "
                   "in-flight: %D", engine, lev->socket.fd, lev->count - 1);
 
-        nxt_router_listen_socket_close_ready(joint);
+        nxt_router_listen_socket_close_ready(task, joint);
 
         return;
     }
@@ -4236,7 +4237,8 @@ nxt_router_listen_socket_close(nxt_task_t *task, void *obj, void *data)
 
 
 static void
-nxt_router_listen_socket_close_ready(nxt_socket_conf_joint_t *joint)
+nxt_router_listen_socket_close_ready(nxt_task_t *task,
+    nxt_socket_conf_joint_t *joint)
 {
     nxt_joint_job_t  *job;
 
@@ -4246,6 +4248,21 @@ nxt_router_listen_socket_close_ready(nxt_socket_conf_joint_t *joint)
     }
 
     joint->close_job = NULL;
+
+    /*
+     * The only record of the acknowledgement on the thread that issues
+     * it.  The configuration thread's "temp conf ... count" line is
+     * written after a cross-thread post, so where it lands in the log is
+     * a function of that thread's wake-up latency, not of where in the
+     * close path the acknowledgement was issued -- it stays in the same
+     * place whether this call is made before the descriptor is released
+     * or after it.  This line does not: it is written by the closing
+     * engine itself, between its own records, so the order of the close
+     * and the acknowledgement is readable from the log.
+     * test_listeners_close_before_reply asserts exactly that.
+     */
+    nxt_debug(task, "engine %p: listen socket close acknowledged",
+              task->thread->engine);
 
     nxt_router_conf_wait_post(job);
 }
@@ -4290,7 +4307,7 @@ nxt_router_listen_socket_close_finish(nxt_task_t *task,
      * nxt_router_listen_socket_release() frees the nxt_listen_socket_t,
      * not the socket configuration the joint points at.
      */
-    nxt_router_listen_socket_close_ready(joint);
+    nxt_router_listen_socket_close_ready(task, joint);
 
     nxt_router_listen_event_release(task, lev, joint);
 }

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,9 +1,11 @@
+import re
 import socket
 import time
 
 import pytest
 
 from unit.control import Control
+from unit.log import Log
 
 prerequisites = {'modules': {'python': 'any'}}
 
@@ -370,6 +372,90 @@ def test_listeners_port_release():
                     time.sleep(0.01)
 
             assert 'success' in resp, 'port release'
+
+
+def test_listeners_close_before_reply(findall):
+    assert 'success' in client.conf(
+        {
+            "listeners": {"127.0.0.1:8080": {"pass": "routes"}},
+            "routes": [],
+        }
+    ), 'listener added'
+
+    # The markers below are all nxt_debug(), so a release build cannot
+    # observe this at all.  There is no build flag in option.available,
+    # so ask the log: skipping is the only honest outcome here, passing
+    # would be a test that cannot fail.
+    if not findall(r'\[debug\]'):
+        pytest.skip('needs a build configured with --debug')
+
+    # Remember where the log ends before the removal.  The tail already
+    # holds a "controller conn write" for the request above, and the
+    # ordering is read off positions in a single read of what follows:
+    # two independent waits could each succeed with the order between
+    # them wrong.
+    pos = len(Log.read())
+
+    assert 'success' in client.conf(
+        {"listeners": {}, "applications": {}}
+    ), 'listener removed'
+
+    # The reply is the barrier that makes the tail complete rather than
+    # something the assertions below compare against: it is written only
+    # after every engine has acknowledged, and every engine writes its
+    # own records before it acknowledges.
+    deadline = time.monotonic() + 15
+
+    while True:
+        tail = Log.read()[pos:]
+
+        if 'controller conn write complete' in tail:
+            break
+
+        if time.monotonic() >= deadline:
+            pytest.fail('the controller did not reply')
+
+        time.sleep(0.01)
+
+    # One record per engine, so with listen_threads > 1 there are
+    # several of each.  Comparing the last of one with the last of the
+    # other is what makes the assertion independent of how the engines
+    # interleave: an engine acknowledges after it has finished closing,
+    # so the latest acknowledgement is later than every close; an engine
+    # that acknowledged first would put the latest close after every
+    # acknowledgement instead.
+    finish = list(
+        re.finditer(
+            r'\[debug\] (\d+)#\d+ .*listen socket close finish: (\d+)',
+            tail,
+        )
+    )
+    ack = list(re.finditer(r'listen socket close acknowledged', tail))
+
+    assert finish, 'listener closed'
+    assert ack, 'removal acknowledged'
+
+    assert finish[-1].start() < ack[-1].start(), 'phase 2 before ack'
+
+    # The one that has to hold: "close finish" is written on entry to
+    # nxt_router_listen_socket_close_finish(), before the descriptor is
+    # released, so the check above cannot see an acknowledgement moved
+    # back above nxt_router_listen_socket_release() inside that function
+    # -- the position #276 moved it out of.  The close(2) of the
+    # descriptor is written by the same engine that then acknowledges,
+    # so anchoring on it covers both positions.
+    #
+    # Match the router's pid: the controller writes "socket close(N)"
+    # for its own connection after every reply, and fd numbers collide
+    # across processes.
+    pid, fd = finish[-1].group(1), finish[-1].group(2)
+    closed = re.search(
+        rf'\[debug\] {pid}#\d+ (\*\d+ )?socket close\({fd}\)', tail
+    )
+
+    assert closed is not None, 'descriptor closed'
+
+    assert closed.start() < ack[-1].start(), 'closed before ack'
 
 
 def test_json_application_name_large():


### PR DESCRIPTION
Closes #297.

#276 made the router close the listening descriptor before the controller
acknowledges a configuration that removed the listener. #293 replaced the strict
bind in `test_listeners_port_release` with a retry, which guards a *leaked*
descriptor — but, as that PR says itself, a retrying test could never have caught
#276's regression class. Nothing guarded the ordering. This does.

## Scope: this touches the router, and #297 said "test-only"

The acknowledgement had **no record written by the thread that issues it**, and
ordering can only be asserted between two records from the same thread. Rejected
alternatives: `temp conf %p count` (`nxt_router.c:1419`) is written by the config
thread after a cross-thread post, so its position measures that thread's wake-up
latency; all controller records are in another process; `event engine post`
(`nxt_event_engine.c:253`) carries no payload identifying what is posted and
would need fragile tid matching; `src/test/` cannot host this, as the property
needs the full router runtime.

So one `nxt_debug()` is added inside `nxt_router_listen_socket_close_ready()`,
which required threading `task` through the prototype and two call sites. It is
compiled out entirely without `--debug` (`nxt_log.h:129`).

## Why the assertion is anchored on close(2), not on "close finish"

An earlier revision compared the `listen socket close finish` record against the
acknowledgement. That record is written at the *entry* of
`nxt_router_listen_socket_close_finish()`, before
`nxt_router_listen_socket_release()`, so it detects only an acknowledgement
issued before the function is entered — the pre-#276 position. It is **green**
when the acknowledgement is moved back above the release *inside* that function,
which is the position #276's own comment describes.

The assertion therefore anchors on the descriptor release itself: the last engine
writes `socket close(fd)` and then its own acknowledgement, in that order, on one
thread. The match is pid-anchored because the controller also writes
`socket close(N)` after every reply and fd numbers collide across processes.

Ordering is program order ⇒ file order: each record is a single `write(2)` from a
stack buffer to stderr, `dup2`'d onto a log opened `O_APPEND`, with the offset
assigned under the inode lock. No buffering, no `writev`, no interleaving;
failures lose records rather than reorder them, and a lost record trips an assert.

`finish[-1] < ack[-1]` is kept as a cheap independent check. The comparison
against `controller conn write` was removed: it is cross-process and measured
true on every mutation, i.e. blind.

## Verification

| tree | result |
|---|---|
| this branch | 50 runs, 50 pass, 0 fail |
| `test_configuration.py` + `test_listener_drain.py` | 36 passed, 6 skipped |
| **#276 reverted** (ack in phase 1) | 10 runs, 0 pass, **10 fail** |
| **ack moved above `listen_socket_release()`** inside `close_finish` | 10 runs, 0 pass, **10 fail** |
| non-debug build | `SKIPPED: needs a build configured with --debug` |

Assertions are last-vs-last, which is independent of engine count: every engine
acknowledges after its own close, so the latest acknowledgement follows every
close; the inverted case is symmetric. Verified at `listen_threads` 1, 2, 8
and 32. A partial regression (some engines swapped) is not detectable by this
anchor, by design.

`test_listeners_port_release` is untouched and stays as the leak guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUVikRAeHfmpyjniLjrhbK
