### PR TITLE
test: check process identity after the pids are refreshed

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -257,15 +257,19 @@ def run(request):
         # Workers must be gone before their files are.  _clear_conf() returns
         # on the controller's ack, but the router quits workers asynchronously,
         # and a java one still in scanClasses() keeps reading temp_dir.
-        _check_processes()
+        # Only wait here: the identity asserts belong after _check_fds(),
+        # which is what refreshes the router/controller pids a respawn test
+        # has changed.
+        _wait_for_processes()
         _clear_temp_dir()
 
     # check descriptors
 
     _check_fds(log=log)
 
-    if option.restart:
-        _check_processes()
+    # check processes id's and amount
+
+    _check_processes()
 
     # Teardown logs too, after the snapshot at the top of this fixture, so
     # read again or those lines are charged to the next test.  Not under
@@ -769,9 +773,7 @@ def _clear_temp_dir():
                         time.sleep(1)
 
 
-def _check_processes():
-    router_pid = _fds_info['router']['pid']
-    controller_pid = _fds_info['controller']['pid']
+def _wait_for_processes():
     main_pid = unit_instance['pid']
 
     for _ in range(600):
@@ -791,6 +793,16 @@ def _check_processes():
             break
 
         time.sleep(0.1)
+
+    return out
+
+
+def _check_processes():
+    router_pid = _fds_info['router']['pid']
+    controller_pid = _fds_info['controller']['pid']
+    main_pid = unit_instance['pid']
+
+    out = _wait_for_processes()
 
     if option.restart:
         assert len(out) == 0, 'all termimated'


### PR DESCRIPTION
Every `test (python-3.x)` leg has been red since #307 merged -- on master
itself (run 34307840947 on `b2474379`, python-3.12/3.13/3.14 all failing), and
on every open PR that inherits it. The legs were green at `31fcf3e4` and
`72036943`, the two commits before it, so the regression starts exactly at
#307's merge.

## Cause

#307 moved `_check_processes()` ahead of `_clear_temp_dir()` so java workers
finish reading their files before those files go away. That is a real fix and
this keeps it.

But it also put `_check_processes()` before `_check_fds()`, and `_check_fds()`
is what refreshes the recorded pids (`test/conftest.py:860`):

```python
ps['pid'] = pid_by_name(ps['name'])     # unconditional
if not ps['skip']:
    assert ps['pid'] == ps_pid, f'same pid {name}'
```

The respawn tests call `skip_fds_check(router=True)` (`test/test_respawn.py:76`),
which suppresses the `same pid` assert but **not** the refresh -- replacing the
router is the whole point of them. So `_check_processes()` began matching the
live router against the pid recorded at setup:

```
E   AssertionError: one router
E   assert 2 == 1
E    +  where 2 = len(['3399262 3398999 unit: router', '3399283 3398999 unit: controller'])
```

Two processes, one router, one controller -- the count is right, the pid just
is not the recorded one. So it is a stale recorded pid, not an old router
lingering beside the new one.

It is deterministic, and it aborts teardown before `_check_fds()` ever refreshes
the pid, which is why unrelated files (`test_tls.py`, `test_variables.py`) show
`ERROR at teardown` too.

## Fix

Split the waiting loop out as `_wait_for_processes()`. #307's early call becomes
that wait alone; the identity asserts go back after `_check_fds()`, where they
were before. The wait before `_clear_temp_dir()` is unchanged, so #307's
ordering guarantee still holds.

## Verification

- Before, `test/test_respawn.py`: 3 passed, **3 errors**, all `AssertionError:
  one router` at teardown.
- After, `test/test_respawn.py test/test_variables.py`: **25 passed**, zero
  teardown errors. Run 3 consecutive times, plus an independent rerun.
- `test/test_app_lifecycle.py` (#307's own file): 5 passed, 40 skipped, no
  teardown errors.

## Not verified locally

- **#307's own flake case was not exercised.** `test_app_lifecycle_restart_control`
  failed on `[node]` on a java leg; neither module builds on this box, so those
  params skipped. What holds structurally is that the pre-`_clear_temp_dir()`
  wait is the same loop in the same place. CI covers it here.
- **`--restart` mode was not run.** That path is textually back to its pre-#307
  shape rather than newly written, but it was not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
