### PR TITLE
runtime: finish a short pid-file write, and close the file on failure

### DIFF
--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -1563,8 +1563,9 @@ nxt_current_directory(nxt_mp_t *mp)
 static nxt_int_t
 nxt_runtime_pid_file_create(nxt_task_t *task, nxt_file_name_t *pid_file)
 {
-    ssize_t     length;
-    nxt_int_t   n;
+    size_t      size, written;
+    ssize_t     n;
+    nxt_int_t   ret;
     nxt_file_t  file;
     u_char      pid[NXT_INT64_T_LEN + nxt_length("\n")];
 
@@ -1574,17 +1575,35 @@ nxt_runtime_pid_file_create(nxt_task_t *task, nxt_file_name_t *pid_file)
 
     nxt_fs_mkdir_p_dirname(pid_file, 0755);
 
-    n = nxt_file_open(task, &file, O_WRONLY, O_CREAT | O_TRUNC,
-                      NXT_FILE_DEFAULT_ACCESS);
+    ret = nxt_file_open(task, &file, O_WRONLY, O_CREAT | O_TRUNC,
+                        NXT_FILE_DEFAULT_ACCESS);
 
-    if (n != NXT_OK) {
+    if (ret != NXT_OK) {
         return NXT_ERROR;
     }
 
-    length = nxt_sprintf(pid, pid + sizeof(pid), "%PI%n", nxt_pid) - pid;
+    size = nxt_sprintf(pid, pid + sizeof(pid), "%PI%n", nxt_pid) - pid;
 
-    if (nxt_file_write(&file, pid, length, 0) != length) {
-        return NXT_ERROR;
+    /*
+     * pwrite() may store less than it was asked for, so resume from where it
+     * stopped rather than report a short write as a failure.  A zero return
+     * carries no errno and cannot make progress, so it ends the loop.
+     */
+
+    for (written = 0; written < size; written += n) {
+        n = nxt_file_write(&file, pid + written, size - written, written);
+
+        if (nxt_slow_path(n <= 0)) {
+            /* nxt_file_write() logs the errno; a zero return has none. */
+            if (n == 0) {
+                nxt_alert(task, "write(\"%FN\") stored %uz of %uz bytes",
+                          file.name, written, size);
+            }
+
+            nxt_file_close(task, &file);
+
+            return NXT_ERROR;
+        }
     }
 
     nxt_file_close(task, &file);


### PR DESCRIPTION
Follow-up to #290, found by auditing the other `nxt_file_write()` callers for the
same short-write shape that PR fixed.

`nxt_runtime_pid_file_create()` (`src/nxt_runtime.c:1564`) wrote the pid with a
single call and treated anything short of the whole buffer as failure:

```c
if (nxt_file_write(&file, pid, length, 0) != length) {
    return NXT_ERROR;
}

nxt_file_close(task, &file);
```

**Two defects, one of them unconditional.**

`pwrite()` may store less than asked, and a partial store here is recoverable:
resuming writes a correct pid file where this reports a failure that aborts the
runtime. The buffer is at most twenty-odd bytes, so this needs a signal or a full
filesystem to happen at all — it is unlikely, not impossible, and it is the wrong
answer when it does.

The second does not depend on that. The early `return NXT_ERROR` leaves
`file.fd` open, because `nxt_file_close()` is only reached on the success path.
Every failing write leaks the descriptor. The process usually exits soon after
and the kernel reclaims it, but the function reads as though it closes what it
opens, and it does not.

**The fix** loops until the buffer is stored, the way `nxt_main_file_store()` has
since 9c0ab65c, and closes the file on both paths. A zero return carries no errno
and cannot make progress, so it ends the loop with an alert naming how much was
stored. The open result moves from `n` to `ret` so `n` can be the `ssize_t` the
write returns.

**Verified** by running unitd with an explicit `--pid`: the file names the live
`unit: main` process. Build is warning-free and `./build/tests` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4FnpWQ2ntR4eb6GYUeMUr
