### PR TITLE
wasm: stop unauthenticated requests from killing the application worker

### DIFF
--- a/src/wasm-wasi-component/src/lib.rs
+++ b/src/wasm-wasi-component/src/lib.rs
@@ -3,6 +3,7 @@ use bytes::{Bytes, BytesMut};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::Error;
+use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::mem::MaybeUninit;
 use std::process::exit;
@@ -359,8 +360,8 @@ impl GlobalState {
     ) -> Result<http::request::Builder> {
         let mut request = http::Request::builder();
 
-        request = request.method(info.method());
-        request = match info.version() {
+        request = request.method(info.method().as_ref());
+        request = match &*info.version() {
             "HTTP/0.9" => request.version(http::Version::HTTP_09),
             "HTTP/1.0" => request.version(http::Version::HTTP_10),
             "HTTP/1.1" => request.version(http::Version::HTTP_11),
@@ -374,14 +375,14 @@ impl GlobalState {
 
         let uri = http::Uri::builder()
             .scheme(if info.tls() { "https" } else { "http" })
-            .authority(info.server_name())
-            .path_and_query(info.target())
+            .authority(info.server_name().as_ref())
+            .path_and_query(info.target().as_ref())
             .build()
             .context("failed to build URI")?;
         request = request.uri(uri);
 
         for (name, value) in info.fields() {
-            request = request.header(name, value);
+            request = request.header(name.as_ref(), value.as_ref());
         }
         Ok(request)
     }
@@ -463,7 +464,7 @@ unsafe impl Send for NxtRequestInfo {}
 unsafe impl Sync for NxtRequestInfo {}
 
 impl NxtRequestInfo {
-    fn method(&self) -> &str {
+    fn method(&self) -> Cow<'_, str> {
         unsafe {
             let raw = (*self.info).request;
             self.get_str(&(*raw).method, (*raw).method_length.into())
@@ -474,21 +475,21 @@ impl NxtRequestInfo {
         unsafe { (*(*self.info).request).tls != 0 }
     }
 
-    fn version(&self) -> &str {
+    fn version(&self) -> Cow<'_, str> {
         unsafe {
             let raw = (*self.info).request;
             self.get_str(&(*raw).version, (*raw).version_length.into())
         }
     }
 
-    fn server_name(&self) -> &str {
+    fn server_name(&self) -> Cow<'_, str> {
         unsafe {
             let raw = (*self.info).request;
             self.get_str(&(*raw).server_name, (*raw).server_name_length.into())
         }
     }
 
-    fn target(&self) -> &str {
+    fn target(&self) -> Cow<'_, str> {
         unsafe {
             let raw = (*self.info).request;
             self.get_str(&(*raw).target, (*raw).target_length.into())
@@ -502,7 +503,7 @@ impl NxtRequestInfo {
         }
     }
 
-    fn fields(&self) -> impl Iterator<Item = (&str, &str)> {
+    fn fields(&self) -> impl Iterator<Item = (Cow<'_, str>, Cow<'_, str>)> {
         unsafe {
             let raw = (*self.info).request;
             (0..(*raw).fields_count).map(move |i| {
@@ -593,10 +594,10 @@ impl NxtRequestInfo {
         &self,
         ptr: &bindings::nxt_unit_sptr_t,
         len: u32,
-    ) -> &str {
+    ) -> Cow<'_, str> {
         let ptr = bindings::nxt_unit_sptr_get(ptr);
         let slice = std::slice::from_raw_parts(ptr, len.try_into().unwrap());
-        std::str::from_utf8(slice).unwrap()
+        String::from_utf8_lossy(slice)
     }
 }
 

--- a/src/wasm-wasi-component/src/lib.rs
+++ b/src/wasm-wasi-component/src/lib.rs
@@ -293,9 +293,27 @@ impl GlobalState {
         // Convert the `nxt_*` representation into the representation required
         // by Wasmtime's `wasi-http` implementation using the Rust `http`
         // crate.
-        let request = self.to_request_builder(&info)?;
+        // A request that the `http` crate refuses to represent must fail on
+        // its own, not take the worker with it: `run()` turns an `Err` from
+        // here into `.expect()`, and both profiles set `panic = 'abort'`.
+        // Unit forwards bytes that `http` rejects -- a `Host` holding
+        // obs-text, a target holding `<`, `>` or a control byte -- so this is
+        // reachable from an unauthenticated request.
+        let builder = match self.to_request_builder(&info) {
+            Ok(builder) => builder,
+            Err(e) => {
+                info.reject(&e);
+                return Ok(());
+            }
+        };
         let body = self.to_request_body(&mut info);
-        let request = request.body(body)?;
+        let request = match builder.body(body) {
+            Ok(request) => request,
+            Err(e) => {
+                info.reject(&e.into());
+                return Ok(());
+            }
+        };
 
         let (sender, receiver) = tokio::sync::oneshot::channel();
 
@@ -579,6 +597,27 @@ impl NxtRequestInfo {
             let rc = bindings::nxt_unit_response_send(self.info);
             assert_eq!(rc, 0);
         }
+    }
+
+    /// Fail this one request with a 400, leaving the worker alive.
+    ///
+    /// Takes `self` so the request info is always released: returning without
+    /// `request_done()` would leak it and hang the client.
+    fn reject(mut self, err: &anyhow::Error) {
+        unsafe {
+            let msg = format!("rejected a malformed request: {err:#}");
+            if let Ok(msg) = CString::new(msg) {
+                bindings::nxt_unit_req_log(
+                    self.info,
+                    bindings::NXT_UNIT_LOG_ERR as i32,
+                    "%s\0".as_ptr().cast(),
+                    msg.as_ptr(),
+                );
+            }
+        }
+        self.init_response(400, 0, 0);
+        self.send_response();
+        self.request_done();
     }
 
     fn request_done(self) {

--- a/test/test_wasm-wasi-component.py
+++ b/test/test_wasm-wasi-component.py
@@ -65,3 +65,21 @@ def test_wasm_component_obs_text():
     )
     assert resp['status'] == 200
     assert resp['body'] == 'Hello'
+
+
+def test_wasm_component_unrepresentable_request():
+    client.load('hello_world')
+
+    # Unit forwards bytes that the Rust "http" crate will not put in a URI:
+    # obs-text in Host, and "<" or a control byte in the target.  Building the
+    # request then fails, and that error must fail this request alone.  The
+    # worker used to abort on it (SIGABRT), which conftest's Log.check_alerts()
+    # would also catch on teardown.
+    for req in (
+        b'GET / HTTP/1.1\r\nHost: caf\xff\r\nConnection: close\r\n\r\n',
+        b'GET /a<b HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n',
+    ):
+        assert client.http(req, raw=True)['status'] == 400, req
+
+    # The worker is still alive and serving after both.
+    assert client.get()['status'] == 200

--- a/test/test_wasm-wasi-component.py
+++ b/test/test_wasm-wasi-component.py
@@ -39,3 +39,29 @@ def test_wasm_component_cstring_nul():
 
     resp = conf_component("")
     assert 'must not be empty' in resp.get('detail', ''), 'empty'
+
+
+def test_wasm_component_obs_text():
+    client.load('hello_world')
+
+    # Non-UTF-8 / obs-text bytes in target must be lossily replaced with U+FFFD
+    # rather than panicking/aborting the wasm worker.
+    resp = client.http(
+        b'GET /caf\xff\xfe HTTP/1.1\r\n'
+        b'Host: localhost\r\n'
+        b'Connection: close\r\n\r\n',
+        raw=True,
+    )
+    assert resp['status'] == 200
+    assert resp['body'] == 'Hello'
+
+    # Non-UTF-8 / obs-text bytes in headers must also not crash the wasm worker.
+    resp = client.http(
+        b'GET / HTTP/1.1\r\n'
+        b'Host: localhost\r\n'
+        b'Custom: caf\xff\xfe\r\n'
+        b'Connection: close\r\n\r\n',
+        raw=True,
+    )
+    assert resp['status'] == 200
+    assert resp['body'] == 'Hello'


### PR DESCRIPTION
Two unauthenticated ways to kill a wasm application worker. Both are one
request, no config needed, and Unit respawns the worker afterwards, so each is
a repeatable request-to-kill DoS rather than a permanent outage.

Both profiles in `src/wasm-wasi-component/Cargo.toml` set `panic = 'abort'`, so
any panic on the request path takes the process down.

## 1. Non-UTF-8 bytes (commit 1)

`NxtRequestInfo::get_str()` decoded raw request slices with
`std::str::from_utf8(slice).unwrap()`:

```
thread 'tokio-rt-worker' panicked at src/lib.rs:599:36:
called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 4, error_len: Some(1) }
[alert] app process exited on signal 6
```

`GET /caf\xff\xfe` or obs-text in a header value is enough. obs-text in a field
value is legal per RFC 9110.

Fixed with `String::from_utf8_lossy()`, returning `Cow<'_, str>` from the five
accessors. Valid UTF-8 stays borrowed, so the common path allocates nothing.

The trade-off: the component sees U+FFFD rather than the bytes the client sent,
so it cannot round-trip them, and `/a\xff` and `/a\xfe` now collapse to the same
string. Rejecting instead would turn RFC-legal traffic into an error. Note
`req->target` is the raw target, so `%FF` is not percent-decoded here, and
Unit's own route matching runs on the normalized `path` before the app is
chosen, so a Unit-level `match` rule cannot be bypassed this way.

## 2. Anything `http` refuses to represent (commit 2)

Lossy decoding alone left an equivalent abort one frame up. `run()` does
`state.handle(msg).await.expect("failed to handle request")`, so *any* error out
of `handle()` aborts. Two come straight from request data:

- `Host:` with obs-text. `nxt_http_validate_host()` skips bytes above `]`
  (`src/nxt_http_request.c:134`), so it reaches the module, and `http` rejects
  every byte >= 0x80 in an authority. Lossy decoding does not help: U+FFFD is
  still >= 0x80.
- a target with `<`, `>`, a backtick, DEL or a control byte.
  `nxt_http_target_chars` only initialises its first 64 entries
  (`src/nxt_http_parse.c:49-59`), so Unit forwards them and `http` rejects them
  in a path. This one is plain ASCII and has nothing to do with UTF-8.

```
thread 'tokio-rt-worker' panicked at src/lib.rs:260:45:
failed to handle request: failed to build URI
[alert] app process 3366095 exited on signal 6
```

Both now answer 400. `reject()` takes `self` so the request info is always
released; returning without `nxt_unit_request_done()` would leak it and hang the
client.

## Verification

Each fix was run in both directions, rebuilding the module from the same
worktree -- not inferred:

- `test_wasm_component_obs_text` fails with the `lib.rs:599` panic and
  `signal 6` without commit 1.
- `test_wasm_component_unrepresentable_request` fails with the `lib.rs:260`
  panic and `signal 6` without commit 2.
- With both, `test_wasm-wasi-component.py` is 4 passed with no `signal 6` or
  panic anywhere in the log.

conftest's `Log.check_alerts()` also fails these tests on teardown if a worker
aborts, independently of the status assertions.

## Not addressed

- `assert_eq!(rc, 0)` on the response side (`lib.rs` `response_write`,
  `init_response`, `add_field`, `send_response`) still aborts if a libunit call
  fails, e.g. on a client that disconnects mid-response. Pre-existing, tracked
  as #318 -- there is no clean 400 to send once headers have gone out, so it
  needs its own decision.
- `request_read()` has a signed/unsigned bug on a negative `amt` (existing
  TODO), and passes a fixed 32 MB rather than the real remaining capacity.
  Pre-existing, tracked as #319.
- The guest gets the raw un-normalized `target` while Unit routed on the
  normalized `path`. Pre-existing.

The failing `python-3.13`/`python-3.14` legs are #307's conftest teardown bug,
which reds those legs on master and on every open PR (same failures on #314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
