### PR TITLE
router: keep the access log values inside UTF-8

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -168,6 +168,7 @@ NXT_TEST_SRCS=" \
     src/test/nxt_sprintf_test.c \
     src/test/nxt_malloc_test.c \
     src/test/nxt_utf8_test.c \
+    src/test/nxt_utf8_sanitize_test.c \
     src/test/nxt_rbtree1_test.c \
     src/test/nxt_http_parse_test.c \
     src/test/nxt_strverscmp_test.c \

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -325,6 +325,27 @@ nxt_router_access_log_json(nxt_task_t *task, nxt_http_request_t *r,
             }
         }
 
+        /*
+         * The value is whatever the variable resolved to, and for a request
+         * header that is bytes the client chose: RFC 9110 Sect. 5.5 admits
+         * obs-text, so 0x80-0xFF reach here unfiltered.  JSON text is UTF-8
+         * (RFC 8259 Sect. 8.1), and nxt_conf_json_escape() escapes the quote
+         * and the backslash but copies every other byte through -- so an
+         * unencodable one leaves a record that is unforgeable and still
+         * unreadable, which a strict consumer drops whole.
+         *
+         * Sanitize here rather than in the serializer.  The same serializer
+         * writes state/conf.json and answers GET /config, where the bytes are
+         * the operator's and have to round-trip exactly: a "share" path is
+         * allowed to be non-UTF-8 on Linux, and rewriting one would point the
+         * router at a different file after a restart.
+         */
+
+        ret = nxt_utf8_sanitize(r->mem_pool, &str, &str);
+        if (nxt_slow_path(ret != NXT_OK)) {
+            return NXT_ERROR;
+        }
+
         nxt_conf_set_member_string(value, &member->name, &str, i);
     }
 

--- a/src/nxt_utf8.c
+++ b/src/nxt_utf8.c
@@ -267,6 +267,109 @@ nxt_utf8_length(const u_char *p, size_t len)
 }
 
 
+/*
+ * Copy "src" into the pool, replacing every byte that begins no valid UTF-8
+ * sequence with U+FFFD.  Returns "src" itself when there is nothing to
+ * replace, so the ordinary path neither allocates nor copies.
+ *
+ * The replacement is per byte rather than per maximal subpart (Unicode 15.0
+ * Sect. 3.9): a truncated four-byte sequence therefore yields up to four
+ * U+FFFD where a maximal-subpart resync yields one.  That changes how many
+ * replacement characters a reader sees, never whether the result is valid,
+ * and it keeps the worst-case expansion at the three bytes of U+FFFD per
+ * input byte -- which matters when the input is a request header somebody
+ * else chose.
+ */
+
+nxt_int_t
+nxt_utf8_sanitize(nxt_mp_t *mp, nxt_str_t *dst, const nxt_str_t *src)
+{
+    size_t        len;
+    u_char        *d, *out;
+    const u_char  *p, *seq, *end, *start;
+
+    /*
+     * "dst" and "src" may be the same nxt_str_t -- the access log sanitizes
+     * a value in place -- so the input is read through locals captured here
+     * and "dst" is not written until both passes are done.
+     */
+
+    start = src->start;
+    end = start + src->length;
+
+    p = start;
+    len = 0;
+
+    while (p < end) {
+
+        /*
+         * nxt_utf8_decode() is a call into another translation unit, and a
+         * logged value is mostly ASCII, so the single-byte case is decided
+         * here rather than paid for at that price once per character.
+         */
+
+        if (nxt_fast_path(*p < 0x80)) {
+            p++;
+            len++;
+
+            continue;
+        }
+
+        seq = p;
+
+        if (nxt_utf8_decode(&seq, end) == 0xFFFFFFFF) {
+            len += nxt_length("\xEF\xBF\xBD");
+            p++;
+
+            continue;
+        }
+
+        len += seq - p;
+        p = seq;
+    }
+
+    if (nxt_fast_path(len == src->length)) {
+        *dst = *src;
+
+        return NXT_OK;
+    }
+
+    out = nxt_mp_nget(mp, len);
+    if (nxt_slow_path(out == NULL)) {
+        return NXT_ERROR;
+    }
+
+    d = out;
+    p = start;
+
+    while (p < end) {
+
+        if (nxt_fast_path(*p < 0x80)) {
+            *d++ = *p++;
+
+            continue;
+        }
+
+        seq = p;
+
+        if (nxt_utf8_decode(&seq, end) == 0xFFFFFFFF) {
+            *d++ = 0xEF; *d++ = 0xBF; *d++ = 0xBD;
+            p++;
+
+            continue;
+        }
+
+        d = nxt_cpymem(d, p, seq - p);
+        p = seq;
+    }
+
+    dst->start = out;
+    dst->length = len;
+
+    return NXT_OK;
+}
+
+
 nxt_bool_t
 nxt_utf8_is_valid(const u_char *p, size_t len)
 {

--- a/src/nxt_utf8.c
+++ b/src/nxt_utf8.c
@@ -158,7 +158,18 @@ nxt_utf8_decode2(const u_char **start, const u_char *end)
 
         } while (n != 0);
 
