### PR TITLE
types: widen nxt_time_t on QNX so dates past 2038 render correctly

### DIFF
--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -701,14 +701,6 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
             goto fail;
         }
 
-        /*
-         * On QNX nxt_time_t is a signed int32_t over an unsigned native
-         * time_t, so an mtime past 2038 arrives here negative and renders
-         * as a date in 1901.  That is the Y2038 limitation nxt_types.h
-         * names in its own comment, it costs the Date header and the ETag
-         * below in the same way, and it cannot be repaired at this call
-         * site, since nxt_gmtime() takes an nxt_time_t.  See #329.
-         */
         nxt_gmtime(nxt_file_mtime(&fi), &tm);
 
         field->value = p;
@@ -729,8 +721,14 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
         }
 
         field->value = p;
+        /*
+         * nxt_file_mtime() yields a native time_t, which need not be
+         * nxt_time_t: on QNX it is a 32-bit unsigned type against a 64-bit
+         * nxt_time_t.  "%T" reads an nxt_time_t from the argument list, so
+         * the value has to be converted before it is passed, not after.
+         */
         field->value_length = nxt_sprintf(p, p + length, "\"%xT-%xO\"",
-                                          nxt_file_mtime(&fi),
+                                          (nxt_time_t) nxt_file_mtime(&fi),
                                           nxt_file_size(&fi))
                               - p;
 

--- a/src/nxt_types.h
+++ b/src/nxt_types.h
@@ -54,10 +54,23 @@ typedef off_t                nxt_off_t;
  */
 #if (NXT_QNX)
 /*
- * QNX defines time_t as uint32_t.
- * Y2038 fix: "typedef int64_t  nxt_time_t".
+ * QNX before SDP 8.0 defines time_t as an unsigned 32-bit type, so the
+ * signed type of the same width this arm used could not represent any
+ * instant past 2038-01-19.  SDP 8.0 and later use a signed 64-bit time_t
+ * (https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.prog/topic/
+ * timing_Time_functions.html), where this arm matches the generic branch
+ * and the typedef below is a no-op.
+ *
+ * NXT_TIME_T_SIZE is probed by auto/types from the native sizeof(time_t),
+ * which is 4 on a pre-8.0 QNX, but every user of the macro -- the NXT_TIME_T_*
+ * macros below, the Y2038 guard in nxt_time_parse(), and the gmtime test --
+ * asks it about nxt_time_t rather than about time_t.  Redefine it to match
+ * the type it is read as.
  */
-typedef int32_t              nxt_time_t;
+typedef int64_t              nxt_time_t;
+
+#undef NXT_TIME_T_SIZE
+#define NXT_TIME_T_SIZE      8
 
 #else
 /* Y2038, if time_t is 32-bit integer. */

--- a/src/test/nxt_gmtime_test.c
+++ b/src/test/nxt_gmtime_test.c
@@ -27,13 +27,16 @@
  * against gmtime().  Do not "simplify" these into the differential loops
  * below: handing a nxt_time_t to gmtime(), which takes a time_t, is only
  * safe where the two types agree, and for a negative value they need not.
- * On QNX nxt_time_t is a signed int32_t while the native time_t is uint32_t,
- * so the same bits are 1969 to nxt_gmtime() and 2106 to the C library.  And
- * where nxt_time_t is 8 bytes against a 4-byte time_t -- the case the
- * NXT_TIME_T_SIZE test above already contemplates -- the library reads half
- * the object: the low half on a little-endian machine, which often looks
- * right by accident, and the high half on a big-endian one, which is
- * garbage.  Fixed fields test the arithmetic on every platform instead.
+ * Where nxt_time_t is 8 bytes against a 4-byte time_t -- QNX before SDP
+ * 8.0, whose native time_t is uint32_t, and the case the NXT_TIME_T_SIZE
+ * test above already contemplates -- the library reads half the object,
+ * the low half on a little-endian machine, which often looks right by
+ * accident, and the high half on a big-endian one, which is garbage.
+ * Fixed fields test the arithmetic on every platform instead.
+ *
+ * For the same reason the loops below never hand gmtime() the address of
+ * the nxt_time_t itself: they convert into a real time_t first, and skip
+ * the values that do not survive the conversion.
  *
  * A file's mtime can be negative ("touch -d 1969-07-20"), and the day-time
  * step used to wrap and render an hour of 1193046.  -432000 and beyond
