### PR TITLE
java: take the server name from the router, not the Host field

### DIFF
--- a/src/java/nxt_jni_Request.c
+++ b/src/java/nxt_jni_Request.c
@@ -597,27 +597,12 @@ nxt_java_Request_getScheme(JNIEnv *env, jclass cls, jlong req_ptr)
 static jstring JNICALL
 nxt_java_Request_getServerName(JNIEnv *env, jclass cls, jlong req_ptr)
 {
-    char                *host, *colon;
-    nxt_unit_field_t    *f;
     nxt_unit_request_t  *r;
 
     r = nxt_jlong2ptr(req_ptr);
 
-    f = nxt_java_findHeader(r->fields, r->fields + r->fields_count,
-                            "Host", 4);
-    if (f != NULL) {
-        host = nxt_unit_sptr_get(&f->value);
-
-        colon = memchr(host, ':', f->value_length);
-
-        if (colon == NULL) {
-            colon = host + f->value_length;
-        }
-
-        return nxt_java_newString(env, host, colon - host);
-    }
-
-    return nxt_java_Request_getLocalName(env, cls, req_ptr);
+    return nxt_java_newString(env, nxt_unit_sptr_get(&r->server_name),
+                              r->server_name_length);
 }
 
 

--- a/test/java/server_name/app.java
+++ b/test/java/server_name/app.java
@@ -1,0 +1,20 @@
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/")
+public class app extends HttpServlet
+{
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException
+    {
+        response.addHeader("X-Server-Name", request.getServerName());
+        response.addHeader("X-Server-Port",
+                           String.valueOf(request.getServerPort()));
+    }
+}

--- a/test/test_java_application.py
+++ b/test/test_java_application.py
@@ -838,6 +838,38 @@ def test_java_application_no_method():
     assert client.post()['status'] == 405, 'no method'
 
 
+def test_java_application_server_name():
+    client.load('server_name')
+
+    def headers(host):
+        return client.get(headers={'Host': host, 'Connection': 'close'})[
+            'headers'
+        ]
+
+    def server_name(host):
+        return headers(host)['X-Server-Name']
+
+    assert server_name('localhost') == 'localhost', 'plain host'
+    assert server_name('localhost:8080') == 'localhost', 'port stripped'
+    assert server_name('LocalHost') == 'localhost', 'lowercased'
+    assert server_name('localhost.') == 'localhost', 'trailing dot stripped'
+    assert server_name('[::1]') == '[::1]', 'ipv6 literal'
+    assert server_name('[::1]:8080') == '[::1]', 'ipv6 literal with port'
+
+    # the port comes from the listener, never from the Host field
+    assert headers('[::1]:9999')['X-Server-Port'] == '8080', 'server port'
+
+    # HTTP/1.0 may omit Host.  The router substitutes "localhost" rather than
+    # leaving the name empty, so that is what the servlet sees -- previously
+    # this module fell back to the listener address instead.  Aligning with
+    # every other module is the point of the change, not a side effect.
+    resp = client.http(
+        b'GET / HTTP/1.0\r\nConnection: close\r\n\r\n', raw=True
+    )
+    assert resp['status'] == 200, 'no host'
+    assert resp['headers']['X-Server-Name'] == 'localhost', 'no host name'
+
+
 def test_java_application_get_header():
     client.load('get_header')
 


### PR DESCRIPTION
Follow-up from the review on #326, which found this while checking whether any module still splits a host itself.

`nxt_java_Request_getServerName()` read the raw `Host` field and cut it at the first colon:

```c
colon = memchr(host, ':', f->value_length);
```

For `Host: [::1]:8080` that colon is inside the IPv6 literal, so the servlet saw `"["`.

## It was wrong in four ways, not one

Every other module reads `server_name` from `nxt_unit_request_t`, which the router has already normalised in `nxt_http_validate_host()`: the port removed with the literal understood, a trailing dot stripped, the name lowercased, and `"localhost"` when there is no `Host`. Java was the only module still parsing the field itself, and it reproduced none of that — the IPv6 literal is simply the most visible symptom.

The fallback to `getLocalName()` goes with it: the router writes `server_name` on **every** request and substitutes `"localhost"` when `Host` is absent, so the field is never missing. Falling back to the local address would also have been the worse answer.

`getServerPort()` already reads `local_port` and is unchanged.

## Verification

`test_java_application_server_name` pins all four normalisations plus the port source:

| Host | expected server name |
|---|---|
| `localhost` | `localhost` |
| `localhost:8080` | `localhost` |
| `LocalHost` | `localhost` |
| `localhost.` | `localhost` |
| `[::1]` | `[::1]` |
| `[::1]:8080` | `[::1]` |

plus `X-Server-Port` == the listener port for `Host: [::1]:9999`.

Checked in both directions: **42 passed** in `test_java_application.py` with the fix, and with `nxt_jni_Request.c` restored from master the new test **fails** — so it is an oracle for this bug rather than a tautology. `test_java_websockets.py` also passes (27 passed, 5 skipped); `WsHandshakeRequest.java` consumes `getServerName()`.

## Not in this commit

The same file has four more `memchr(..., ':', ...)` splits, on `local_addr` and `remote` — but those fields carry the **address only, with no port** (`nxt_router.c` copies `nxt_sockaddr_address()` for `address_length` bytes). They are splitting a port off a string that has none, which is a different defect with a different root cause. Worth noting that `getLocalPort()` returns a hard-coded `80` on every IPv4 request as a result, and `getRemotePort()` cannot be fixed in-module at all — there is no remote-port field in `nxt_unit_request_t`. Those want their own commit and, for the last one, probably an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)