-        if (overlong < u && u < 0x110000) {
+        /*
+         * Shortest form, inside the Unicode range, and not a surrogate:
+         * U+D800-U+DFFF exist only to be paired inside UTF-16 and have no
+         * UTF-8 encoding at all (Unicode 15.0 Sect. 3.9, D92), so a decoder
+         * that returns them hands its caller a code point that cannot be
+         * re-encoded -- and, for anything that then writes the bytes back
+         * out, output no strict reader will take.
+         */
+
+        if (overlong < u && u < 0x110000
+            && !(u >= 0xD800 && u <= 0xDFFF))
+        {
             *start = p;
             return u;
         }

--- a/src/nxt_utf8.h
+++ b/src/nxt_utf8.h
@@ -17,6 +17,8 @@
 
 
 NXT_EXPORT u_char *nxt_utf8_encode(u_char *p, uint32_t u);
+NXT_EXPORT nxt_int_t nxt_utf8_sanitize(nxt_mp_t *mp, nxt_str_t *dst,
+    const nxt_str_t *src);
 NXT_EXPORT uint32_t nxt_utf8_decode(const u_char **start, const u_char *end);
 NXT_EXPORT uint32_t nxt_utf8_decode2(const u_char **start, const u_char *end);
 NXT_EXPORT nxt_int_t nxt_utf8_casecmp(const u_char *start1,

--- a/src/test/nxt_tests.c
+++ b/src/test/nxt_tests.c
@@ -158,6 +158,10 @@ main(int argc, char **argv)
         return 1;
     }
 
+    if (nxt_utf8_sanitize_test(thr) != NXT_OK) {
+        return 1;
+    }
+
     if (nxt_http_parse_test(thr) != NXT_OK) {
         return 1;
     }

--- a/src/test/nxt_tests.h
+++ b/src/test/nxt_tests.h
@@ -63,6 +63,7 @@ nxt_int_t nxt_gmtime_test(nxt_thread_t *thr);
 nxt_int_t nxt_sprintf_test(nxt_thread_t *thr);
 nxt_int_t nxt_malloc_test(nxt_thread_t *thr);
 nxt_int_t nxt_utf8_test(nxt_thread_t *thr);
+nxt_int_t nxt_utf8_sanitize_test(nxt_thread_t *thr);
 nxt_int_t nxt_http_parse_test(nxt_thread_t *thr);
 nxt_int_t nxt_strverscmp_test(nxt_thread_t *thr);
 nxt_int_t nxt_base64_test(nxt_thread_t *thr);

--- a/src/test/nxt_utf8_sanitize_test.c
+++ b/src/test/nxt_utf8_sanitize_test.c
@@ -1,0 +1,221 @@
+
+/*
+ * Copyright (C) NGINX, Inc.
+ */
+
+#include <nxt_main.h>
+#include "nxt_tests.h"
+
+
+/*
+ * nxt_utf8_sanitize() is what keeps a JSON access log record readable when
+ * the value came from the request: a byte that begins no valid sequence has
+ * no JSON representation at all (RFC 8259 Sect. 8.1 makes JSON text UTF-8),
+ * so it is replaced with U+FFFD rather than escaped or copied.
+ *
+ * The strings below are the ones where a sizing pass and a copying pass can
+ * drift apart -- bytes kept, bytes replaced, and sequences that decode to
+ * nothing -- because the function walks the input twice and the second walk
+ * fills a buffer the first one sized.
+ */
+
+/*
+ * A strict UTF-8 test written from the definition rather than from
+ * src/nxt_utf8.c, which is the decoder the escaper itself uses.  Asserting
+ * with that decoder would only prove the escaper agrees with itself: its
+ * final gate is "overlong < u && u < 0x110000", so it accepts the surrogate
+ * range, and a surrogate copied into the output would satisfy an assertion
+ * built on it while a real consumer rejected the record.  Unicode 15.0
+ * Sect. 3.9, table 3-7.
+ */
+
+static nxt_bool_t
+nxt_utf8_sanitize_test_utf8(const u_char *p, size_t len)
+{
+    uint32_t      u, min;
+    nxt_uint_t    n;
+    const u_char  *end;
+
+    end = p + len;
+
+    while (p < end) {
+
+        if (*p < 0x80) {
+            p++;
+            continue;
+        }
+
+        if (*p >= 0xF0) {
+            if (*p > 0xF4) {
+                return 0;
+            }
+
+            u = *p & 0x07;
+            n = 3;
+            min = 0x10000;
+
+        } else if (*p >= 0xE0) {
+            u = *p & 0x0F;
+            n = 2;
+            min = 0x800;
+
+        } else if (*p >= 0xC2) {
+            u = *p & 0x1F;
+            n = 1;
+            min = 0x80;
+
+        } else {
+            /* A continuation byte on its own, or an overlong C0/C1 lead. */
+            return 0;
+        }
+
+        if (p + n >= end) {
+            return 0;
+        }
+
+        p++;
+
+        while (n != 0) {
+            if ((*p & 0xC0) != 0x80) {
+                return 0;
+            }
+
+            u = (u << 6) | (*p & 0x3F);
+            p++;
+            n--;
+        }
+
+        /* Shortest form, in range, and not a surrogate. */
+
+        if (u < min || u > 0x10FFFF || (u >= 0xD800 && u <= 0xDFFF)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+
+static const struct {
+    const char  *name;
+    const char  *data;
+    size_t      length;
+} nxt_utf8_sanitize_cases[] = {
+    { "plain",              "hello",                    5 },
+    { "quote",              "a\"b",                     3 },
+    { "backslash",          "a\\b",                     3 },
+    { "named control",      "\n\r\t\b\f",               5 },
+    { "numeric control",    "\x01\x02\x1F",             3 },
+    { "nul",                "\x00",                     1 },
+    { "two-byte utf8",      "\xC3\xA9",                 2 },
+    { "three-byte utf8",    "\xE2\x82\xAC",             3 },
+    { "four-byte utf8",     "\xF0\x9F\x92\xA9",         4 },
+    { "lone 0xFF",          "\xFF",                     1 },
+    { "lone continuation",  "\x80",                     1 },
+    { "truncated two-byte", "\xC3",                     1 },
+    { "truncated four-byte","\xF0\x9F",                 2 },
+    { "overlong",           "\xC0\xAF",                 2 },
+    { "surrogate",          "\xED\xA0\x80",             3 },
+    { "above 0x10FFFF",     "\xF5\x80\x80\x80",         4 },
+    { "invalid then quote", "\xFF\"",                   2 },
+    { "invalid run",        "\xFF\xFE\xFD",             3 },
+    { "mixed",              "a\xC3\xA9\xFF\n\"z",       7 },
+};
+
+
+nxt_int_t
+nxt_utf8_sanitize_test(nxt_thread_t *thr)
+{
+    nxt_mp_t    *mp;
+    nxt_str_t   src, dst, alias;
+    nxt_int_t   ret;
+    nxt_uint_t  i;
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "utf8 sanitize test started");
+
+    mp = nxt_mp_create(1024, 128, 256, 32);
+    if (mp == NULL) {
+        nxt_log_alert(thr->log, "utf8 sanitize test: nxt_mp_create() failed");
+        return NXT_ERROR;
+    }
+
+    for (i = 0; i < nxt_nitems(nxt_utf8_sanitize_cases); i++) {
+
+        src.start = (u_char *) nxt_utf8_sanitize_cases[i].data;
+        src.length = nxt_utf8_sanitize_cases[i].length;
+
+        dst.start = NULL;
+        dst.length = 0;
+
+        ret = nxt_utf8_sanitize(mp, &dst, &src);
+        if (ret != NXT_OK) {
+            nxt_log_alert(thr->log, "utf8 sanitize test: \"%s\" failed",
+                          nxt_utf8_sanitize_cases[i].name);
+            goto fail;
+        }
+
+        if (!nxt_utf8_sanitize_test_utf8(dst.start, dst.length)) {
+            nxt_log_alert(thr->log, "utf8 sanitize test: \"%s\" produced "
+                          "invalid UTF-8: \"%*s\"",
+                          nxt_utf8_sanitize_cases[i].name,
+                          (size_t) dst.length, dst.start);
+            goto fail;
+        }
+
+        /*
+         * The access log sanitizes in place -- nxt_utf8_sanitize(mp, &s, &s)
+         * -- so the aliased call is the one that matters, and it is the one
+         * a two-pass implementation gets wrong by writing "dst" before the
+         * second pass has read "src".
+         */
+
+        alias = src;
+
+        ret = nxt_utf8_sanitize(mp, &alias, &alias);
+        if (ret != NXT_OK) {
+            nxt_log_alert(thr->log, "utf8 sanitize test: \"%s\" failed "
+                          "in place", nxt_utf8_sanitize_cases[i].name);
+            goto fail;
+        }
+
+        if (alias.length != dst.length
+            || memcmp(alias.start, dst.start, dst.length) != 0)
+        {
+            nxt_log_alert(thr->log, "utf8 sanitize test: \"%s\" in place "
+                          "gave \"%*s\", not the \"%*s\" of the separate "
+                          "call", nxt_utf8_sanitize_cases[i].name,
+                          (size_t) alias.length, alias.start,
+                          (size_t) dst.length, dst.start);
+            goto fail;
+        }
+
+        /*
+         * A string that needs nothing done to it must come back as itself,
+         * not as a copy: the ordinary request logs no invalid bytes, and
+         * allocating per value per request would be paid on every one.
+         */
+
+        if (nxt_utf8_sanitize_test_utf8(src.start, src.length)
+            && dst.start != src.start)
+        {
+            nxt_log_alert(thr->log, "utf8 sanitize test: \"%s\" copied a "
+                          "string that was already valid",
+                          nxt_utf8_sanitize_cases[i].name);
+            goto fail;
+        }
+    }
+
+    nxt_mp_destroy(mp);
+
+    nxt_thread_time_update(thr);
+    nxt_log_error(NXT_LOG_NOTICE, thr->log, "utf8 sanitize test passed");
+
+    return NXT_OK;
+
+fail:
+
+    nxt_mp_destroy(mp);
+
+    return NXT_ERROR;
+}

--- a/src/test/nxt_utf8_test.c
+++ b/src/test/nxt_utf8_test.c
@@ -107,6 +107,24 @@ nxt_utf8_test(nxt_thread_t *thr)
 
         d = nxt_utf8_decode(&pp, p);
 
+        /*
+         * The surrogates are encodable as bytes but are not UTF-8, so the
+         * decoder refuses them; nxt_utf8_encode() still produces the
+         * three-byte form, which is what a WTF-8 producer would emit.
+         */
+
+        if (u >= 0xD800 && u <= 0xDFFF) {
+
+            if (d != 0xFFFFFFFF) {
+                nxt_log_alert(thr->log, "nxt_utf8_decode(%05uxD) returned "
+                              "%05uxD for a surrogate, expected a refusal",
+                              u, d);
+                return NXT_ERROR;
+            }
+
+            continue;
+        }
+
         if (u != d) {
             nxt_log_alert(thr->log, "nxt_utf8_decode(%05uxD) failed: %05uxD",
                           u, d);


### PR DESCRIPTION
Rewritten after review from a peer session that had already surveyed this code.
`f20694e5` → `eb7f087c`, now two commits, and the title no longer matches what
this does — it is no longer a change to `nxt_conf_json_escape()` at all.

## The previous approach was a data-integrity regression

I put the replacement in `nxt_conf_json_escape()`. That serialiser has four
consumers, and only one of them is the access log:

| | |
|---|---|
| `src/nxt_router_access_log.c:361` | the JSON log record — the one I meant |
| `src/nxt_controller.c:2769` | `GET /config` response body |
| `src/nxt_controller.c:2581` | `nxt_controller_conf_store` → `state/conf.json` |
| `src/nxt_router.c:1940` | app configuration sent to the worker |

The other three carry operator data that has to round-trip byte-exact, and the
config parser admits non-UTF-8 (`src/nxt_conf.c:1924` accepts any `ch >= ' '`).
Measured on the previous head:

```
PUT   "share": "/srv/caf\xff/$uri"        (a legal path on Linux)
GET   "share": "/srv/caf�/$uri"
state/conf.json:  /srv/caf�/$uri
```

So it rewrote stored configuration, and after a restart the router would open a
different file. Object *keys* take the same escaper, so a header-match key would
have come back as a different header name. That is worse than the problem it
fixed. Verified fixed: the same PUT now stores `/srv/caf\xff/$uri` byte for byte.

## What it does now

**`utf8: refuse the surrogates in nxt_utf8_decode2()`** — the gate is
`overlong < u && u < 0x110000`, and for lead `ED` the floor is `0x07FF`, so
`ED A0 80` returned U+D800 with a three-byte advance. Moved here rather than
worked around locally because the caller audit came back empty: outside
`nxt_utf8.*` and the tests the family has two callers, both `nxt_conf.c`, and
`decode2`/`casecmp`/`lowcase`/`is_valid` have none. njs uses its own decoder.
`src/test/nxt_utf8_test.c` asserted the old behaviour — its round trip required
`decode()` to return every value below `0x110000`, surrogates included — and now
requires a refusal.

**`router: keep the access log's values inside UTF-8`** — `nxt_utf8_sanitize()`
copies a string into the request pool replacing unencodable bytes with U+FFFD,
returning the original when there is nothing to replace, and the access log calls
it before `nxt_conf_set_member_string()`. Real U+FFFD bytes, not the six-character
escape, so the worst case is 3x rather than 6x on attacker-controlled input.

```
User-Agent: caf\xff\xfe-bad\xed\xa0\x80end
→ {"ua":"caf��-bad���end","status":"200"}   parses; ASCII values untouched
```

## On the test

The earlier version validated with `nxt_utf8_is_valid()` — the same decoder the
code under test uses — so it could only prove the code agreed with itself, which
is exactly how the surrogate case passed while the bytes were being copied. It
now validates with a strict decoder written from Unicode 15.0 §3.9 table 3-7.

It also calls the function the way its only caller does, in place. That aliased
form was broken when I wrote it — `dst` was assigned before the second pass read
`src`, and the log came back as a run of NULs — and the separate-arguments test
did not catch it; an end-to-end run did.

Two things I did not take from the review: per-byte replacement instead of
maximal-subpart resync (it changes only how many U+FFFD appear, never validity),
and `printed == size` in the test, which no longer applies now that nothing sizes
a serializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4FnpWQ2ntR4eb6GYUeMUr
