### PR TITLE
test: wait for the workers before deleting what they run

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -253,15 +253,28 @@ def run(request):
 
     if not option.restart:
         _clear_conf(log=log)
+
+        # Workers must be gone before their files are.  _clear_conf() returns
+        # on the controller's ack, but the router quits workers asynchronously,
+        # and a java one still in scanClasses() keeps reading temp_dir.
+        _check_processes()
         _clear_temp_dir()
 
     # check descriptors
 
     _check_fds(log=log)
 
-    # check processes id's and amount
+    if option.restart:
+        _check_processes()
 
-    _check_processes()
+    # Teardown logs too, after the snapshot at the top of this fixture, so
+    # read again or those lines are charged to the next test.  Not under
+    # --restart: it stops unitd and may have deleted the log with temp_dir.
+
+    if not option.restart:
+        with Log.open() as f:
+            log += f.read()
+            Log.set_pos(f.tell())
 
     # print unit.log in case of error
 


### PR DESCRIPTION
`test_app_lifecycle_restart_control[node]` has failed about 1.5% of build-test
runs since 2026-08-29 — on #277, #288, #299 and #304, none of which touch
anything near it. It is a harness defect, not a product bug, and neither the
label nor the timestamp on the alert is true.

## What was actually happening

`"Unhandled exception in application start"` exists **once** in the tree, at
`src/nxt_java.c:421`, so the process is always a **java** one. `[node]` skips on
a java leg, but the autouse `run` fixture still runs its finalizer, so a test
that never executed reports the *previous* test's alert.

The stamp on the alert is the worker's **fork** time, not the crash time: a
worker still inside `nxt_java_start()` has not reached the event loop that
advances the cached clock. That is why the write appeared to land in the
`[node]` window.

The alert itself is real, and the harness causes it:

```
java.lang.IllegalArgumentException: Could not load class app :
  java.nio.file.NoSuchFileException:
    /tmp/unit-test-XXXXXXXX/java/WEB-INF/classes/app.class
    at nginx.unit.Context.scanClasses(Context.java:1661)
```

`_clear_conf()` returns when the controller acknowledges the empty
configuration, but the router quits the workers asynchronously. `_clear_temp_dir()`
then deleted the application out from under a worker still reading it. Only java
loses this race — only java spends about a second in `scanClasses()` between its
fork and its first request. Unit is correct throughout: it reports an
application that genuinely failed to start.

## The change

Wait for the processes before deleting their files, and read the log again
afterwards. The second read is not cosmetic — teardown's own output lands after
the snapshot taken at the top of the fixture, so an alert provoked there was
charged to whichever test ran next. Without it this change would only relabel
the flake from `[node]` to `[java]`.

## Evidence

| | |
|---|---|
| frequency | 4–6 confirmed failures / 296 runs since the test landed (`7bea6d55`) |
| legs | java-25 and java-26 only — never 17, never 21, never a node leg |
| first seen | 2026-08-29, eleven days after the test landed; no commit boundary explains it |
| masked by | reruns — 5 of the last 100 runs have `run_attempt > 1` and report success |

Locally: `test_app_lifecycle.py`, `test_php_application.py`, `test_configuration.py`
and `test_access_log.py` — 69 passed. Under `--restart`, one pre-existing
`PermissionError` in `test_php_application_forbidden` (needs sudo), verified
identical on unpatched HEAD.

The failure itself was not reproduced locally: it needs the java module, which
is not built on the machine used. The alternative hypothesis — that the router
spawns a fresh worker while an app is being removed, which would have made this
a product bug — was tested and rejected: 25 iterations of load, restart storm
and clear-config gave 0/25 spawn-during-removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUVikRAeHfmpyjniLjrhbK
