### PR TITLE
static: refuse an "index" carrying a zero byte

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -123,6 +123,8 @@ static nxt_int_t nxt_conf_vldt_pass(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_return(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
+static nxt_int_t nxt_conf_vldt_index(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_share(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_share_element(nxt_conf_validation_t *vldt,
@@ -876,6 +878,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_share_action_members[] = {
     }, {
         .name       = nxt_string("index"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_index,
     }, {
         .name       = nxt_string("types"),
         .type       = NXT_CONF_VLDT_STRING | NXT_CONF_VLDT_ARRAY,
@@ -1114,6 +1117,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_php_target_members[] = {
     }, {
         .name       = nxt_string("index"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_index,
     },
 
     NXT_CONF_VLDT_END
@@ -1131,6 +1135,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_php_notargets_members[] = {
     }, {
         .name       = nxt_string("index"),
         .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_index,
     },
 
     NXT_CONF_VLDT_NEXT(nxt_conf_vldt_php_common_members)
@@ -2438,6 +2443,39 @@ nxt_conf_vldt_return(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     if (status < NXT_HTTP_INVALID || status > NXT_HTTP_STATUS_MAX) {
         return nxt_conf_vldt_error(vldt, "The \"return\" value is out of "
                                    "allowed HTTP status code range 0-999.");
+    }
+
+    return NXT_OK;
+}
+
+
+/*
+ * "index" is appended to a "share" directory and the result is handed to
+ * open() as a NUL-terminated C string (nxt_http_static.c, where the name is
+ * assembled).  An embedded NUL truncates the name there, so "a\u0000b" opens
+ * "a".  Unlike "share" this value is not a template, so it can be refused once
+ * at configuration time instead of on every request.
+ *
+ * The neighbouring "share" has the same guard applied per request, and
+ * "component" and the environment names and values are refused the same way;
+ * this is the sink that was missed.
+ */
+
+static nxt_int_t
+nxt_conf_vldt_index(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
+    void *data)
+{
+    nxt_str_t  str;
+
+    nxt_conf_get_string(value, &str);
+
+    /* memchr() on a null pointer is undefined even for a zero length. */
+
+    if (str.length != 0
+        && nxt_slow_path(memchr(str.start, '\0', str.length) != NULL))
+    {
+        return nxt_conf_vldt_error(vldt, "The \"index\" must not contain "
+                                   "null character.");
     }
 
     return NXT_OK;

--- a/test/test_php_targets.py
+++ b/test/test_php_targets.py
@@ -98,3 +98,63 @@ def test_php_application_targets_error():
     assert 'error' in client.conf_delete(
         'applications/targets/default/root'
     ), 'root remove'
+
+
+def test_php_application_index_nul():
+    # "index" is appended to a directory and handed to open() as a
+    # NUL-terminated C string, so an embedded NUL truncates the name at the
+    # sink.  This validator is shared with the static "share" action
+    # (test_static.py::test_static_index_nul); here it is exercised on both
+    # PHP schemas that attach it: a target's "index" and the top-level
+    # "index" used without targets.  "spare": 0 validates the configuration
+    # without spawning a PHP worker.
+    root = f"{option.test_dir}/php/targets"
+
+    def conf_targets_index(index):
+        return client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "applications/targets"}},
+                "applications": {
+                    "targets": {
+                        "type": client.get_application_type(),
+                        "processes": {"spare": 0},
+                        "targets": {
+                            "default": {"index": index, "root": root},
+                        },
+                    }
+                },
+            }
+        )
+
+    def conf_notargets_index(index):
+        return client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "applications/notargets"}},
+                "applications": {
+                    "notargets": {
+                        "type": client.get_application_type(),
+                        "processes": {"spare": 0},
+                        "root": root,
+                        "index": index,
+                    }
+                },
+            }
+        )
+
+    resp = conf_targets_index("index\0.php")
+    assert (
+        'must not contain null character' in resp.get('detail', '')
+    ), 'targets index with null character'
+
+    assert 'success' in conf_targets_index(
+        "index.php"
+    ), 'clean targets index still accepted'
+
+    resp = conf_notargets_index("index\0.php")
+    assert (
+        'must not contain null character' in resp.get('detail', '')
+    ), 'notargets index with null character'
+
+    assert 'success' in conf_notargets_index(
+        "index.php"
+    ), 'clean notargets index still accepted'

--- a/test/test_static.py
+++ b/test/test_static.py
@@ -51,6 +51,25 @@ def test_static_index(temp_dir):
     assert client.get()['status'] == 404, 'index empty'
 
 
+def test_static_index_nul(temp_dir):
+    # "index" is appended to "share" and handed to open() as a NUL-terminated
+    # C string, so an embedded NUL truncated the name at the sink: an index of
+    # "README\0x" opened "README".  "share" has been guarded against this since
+    # it is templated; this is the same sink reached by the other half.
+    assert 'error' in client.conf(
+        {"share": f'{temp_dir}/assets$uri', "index": "README\u0000x"},
+        'routes/0/action',
+    ), 'index with null character'
+
+    # An empty index stays valid -- see test_static_index.
+    assert 'success' in client.conf(
+        {"share": f'{temp_dir}/assets$uri', "index": "README"},
+        'routes/0/action',
+    ), 'clean index still accepted'
+
+    assert client.get()['body'] == 'readme', 'clean index still served'
+
+
 def test_static_index_default():
     assert client.get(url='/index.html')['body'] == '0123456789', 'index'
     assert client.get(url='/')['body'] == '0123456789', 'index 2'


### PR DESCRIPTION
`index` is appended to a `share` directory and the result is handed to `open()`
as a NUL-terminated C string, so an embedded NUL truncates the name at the sink.

Confirmed against a running unitd. With a file named `a` in the share directory:

```json
{"share": "<dir>$uri", "index": "a\u0000b"}
```

```
$ curl -i http://127.0.0.1:8099/
HTTP/1.1 200 OK
Content-Length: 14

SERVED-FILE-A
```

The name truncated at the NUL and served `a`.

The zero byte gets in because an escaped `\u0000` survives configuration parsing:
`nxt_conf_json_parse_string()` decodes it through `nxt_utf8_encode()`, which
writes a single `0x00`.

### Why here

This sink already has a guard on its other half. `nxt_http_static.c:459` rejects
a `share` whose expansion contains a NUL, with a comment naming `open()` as the
reason — this fork's own hardening. `index` is `nxt_cpymem`'d into **the same
buffer feeding the same `open()`** twelve lines later (`:520-522`) with no
guard.

`share` is a template, so it has to be checked per request. `index` is a plain
configuration string (`nxt_conf_get_string_dup`, `:238`), so it is refused once
at configuration time instead — no per-request cost, and it fails loudly.

Seven fields in the validator already reject a null character (environment names
and values, `component`, and others). This is the eighth that needed it; the
same validator is attached to the PHP `index` members, which reach a filename
the same way.

### Not changed

An empty `index` stays valid — `test_static_index` configures one and expects a
404. That is unchanged, and the test still passes.

### Test

`test_static_index_nul` in `test/test_static.py`: the NUL form is refused, a
clean index is still accepted and still served.

Part of #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqWagVeqR5uyNaDfUx6nRR
