### PR TITLE
conf: refuse a configuration that is not UTF-8

### DIFF
--- a/src/nxt_conf.h
+++ b/src/nxt_conf.h
@@ -128,6 +128,14 @@ void nxt_conf_json_position(u_char *start, const u_char *pos, nxt_uint_t *line,
 
 nxt_int_t nxt_conf_validate(nxt_conf_validation_t *vldt);
 
+/*
+ * Checks every string in the tree -- values and member names alike -- for
+ * valid UTF-8.  Separate from nxt_conf_validate() because
+ * the two callers want different answers: the control API refuses such a
+ * configuration, while a state file that already holds one still has to load.
+ */
+nxt_int_t nxt_conf_validate_encoding(nxt_conf_validation_t *vldt);
+
 NXT_EXPORT void nxt_conf_get_string(const nxt_conf_value_t *value,
     nxt_str_t *str);
 NXT_EXPORT nxt_str_t *nxt_conf_get_string_dup(const nxt_conf_value_t *value,

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -1804,6 +1804,134 @@ nxt_conf_vldt_type(nxt_conf_validation_t *vldt, const nxt_str_t *name,
  *
  * Never fails validation: on allocation failure the pointer is left empty.
  */
+/*
+ * A configuration string is JSON text, and RFC 8259 Sect. 8.1 defines JSON
+ * text as UTF-8.  The parser does not enforce it: nxt_conf_json_parse_string()
+ * copies every byte above 0x1F through untouched, so a PUT can store bytes that
+ * no JSON parser reads back -- including the body of GET /config, which is
+ * served as "application/json", a media type that carries no charset parameter.
+ *
+ * This walks the parsed tree rather than the schema.  A configuration option
+ * added later cannot escape the check by forgetting to ask for it, which is the
+ * property that matters here: the zero-byte guards this fork already carries
+ * were written one sink at a time, and the sink nobody reported kept its hole.
+ *
+ * A zero byte is deliberately NOT rejected.  It is valid UTF-8, and "location"
+ * accepts one today and percent-encodes it (test/test_return.py:137), so
+ * refusing it here would break a documented behaviour to fix a different
+ * problem.  The path sinks guard themselves; see nxt_http_static.c.
+ */
+
+static nxt_int_t
+nxt_conf_vldt_encoding_str(nxt_conf_validation_t *vldt, const nxt_str_t *str,
+    const char *what)
+{
+    if (nxt_slow_path(!nxt_utf8_is_valid(str->start, str->length))) {
+        return nxt_conf_vldt_error(vldt, "The %s is not valid UTF-8.  JSON "
+                                   "text is UTF-8 (RFC 8259 Sect. 8.1), so "
+                                   "these bytes have no JSON representation "
+                                   "and could not be read back.", what);
+    }
+
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_conf_vldt_encoding_value(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t *value)
+{
+    u_char                *p;
+    uint32_t              index, next, count;
+    nxt_str_t             name, str;
+    nxt_int_t             ret;
+    nxt_conf_value_t      *member;
+    nxt_conf_vldt_path_t  seg;
+
+    u_char                buf[sizeof("4294967295") - 1];
+
+    switch (nxt_conf_type(value)) {
+
+    case NXT_CONF_STRING:
+        nxt_conf_get_string(value, &str);
+
+        return nxt_conf_vldt_encoding_str(vldt, &str, "value");
+
+    case NXT_CONF_ARRAY:
+        count = nxt_conf_array_elements_count(value);
+
+        for (index = 0; index < count; index++) {
+            p = nxt_sprintf(buf, buf + sizeof(buf), "%uD", index);
+
+            seg.prev = vldt->path;
+            seg.seg.start = buf;
+            seg.seg.length = p - buf;
+            vldt->path = &seg;
+
+            ret = nxt_conf_vldt_encoding_value(vldt,
+                                    nxt_conf_get_array_element(value, index));
+
+            vldt->path = seg.prev;
+
+            if (nxt_slow_path(ret != NXT_OK)) {
+                return ret;
+            }
+        }
+
+        return NXT_OK;
+
+    case NXT_CONF_OBJECT:
+        next = 0;
+
+        for ( ;; ) {
+            member = nxt_conf_next_object_member(value, &name, &next);
+
+            if (member == NULL) {
+                break;
+            }
+
+            /*
+             * Check the name before it becomes a path segment.  The pointer
+             * rendered for an error is echoed in the response body, so putting
+             * the offending bytes there would make the error report itself
+             * unreadable for the same reason it is being reported.  A bad name
+             * is reported against the object that holds it.
+             */
+
+            ret = nxt_conf_vldt_encoding_str(vldt, &name, "member name");
+
+            if (nxt_slow_path(ret != NXT_OK)) {
+                return ret;
+            }
+
+            seg.prev = vldt->path;
+            seg.seg = name;
+            vldt->path = &seg;
+
+            ret = nxt_conf_vldt_encoding_value(vldt, member);
+
+            vldt->path = seg.prev;
+
+            if (nxt_slow_path(ret != NXT_OK)) {
+                return ret;
+            }
+        }
+
+        return NXT_OK;
+
+    default:
+        return NXT_OK;
+    }
+}
+
+
+nxt_int_t
+nxt_conf_validate_encoding(nxt_conf_validation_t *vldt)
+{
+    return nxt_conf_vldt_encoding_value(vldt, vldt->conf);
+}
+
+
 static void
 nxt_conf_vldt_render_pointer(nxt_conf_validation_t *vldt)
 {

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -379,6 +379,27 @@ nxt_controller_start(nxt_task_t *task, nxt_process_data_t *data)
     vldt.conf_pool = mp;
     vldt.ver = nxt_conf_ver;
 
+    /*
+     * A state file written before this check existed can hold bytes the
+     * control API would now refuse.  Rejecting it here would drop the whole
+     * configuration on the next restart -- the daemon would come back serving
+     * nothing -- and repairing it would silently rewrite an operator's value,
+     * which is how a working non-UTF-8 "share" path becomes a broken one.  So
+     * it is loaded exactly as written and reported, once, with the pointer
+     * that names it.  The API refuses to store any more of them.
+     */
+
+    if (nxt_conf_validate_encoding(&vldt) == NXT_DECLINED) {
+        nxt_log(task, NXT_LOG_WARN, "the restored configuration holds a value "
+                "at \"%V\" that the control API would now reject: %V  It is "
+                "kept as written, and the configuration is running; correct it "
+                "to be able to update the configuration.",
+                &vldt.pointer, &vldt.error);
+
+        nxt_memzero(&vldt.error, sizeof(nxt_str_t));
+        nxt_memzero(&vldt.pointer, sizeof(nxt_str_t));
+    }
+
     ret = nxt_conf_validate(&vldt);
 
     if (nxt_slow_path(ret != NXT_OK)) {
@@ -1510,7 +1531,22 @@ nxt_controller_process_config(nxt_task_t *task, nxt_controller_request_t *req,
         vldt.conf_pool = mp;
         vldt.ver = NXT_VERNUM;
 
-        rc = nxt_conf_validate(&vldt);
+        /*
+         * Before nxt_conf_validate(), which quotes an offending member name
+         * into its own error text: a name that is not UTF-8 would otherwise
+         * reach the response body and make the error report unreadable for
+         * the very reason it is being reported.
+         *
+         * This runs on the tree that would be installed, so a configuration
+         * that already holds such a value has to have it corrected before any
+         * other part of it can be updated.  The pointer in the error names it.
+         */
+
+        rc = nxt_conf_validate_encoding(&vldt);
+
+        if (nxt_fast_path(rc == NXT_OK)) {
+            rc = nxt_conf_validate(&vldt);
+        }
 
         if (nxt_slow_path(rc != NXT_OK)) {
             nxt_mp_destroy(mp);
@@ -1595,7 +1631,22 @@ nxt_controller_process_config(nxt_task_t *task, nxt_controller_request_t *req,
         vldt.conf_pool = mp;
         vldt.ver = NXT_VERNUM;
 
-        rc = nxt_conf_validate(&vldt);
+        /*
+         * Before nxt_conf_validate(), which quotes an offending member name
+         * into its own error text: a name that is not UTF-8 would otherwise
+         * reach the response body and make the error report unreadable for
+         * the very reason it is being reported.
+         *
+         * This runs on the tree that would be installed, so a configuration
+         * that already holds such a value has to have it corrected before any
+         * other part of it can be updated.  The pointer in the error names it.
+         */
+
+        rc = nxt_conf_validate_encoding(&vldt);
+
+        if (nxt_fast_path(rc == NXT_OK)) {
+            rc = nxt_conf_validate(&vldt);
+        }
 
         if (nxt_slow_path(rc != NXT_OK)) {
             nxt_mp_destroy(mp);

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -55,6 +55,62 @@ def test_json_unicode():
     }, 'unicode get'
 
 
+def test_json_utf8_invalid_value():
+    # A configuration string is JSON text and JSON text is UTF-8 (RFC 8259
+    # Sect. 8.1).  Bytes that begin no valid sequence used to be stored and
+    # echoed back, which made GET /config undecodable.
+    resp = client.conf(
+        b'{"listeners": {"*:8080": {"pass": "routes"}},'
+        b' "routes": [{"match": {"headers": {"X-T": "caf\xff\xfe"}},'
+        b' "action": {"return": 200}}]}'
+    )
+
+    assert 'error' in resp, 'invalid utf-8 value rejected'
+    assert 'UTF-8' in resp['detail'], 'reason given'
+    assert (
+        resp['location']['path'] == '/routes/0/match/headers/X-T'
+    ), 'pointer names the value'
+
+
+def test_json_utf8_invalid_member_name():
+    resp = client.conf(
+        b'{"listeners": {"*:8080": {"pass": "routes"}},'
+        b' "routes": [{"match": {"headers": {"X-\xff": "v"}},'
+        b' "action": {"return": 200}}]}'
+    )
+
+    assert 'error' in resp, 'invalid utf-8 member name rejected'
+    assert 'member name' in resp['detail'], 'name named as the culprit'
+
+    # The pointer is echoed in this very response, so it must point at the
+    # object holding the bad name rather than embed the name itself --
+    # otherwise the error report is unreadable for the reason it reports.
+    assert (
+        resp['location']['path'] == '/routes/0/match/headers'
+    ), 'pointer stops at the parent'
+
+
+def test_json_utf8_valid():
+    # Multi-byte UTF-8 is not affected: it must round-trip byte for byte.
+    value = 'caf\u00e9-\U0001f600-\u043d'
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {
+                    "match": {"headers": {"X-T": value}},
+                    "action": {"return": 200},
+                }
+            ],
+        }
+    ), 'valid utf-8 accepted'
+
+    assert (
+        client.conf_get('routes/0/match/headers/X-T') == value
+    ), 'valid utf-8 round-trips unchanged'
+
+
 def test_json_unicode_2():
     assert 'success' in client.conf(
         {


### PR DESCRIPTION
Found while writing up the encoding-contract work behind #284 and #304.

`nxt_conf_json_parse_string()` does not check that a configuration string is
UTF-8. The literal-byte path is one line — `src/nxt_conf.c:1924`:

```c
if (nxt_fast_path(ch >= ' ')) {
    continue;
}
```

`ch` is a `u_char`, so every byte from `0x80` to `0xFF` satisfies it, and a
string with no escapes is `memcpy`'d verbatim (`:2040-2042`).

### What that does today

Against 1.36.0, PUT a route header-match value of `caf\xff\xfe-bad`:

```
$ curl -X PUT --data-binary @cfg.json .../config/
{"success": "Reconfiguration done."}

$ curl .../config/ | python3 -c "import json,sys; json.loads(sys.stdin.buffer.read())"
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 144
```

The bytes are also written to `state/conf.json`, so the file is not valid UTF-8
either. RFC 8259 Sect. 8.1 defines JSON text as UTF-8, and the controller serves
`Content-Type: application/json`, a media type with no charset parameter.

Both clients this project ships reject it: `unitctl` parses that response with
`serde_json::from_reader` (`tools/unitctl/unit-client-rs/src/unit_client.rs:284`)
and the test suite with `json.loads` (`test/unit/control.py:27`). **A
configuration Unit accepts and stores cannot be read back by its own tooling.**

There is also an asymmetry: `"a\ud800b"` written as an escape is rejected with a
precise message, while the identical code point written as the raw bytes
`ED A0 80` is accepted. Validation existed for one spelling and not the other.

### The check

A recursive walk over the parsed tree, not over the schema. A configuration
option added later cannot escape it by forgetting to ask — which matters here,
because this fork's zero-byte guards were written one sink at a time and the
sink nobody reported kept its hole.

It runs *before* `nxt_conf_validate()`, which quotes an offending member name
into its own error text; a name that is not UTF-8 would otherwise reach the
response body and make the error unreadable for the very reason it is being
reported. For the same reason a bad member name is reported against the object
that holds it:

```
"detail": "The member name is not valid UTF-8. ..."
"location": {"path": "/routes/0/match/headers"}
```

### Existing state files still load

Rejecting one would drop the whole configuration on the next restart and bring
the daemon back serving nothing. Repairing it would silently rewrite an
operator's value — which is how a working non-UTF-8 `share` path becomes a
broken one. So it loads exactly as written, with one warning naming the pointer,
and the API refuses to store any more. Verified: config intact, bytes preserved,
app still serving.

### Deliberately not included

A zero byte is **not** rejected. It is valid UTF-8, and `location` accepts one
today and percent-encodes it (`test/test_return.py:137` asserts this), so
refusing it here would break a documented behaviour to fix a different problem.
The path sinks keep their own guards; the one `index` was missing is a separate
PR.

### First caller of `nxt_utf8_is_valid()`

Until 7776a124 that function blessed UTF-16 surrogates and had no caller to
notice. With the decoder fixed, a raw `ED A0 80` in a configuration string is
now refused here too, not just the `\ud800` spelling the parser already
rejected — verified against a build of this branch on current master.

Part of #311.

### Test

Three cases in `test/test_configuration.py`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqWagVeqR5uyNaDfUx6nRR