@@ -101,7 +104,19 @@ nxt_gmtime_test(nxt_thread_t *thr)
     for (s = 0; s < NXT_GMTIME_MAX; s += 86400) {
 
         nxt_gmtime(s, &tm0);
+
         native = (time_t) s;
+
+        if ((nxt_time_t) native != s) {
+            /*
+             * The native time_t is narrower than nxt_time_t and cannot hold
+             * s, so gmtime() would be given a truncated value and there is
+             * nothing left to compare against.  Where the two types agree
+             * this never triggers.
+             */
+            break;
+        }
+
         tm1 = gmtime(&native);
 
         if (tm0.tm_mday != tm1->tm_mday
@@ -126,7 +141,13 @@ nxt_gmtime_test(nxt_thread_t *thr)
     for (s = 0; s < 90000; s++) {
 
         nxt_gmtime(s, &tm0);
+
         native = (time_t) s;
+
+        if ((nxt_time_t) native != s) {
+            break;
+        }
+
         tm1 = gmtime(&native);
 
         if (tm0.tm_hour != tm1->tm_hour
@@ -161,7 +182,8 @@ nxt_gmtime_test(nxt_thread_t *thr)
     start = nxt_thread_monotonic_time(thr);
 
     for (s = 0; s < 10000000; s++) {
-        (void) gmtime(&s);
+        native = (time_t) s;
+        (void) gmtime(&native);
     }
 
     nxt_thread_time_update(thr);


### PR DESCRIPTION
`src/nxt_types.h` typedefs `nxt_time_t` as `int32_t` on QNX, over a native `time_t` that is unsigned 32-bit before SDP 8.0. Any instant at or past 2^31 seconds narrows to a negative value, and since #328 made `nxt_gmtime()` interpret negatives as pre-epoch, such a file renders as a date in 1901-1970. The header's own comment has prescribed the fix since the code was imported: `typedef int64_t`.

`nxt_localtime()` hides the same narrowing, because it casts back to the native `time_t` before calling libc — which is why only the `nxt_gmtime()` consumers show it.

## What changed

- `nxt_time_t` is `int64_t` on QNX, and `NXT_TIME_T_SIZE` is forced to 8 in the same arm. That macro is read as the size of `nxt_time_t`, not of the native type: it sizes the `%T` output buffers (`nxt_types.h`), guards `nxt_time_parse()` against unrepresentable dates, and selects the range the gmtime test sweeps. `auto/types` probes the native `sizeof(time_t)`, so on a pre-8.0 QNX it would report 4 for a type that now holds 64 bits.
- `nxt_http_static.c` casts `st_mtime` to `nxt_time_t` for the ETag's `%T`. `nxt_sprintf` does `va_arg(args, nxt_time_t)`, so an unpromoted native `time_t` of a different width is misread. A no-op wherever the two types agree, which is every other platform.
- `nxt_gmtime_test.c`: the differential loops now skip any value the native `time_t` cannot hold, instead of comparing `nxt_gmtime()` against a truncated `gmtime()`. Without this the widened range would fail at the first value past `UINT32_MAX` — a failure of the test, not of the function. The benchmark loop no longer passes `&s` (an `nxt_time_t *`) to `gmtime()`, which takes a `time_t *`; where the widths differ that does not compile.

## SDP 8.0

QNX changed this in 8.0: ["This release of QNX OS uses a signed 64-bit value for seconds since the start of 1970 ... Previous releases used an unsigned 32-bit value"](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.prog/topic/timing_Time_functions.html). So on 8.0 the probe already yields 8 and this arm is a no-op; it matters only for pre-8.0 targets. The stale "QNX defines time_t as uint32_t" comment is reworded to say that, with the citation. Nothing here claims anything about 7.x signedness — no one has read that from a header.

No version gate: on 8.0 the widened typedef is byte-identical to the generic `#else` branch, so a `_NTO_VERSION` check would add an untestable branch for no behavioural difference.

## Unverified, plainly

**None of this has been compiled for QNX.** There is no QNX host here, no QNX CI, and the SDP is licence-gated — the only container images carrying it are third-party repackages, which were deliberately not used. The arm has never been built in this repo's observable history. Every line is justified from the source, and the one line that touches platforms people do run — the ETag cast — is provably a no-op where `nxt_time_t == time_t`.

What was verified: `./build/tests` 47 passed, exit 0; `TZ=Asia/Kolkata pytest -q test/test_static.py` 23 passed, 1 skipped. Building with the QNX arm forced on compiles and passes, but cannot exercise any of the above, because on Linux both branches produce a 64-bit type over a 64-bit native one.

Fixes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143ggPMsUKpRPWoQLTxBZUk
