### PR TITLE
test: assert the Last-Modified value, not just its shape

### DIFF
--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -1,5 +1,7 @@
+import os
 import re
 import time
+from email.utils import formatdate
 from pathlib import Path
 
 import pytest
@@ -544,6 +546,11 @@ def test_variables_response_header(temp_dir, wait_for_record):
     Path(f'{temp_dir}/foo').mkdir()
     Path(f'{temp_dir}/foo/index.html').write_text('index', encoding='utf-8')
 
+    # A fixed mtime, so the logged $response_header_last_modified can be
+    # checked against a value computed here instead of against a shape.
+    mtime = 1600000000  # Sun, 13 Sep 2020 12:26:40 GMT
+    os.utime(f'{temp_dir}/foo/index.html', (mtime, mtime))
+
     assert 'success' in client.conf(
         {
             "listeners": {"*:8080": {"pass": "routes"}},
@@ -564,10 +571,17 @@ def test_variables_response_header(temp_dir, wait_for_record):
         '$response_header_connection'
     )
 
+    # The exact string, not r'.*GMT': matching only the trailing "GMT"
+    # accepts any instant at all, which is how a Last-Modified rendered from
+    # localtime() and labelled GMT stayed green here for years.  $date is the
+    # response clock, not a file's, so it stays a shape.
+    last_modified = re.escape(formatdate(mtime, usegmt=True))
+
     assert client.get(url='/foo/index.html')['status'] == 200
     assert (
         wait_for_record(
-            r'share@.*GMT@".*"@text/html@Unit/.*@.*GMT@5@close', 'access.log'
+            rf'share@{last_modified}@".*"@text/html@Unit/.*@.*GMT@5@close',
+            'access.log',
         )
         is not None
     )


### PR DESCRIPTION
The suite never checked what `Last-Modified` actually said. The only assertion outside `test_static.py` was `wait_for_record(r'share@.*GMT@…')` in `test_variables.py`, which matches the literal word `GMT` and any value in front of it. That is how #322 lived for years: a header rendered in local time and labelled `GMT` satisfied it exactly as well as a correct one.

#328 added exact-string tests for the static handler. This does the same for the log-variable path, which is the other way the header is observed.

The test pins the file's mtime with `os.utime()` and asserts `formatdate(mtime, usegmt=True)`. The oracle is computed in the test and never read back from the server; `email.utils.formatdate` uses hard-coded English day and month tables and `time.gmtime`, so it is locale- and zone-independent, and it is the same oracle `test_static.py` already uses. `$response_header_date` stays `.*GMT` — it is the response clock and has no fixed value.

No `tm_gmtoff == 0` skip guard here, deliberately. `test_static_last_modified_is_gmt` skips under UTC because telling `localtime()` from `gmtime()` is its only purpose. An exact-value assertion is meaningful in every zone: under UTC it still pins the instant, weekday and format, so a skip would remove coverage from the legs that do not pin `TZ`.

## It fails against the bug

Built `fd2d1501` with `src/nxt_http_static.c` and `src/nxt_gmtime.c` from `fd2d1501^`:

- new assertion, `TZ=Asia/Kolkata` → FAILED, `share@Sun,\ 13\ Sep\ 2020\ 12:26:40\ GMT@…` not found
- old `.*GMT` assertion, same binary → PASSED

That pair is the whole issue in two runs. Against the fixed binary the new test passes under both `TZ=UTC` and `TZ=Asia/Kolkata`.

Test-only; no product code is touched.

Fixes #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143ggPMsUKpRPWoQLTxBZUk
