### PR TITLE
ci: pin TZ in sanitize.yml's pytest step

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -303,11 +303,25 @@ jobs:
       # graceful tests).
       - name: Run ${{ matrix.runtime }} sanitizer subset
         continue-on-error: ${{ matrix.experimental == true }}
+        # TZ: same pin as build-test.yml's pytest step, and for the same
+        # reason (see its comment) -- without it this leg's
+        # test_static_last_modified_is_gmt is as vacuous under UTC as that
+        # one was.
         env:
           ASAN_OPTIONS: "detect_leaks=0"
           UBSAN_OPTIONS: "print_stacktrace=1"
+          TZ: Asia/Kolkata
         run: |
           set -o pipefail
+          # An image without tzdata reads an unknown zone as UTC, where the
+          # test above skips itself and the leg stays green -- the pin would
+          # be silently absent.  Assert the offset instead of trusting it.
+          offset=$(date +%z)
+          if [ "$offset" != "+0530" ]; then
+            echo "TZ=$TZ resolved to $offset, expected +0530:" \
+                 "the zone is missing from this image and the pin does nothing"
+            exit 1
+          fi
           python3 -m pytest -v --save-log ${{ matrix.pytest_opts }} \
             ${{ matrix.tests }} | tee "${RUNNER_TEMP}/pytest.out"
 


### PR DESCRIPTION
`sanitize.yml` ran the Python suite with no `TZ`. Under UTC `localtime()` and `gmtime()` agree, so `test_static_last_modified_is_gmt` cannot fail there — the same vacuous-under-UTC problem #328 fixed for `build-test.yml`. Until now the two pytest legs were both green while only one of them was actually checking anything.

The python leg does run the affected file: `sanitize.yml`'s matrix lists `test/test_static.py` whole, and the test has no `require`/`is_su` gate. The php and go legs share the step and get `TZ` too, which is harmless — nothing else in the selected tests parses or compares a wall-clock time.

No sudo is involved here: `python3 -m pytest` runs directly and unitd is forked from that process (`conftest.py` copies `os.environ` into the child), so a step-level `env:` is enough. `build-test.yml` needs `sudo -E` because it invokes `sudo -E pytest-3`; the two carry the environment differently, so this is not a copy of that mechanism.

If an image ever lacks the zone, `TZ` reads as UTC and the test skips with a stated reason (`test_static.py` checks `tm_gmtoff == 0`) rather than passing falsely. The ubuntu-latest image has it today: #328's run shows the test PASSED, not SKIPPED, on every python leg under this pin.

Fixes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143ggPMsUKpRPWoQLTxBZUk
