### PR TITLE
libunit: drop the declaration of a function that does not exist

### DIFF
--- a/src/nxt_unit.h
+++ b/src/nxt_unit.h
@@ -245,10 +245,6 @@ void nxt_unit_port_id_init(nxt_unit_port_id_t *port_id, pid_t pid, uint16_t id);
 /* Calculates hash for given field name. */
 uint16_t nxt_unit_field_hash(const char* name, size_t name_length);
 
-/* Split host for server name and port. */
-void nxt_unit_split_host(char *host_start, uint32_t host_length,
-    char **name, uint32_t *name_length, char **port, uint32_t *port_length);
-
 /* Group duplicate fields for easy enumeration. */
 void nxt_unit_request_group_dup_fields(nxt_unit_request_info_t *req);
 


### PR DESCRIPTION
`nxt_unit_split_host()` is declared in `src/nxt_unit.h` and defined nowhere. The first caller gets a link error, not a function.

## It was removed on purpose in 2019; the header was missed

This is not an unimplemented API point. Upstream **`e929d082`** (2019-02-27, *"Fixed processing of SERVER_NAME after 77aad2c142a0"*) says so directly:

> The nxt_unit_split_host() function was removed.  It didn't work correctly with
> IPv6 literals.  Anyway, after 77aad2c142a0 the port splitting is done in router
> while Host header processing.

That commit deletes the definition (`src/nxt_unit.c | 57 ------`) and rewrites every caller — `nxt_php_sapi.c`, `nxt_python_wsgi.c`, `perl/nxt_perl_psgi.c`, `ruby/nxt_ruby.c`, `go/unit/nxt_cgo_lib.c` — onto `server_name` and `local_port`. **`src/nxt_unit.h` is not in its file list.** The declaration has been a leftover ever since.

## Nothing needs it

- **The router does the split, correctly.** `nxt_http_validate_host()` (`src/nxt_http_request.c`) is a state machine that handles `[`…`]` IPv6 literals — the case that got the original deleted — strips a trailing dot and lowercases. `r->host` is host-without-port.
- **Modules already have both halves.** `nxt_unit_request_t` carries `server_name` *and* `local_port` (`src/nxt_unit_request.h`). The port is not missing.
- **Almost no module re-implements the split.** python, php, ruby, perl, go and both wasm modules read `server_name` directly. The one exception is Java: `nxt_java_Request_getServerName()` (`src/java/nxt_jni_Request.c:611`) does `memchr(host, ':', f->value_length)` on the raw `Host` field — which is exactly the IPv6 bug the upstream removal cites, since `Host: [::1]:8080` matches inside the literal and yields `"["` as the server name. Its `getServerPort()` already uses `local_port`, so only the *name* half is duplicated, in one module.

  That one duplicate does not argue for restoring the helper — it argues for Java reading `server_name` like everyone else, which is a separate follow-up. Re-exporting a splitter would invite modules to re-derive from the raw field and get a second, weaker answer than the router's.
- **The input no longer exists.** `Host:` reaches libunit post-normalization with the port already stripped, and `SERVER_PORT` means the listener port — settled upstream in #761/#1628, which moved every module off a hard-coded `"80"` onto `local_port`. Re-implementing this would add a second, worse source of truth for the port to a stable ABI.

Nobody has asked for it either: no issue or comment in the upstream archive mentions `nxt_unit_split_host`, and #738 (the Rust binding author who abandoned the project over libunit's surface) raised threading, buffer lifetime, backpressure and docs — never host parsing.

## Why remove rather than leave

For anyone writing against libunit the header *is* the documentation, and an exported name that cannot be linked invites someone to design around a function that does not exist and discover it at link time. A vendored copy of this header is already published in at least one Rust binding's docs, where bindgen would have emitted an `extern` that links to nothing.

`unitd` and the PHP module both rebuild clean with the declaration gone, which is the proof nothing referenced it. Removal only; no behaviour change, no ABI change — there is no symbol to break.

---

*Three earlier claims in this description were wrong and are corrected above. The most recent: it said no module re-implements the split — Java does (see above), found in review. The first said the declaration arrived with this repository's first commit — an artefact of a **shallow clone**, where `git rev-list --max-parents=0` reports a graft boundary as a root and `git log -S` stops there. The second hedged to "older than the visible history". The actual provenance is `e929d082`, verified from the commit message and its file list.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
