### PR TITLE
string: do not call mem* with a null pointer and a zero length

### DIFF
--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -58,6 +58,15 @@ NXT_EXPORT void nxt_memcpy_upcase(u_char *dst, const u_char *src,
 nxt_inline void *
 nxt_cpymem(void *dst, const void *src, size_t length)
 {
+    /*
+     * memcpy() declares "src" non-null even for a zero-length copy, and
+     * callers reach here with the NULL start of an empty nxt_str_t.  The
+     * copy has nothing to do in that case and dst + 0 is dst.
+     */
+    if (length == 0) {
+        return dst;
+    }
+
     return memcpy(dst, src, length) + length;
 }
 
@@ -122,9 +131,16 @@ NXT_EXPORT nxt_str_t *nxt_str_dup(nxt_mp_t *mp, nxt_str_t *dst,
 NXT_EXPORT char *nxt_str_cstrz(nxt_mp_t *mp, const nxt_str_t *src);
 
 
+/*
+ * memcmp() declares both pointers non-null whatever the length, and a
+ * zero-length nxt_str_t carries a NULL start, so the length test has to
+ * short-circuit the call rather than only decide its result.  Two empty
+ * strings are equal, which is what falling through to "true" gives.
+ */
 #define nxt_strstr_eq(s1, s2)                                                 \
     (((s1)->length == (s2)->length)                                           \
-      && (memcmp((s1)->start, (s2)->start, (s1)->length) == 0))
+      && ((s1)->length == 0                                                   \
+          || memcmp((s1)->start, (s2)->start, (s1)->length) == 0))
 
 
 #define nxt_strcasestr_eq(s1, s2)                                             \

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -73,6 +73,11 @@ nxt_is_tstr(nxt_str_t *str)
 {
     u_char  *p;
 
+    /* memchr() declares its pointer non-null; an empty string has none. */
+    if (str->length == 0) {
+        return 0;
+    }
+
     p = memchr(str->start, '`', str->length);
     if (p != NULL) {
         return 1;


### PR DESCRIPTION
Closes the code half of #200.

A zero-length `nxt_str_t` carries a `NULL` start, and three helpers pass that
straight to a libc function whose pointer parameters are declared non-null
*regardless of the length*:

| site | call |
|---|---|
| `nxt_strstr_eq()` | `memcmp(NULL, NULL, 0)` once the lengths match |
| `nxt_cpymem()` | `memcpy(dst, NULL, 0)` |
| `nxt_is_tstr()` | `memchr(NULL, c, 0)`, twice |

Every implementation returns without dereferencing, which is why this has never
misbehaved. It is still undefined, and `nonnull` is the kind of attribute a
compiler may propagate: having seen the call, it can infer the pointer is not
`NULL` and drop a later check that says otherwise. UBSan reports all three, and
`.github/sanitizer-allowlist.txt` currently waives them — one entry per site,
each pointing at #200.

Guard the calls. Two empty strings are equal, `dst + 0` is `dst`, and an empty
string contains no character, so each guard returns exactly what the call would
have.

### Two things stated plainly

**`nxt_cpymem()` is hot and this adds a branch to it.** The test is on a value
most callers know at compile time, so it should usually fold away, but I am not
claiming it is free — only that it is correct and cheap for what it removes.

**The three allowlist entries are left in place on purpose.** An entry that
matches nothing costs nothing, and deleting them honestly requires a sanitizer
run that demonstrably exercised these paths. My attempts to produce one kept
failing environmentally — no pytest for the host interpreter, an occupied
`:8080`, then no network inside the network-isolated container — rather than
producing evidence. Rather than delete suppressions on the strength of a grep
over logs I could not show came from a real run, they stay until this branch's
own sanitize leg comes back without the reports. Sweeping them is a two-line
follow-up.

Build is warning-free under both a normal and an ASan+UBSan configure;
`./build/tests` exits 0 (45 passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4FnpWQ2ntR4eb6GYUeMUr
